### PR TITLE
Convert _static_extension_utils from C++ to Cython

### DIFF
--- a/prelude/python/python_binary.bzl
+++ b/prelude/python/python_binary.bzl
@@ -281,8 +281,10 @@ def convert_python_library_to_executable(
 
         cxx_executable_srcs = [
             CxxSrcWithFlags(file = ctx.attrs.cxx_main, flags = []),
-            CxxSrcWithFlags(file = ctx.attrs._cxx_static_extension_utils, flags = []),
             CxxSrcWithFlags(file = static_extension_info_out, flags = []),
+        ] + [
+            CxxSrcWithFlags(file = i, flags = [])
+            for i in ctx.attrs._cxx_static_extension_utils
         ]
         impl_params = CxxRuleConstructorParams(
             rule_type = "python_binary",

--- a/prelude/rules_impl.bzl
+++ b/prelude/rules_impl.bzl
@@ -258,7 +258,7 @@ def _python_binary_attrs():
         "package_split_dwarf_dwp": attrs.bool(default = False),
         "_create_manifest_for_source_dir": _create_manifest_for_source_dir(),
         "_cxx_hacks": attrs.dep(default = "prelude//cxx/tools:cxx_hacks"),
-        "_cxx_static_extension_utils": attrs.option(attrs.source(), default = None),
+        "_cxx_static_extension_utils": attrs.list(attrs.source(), default = []),
         "_cxx_toolchain": _cxx_toolchain(),
         "_omnibus_environment": omnibus_environment_attr(),
         "_package_remotely": attrs.bool(default = _package_python_binary_remotely()),


### PR DESCRIPTION
Summary: I was starting to get segmentation faults as I was working on converting some of the additional Python code to C. So I decided to look into converting the current C code into Cython, which actually simplifies it quite a bit and makes the rest of the migration trivial. It's also much easier to maintain the code, since most of them looks and behaves pretty much like Python.

Differential Revision: D40171356

