### PR TITLE
chore: add boilerplate for hacking on buck2 with nix + direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
+fi
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target/
 Cargo.lock
 buck-out
+/.direnv
 
 # symlinks
 /examples/prelude/prelude

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681215634,
+        "narHash": "sha256-dI0SsSWb7ksK3OtTCf61vdlBhok838aIpwQ2EUM+jhY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5a156c2e89c1eca09b40bcdcee86760e0e4d79a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1681179516,
+        "narHash": "sha256-Ij/3YM5Gz5AiDKnP77ODJp2RGRRWmGTWYlfnuUT3z78=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "9e7373ba5627ffe952f66a3e82e3a375bdc38565",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "A flake for hacking on and building buck2";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ (import rust-overlay) ];
+      };
+
+    rust-version = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+    my-rust-bin = rust-version.override {
+      extensions = [ "rust-analyzer" ];
+    };
+
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = [ pkgs.cargo-bloat my-rust-bin ];
+      };
+    });
+}


### PR DESCRIPTION
I've been using this to hack on and build `buck2` for a while now, since I often don't use `rustup` (and actually not using NixOS -- but Nix-On-Ubuntu-On-WSL2?!?!!) and figured it might be worth putting upstream at this point, with the official announcement being made. This will at least let any prospective users who have Nix get compiling real quick. It will also allow some future improvements to `flake.nix`, but...

Please note (especially lurking Nix users): this only allows you to use Nix to provision a development environment, one which is capable of running `cargo build`. There is not yet a "nix package" (AKA thing that installs inside `/nix/store`) for buck2 in this PR. I have one as part of `buck2-nix`, but it's out of date because some recent changes in mid/late February started causing a build failure. I'll open up a separate PR for that later and discuss it.

Please see the commit message for a longer version.