### PR TITLE
only try to create toolchain folder if it does not exist

### DIFF
--- a/buck2_client/src/commands/init.rs
+++ b/buck2_client/src/commands/init.rs
@@ -251,7 +251,11 @@ fn set_up_project(
             ));
         }
 
-        std::fs::create_dir(path.join("toolchains"))?;
+        let toolchains = path.join("toolchains");
+        if !toolchains.exists() {
+            std::fs::create_dir(&toolchains)?;
+        }
+
         writeln!(buck_config, "prelude = prelude")?;
         writeln!(buck_config, "toolchains = toolchains")?;
 


### PR DESCRIPTION
This adjusts the init script to allow existing toolchain folders. This is useful in the case of pytorch where a toolchain folder may exist in the repo, but we still want to init it for buck2