### PR TITLE
Include a warning message if Windows fails to create a symlink

### DIFF
--- a/app/buck2_core/src/fs/fs_util.rs
+++ b/app/buck2_core/src/fs/fs_util.rs
@@ -56,6 +56,20 @@ fn symlink_impl(original: &Path, link: &Path) -> anyhow::Result<()> {
 fn symlink_impl(original: &Path, link: &Path) -> anyhow::Result<()> {
     use std::io::ErrorKind;
 
+    use anyhow::Context as _;
+
+    fn permission_check(result: io::Result<()>) -> anyhow::Result<()> {
+        match result {
+            // Standard issue on Windows machines, so hint at the resolution, as it is not obvious.
+            Err(e) if e.to_string().contains("privilege is not held") => Err(anyhow::anyhow!(e)
+                .context(
+                    "Perhaps you need to turn on 'Developer Mode' in Windows to enable symlinks.",
+                )),
+            Err(e) => Err(e.into()),
+            Ok(_) => Ok(()),
+        }
+    }
+
     // If original is a relative path, fix it up to be absolute
     let target_abspath = if original.is_absolute() {
         Cow::Borrowed(original)
@@ -95,15 +109,13 @@ fn symlink_impl(original: &Path, link: &Path) -> anyhow::Result<()> {
     let target_metadata = target_canonical.metadata();
     match target_metadata {
         Ok(meta) if meta.is_dir() => {
-            std::os::windows::fs::symlink_dir(&target_canonical, link)?;
-            Ok(())
+            permission_check(std::os::windows::fs::symlink_dir(&target_canonical, link))
         }
         Err(e) if e.kind() != ErrorKind::NotFound => Err(e.into()),
         _ => {
             // Either file or not existent. Default to file.
             // TODO(T144443238): This will cause issues if the file type turns out to be directory, fix this
-            std::os::windows::fs::symlink_file(&target_canonical, link)?;
-            Ok(())
+            permission_check(std::os::windows::fs::symlink_file(&target_canonical, link))
         }
     }
 }


### PR DESCRIPTION
Standard issue is you don't have developer mode on, so give that hint. Checked on my machine without developer mode and it now says:

```
Internal error: symlink(original=../../../../../../../../../prelude/python_bootstrap/tools/win_python_wrapper.bat, link=C:\Neil\buck2\examples\prelude\buck-out\v2\gen\prelude\fb50fd37ce946800\python_bootstrap\tools\__win_python_wrapper__\resources\win_python_wrapper.bat): Perhaps you need to turn on 'Developer Mode' in Windows to enable symlinks.: A required privilege is not held by the client. (os error 1314)
```

Unfortunately this doesn't have an ErrorKind, so have to do it with substring matching.