### PR TITLE
Remove merge_imports from rustfmt config as it is deprecated

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,6 @@
 edition = "2021"
 version = "Two"
 imports_granularity = "Item"
-merge_imports = true
 use_field_init_shorthand = true
 use_try_shorthand = true
 group_imports = "StdExternalCrate"


### PR DESCRIPTION
Summary:
Seeing a lot of warnings when running `cargo fmt`,
```
Warning: the `merge_imports` option is deprecated. Use `imports_granularity="Crate"` instead
```

[GitHub issue on the deprecation](https://github.com/rust-lang/rustfmt/issues/3362#issuecomment-766415850)

As we already have the imports_granularity="Item", it seems we can get rid of the deprecated option?

Differential Revision: D37313506

