### PR TITLE
Remove `ld` in example toolchain and use `gcc`

### DIFF
--- a/examples/prelude/toolchain/toolchain.bzl
+++ b/examples/prelude/toolchain/toolchain.bzl
@@ -35,24 +35,9 @@ def _cxx_toolchain(ctx):
         CxxToolchainInfo(
             mk_comp_db = ctx.attrs.make_comp_db,
             linker_info = LinkerInfo(
-                linker = RunInfo(args = ["ld"]),
+                linker = RunInfo(args = ["gcc"]),
                 linker_flags = [
-                    "-dynamic-linker",
-                    "/lib64/ld-linux-x86-64.so.2",
-                    "/usr/lib64/crt1.o",
-                    "/usr/lib64/crti.o",
-                    "/usr/lib64/crtn.o",
-                    "-L/usr/lib/gcc/x86_64-redhat-linux/12",
                     "-lstdc++",
-                    "-lm",
-                    "-lgcc",
-                    "-lc",
-                ] + [
-                    "/usr/lib/gcc/x86_64-redhat-linux/12/crtendS.o",
-                    "/usr/lib/gcc/x86_64-redhat-linux/12/crtbeginS.o",
-                ] if ctx.attrs.link_style == "shared" else [
-                    "/usr/lib/gcc/x86_64-redhat-linux/12/crtend.o",
-                    "/usr/lib/gcc/x86_64-redhat-linux/12/crtbegin.o",
                 ],
                 archiver = RunInfo(args = ["ar", "rcs"]),
                 type = "gnu",


### PR DESCRIPTION
This diff favours gcc over ld, allowing for autodiscovery of link paths.