### PR TITLE
Improve env-vars under build_rs.py

### DIFF
--- a/shim/third-party/macros/build_rs.py
+++ b/shim/third-party/macros/build_rs.py
@@ -45,6 +45,8 @@ def mk_env(args, parent):
     env["CARGO_CFG_TARGET_OS"] = "linux"
     env["CARGO_CFG_TARGET_POINTER_WIDTH"] = "64"
     env["CARGO_CFG_TARGET_ENDIAN"] = "little"
+    for k, v in args.env or []:
+        env[k] = v
     return env
 
 def run_args(args):

--- a/shim/third-party/macros/rust_third_party.bzl
+++ b/shim/third-party/macros/rust_third_party.bzl
@@ -50,6 +50,9 @@ def _make_cmd(mode, buildscript, package_name, version, features, cfgs, env, tar
         elif type(value) == type([]):
             for x in value:
                 cmd += " --" + flag + "=" + x
+        elif type(value) == type({}):
+            for k, v in value.items():
+                cmd += " --" + flag + "=" + k + "=" + v
         else:
             cmd += " --" + flag + "=" + value
     return cmd


### PR DESCRIPTION
The `build_rs.py` script sets a number of environment variables to mimic the environment set up by Cargo. One variable that was missing in this case was `HOST` which is set similar to `TARGET`. For now this PR takes the same short-cut as for `TARGET` to hard code the value to Linux x64.

Reindeer supports custom environment variables set for the build-script gen_srcs and rustc_flags modes. However, the `build_rs.py` didn't handle these correctly. This PR fixes that.

Both these issues were noticed while attempting to run the `build.rs` script from the jemalloc package.
