### PR TITLE
docs: cxx requires both clang and lld

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,7 +44,7 @@ buck2 init
 
 To build the entire project, run:
 
-Note: _Requires clang to be in the path_
+Note: _Requires clang and lld to be in the path_
 ```sh
 buck2 build //...
 ```


### PR DESCRIPTION
While trying the guide on my archlinux desktop, I saw the following errors if I only have `clang` installed (via `pacman -S clang`)

```
$ buck2 build //...
Action failed: root//:main (cxx_link_executable)
Local command returned non-zero exit code 1
Reproduce locally: `clang++ "-fuse-ld=lld" -o buck-out/v2/gen/root/524f8da68ea2a374/__main__/main @buck-out/v2/gen/root/524f8da68ea2a374/__main__/main.linker.argsfile`
stdout:
stderr:
clang-15: error: invalid linker name in argument '-fuse-ld=lld'
Action failed: root//:print (cxx_link lib_print.so)
Local command returned non-zero exit code 1
Reproduce locally: `clang++ "-fuse-ld=lld" -o buck-out/v2/gen/root/524f8da68ea2a374/__print__/lib_print.so @buck-out/v2/gen/root/524f8da68ea2a374/__print__/lib_print.so.linker.argsfile`
stdout:
stderr:
clang-15: error: invalid linker name in argument '-fuse-ld=lld'
Build ID: c967e7ad-5e3c-49ac-8b92-bb5827cf9100
Jobs completed: 55. Time elapsed: 0.2s. Cache hits: 0%. Commands: 8 (cached: 0, remote: 0, local:
BUILD FAILED
Failed to build 'root//:main (prelude//platforms:default#524f8da68ea2a374)'
Failed to build 'root//:print (prelude//platforms:default#524f8da68ea2a374)'
```

It turns out that I need `lld` to be available as well (via `pacman -S lld`).