### PR TITLE
build reqwest

### DIFF
--- a/shim/third-party/rust/fixups/reqwest/fixups.toml
+++ b/shim/third-party/rust/fixups/reqwest/fixups.toml
@@ -1,0 +1,1 @@
+extra_srcs = ["src/**/*.rs"]


### PR DESCRIPTION
Add a fixup to build the reqwest crate.

With this patch and https://github.com/facebookincubator/buck2/pull/26 applied I am able to build all of //third-party/rust: on Ubuntu 22.04 x86_64 Linux apart from the following which are expected to fail due to platform incompatibility.
* blake3-0.3.8-simd_neon-aarch64
* blake3-0.3.8-simd_neon-armv7
* winreg-0.10.1
