### PR TITLE
BXL script performance degradation hotfix

### DIFF
--- a/prelude/cpp_lsp/cpp_gen_cdb.bxl
+++ b/prelude/cpp_lsp/cpp_gen_cdb.bxl
@@ -57,6 +57,7 @@ def _impl(ctx):
         cmd.add(outputDir.as_output())
         cmd.add("--filename")
         cmd.add(filename)
+        cmd.add("--use-dotslash")
 
         # TODO: do we need these as well?
         # cmd.hidden(cxx_compile_info.cxx_compile_cmd.base_compile_cmd)


### PR DESCRIPTION
Summary: There is a hot fix for bxl script performance degradation. The fix assumes that we call a prebuild hmapconverter as a dotslash file instead of running it from buck

Reviewed By: etriebe

Differential Revision: D39173018

