### PR TITLE
Make rustc configurable

### DIFF
--- a/prelude/toolchains/rust.bzl
+++ b/prelude/toolchains/rust.bzl
@@ -32,7 +32,7 @@ def _system_rust_toolchain_impl(ctx):
         DefaultInfo(),
         RustToolchainInfo(
             clippy_driver = "clippy-driver",
-            compiler = "rustc",
+            compiler = ctx.attrs.compiler,
             default_edition = ctx.attrs.default_edition,
             extern_html_root_url_prefix = ctx.attrs.extern_html_root_url_prefix,
             failure_filter_action = ctx.attrs.failure_filter_action[RunInfo],
@@ -51,6 +51,7 @@ def _system_rust_toolchain_impl(ctx):
 system_rust_toolchain = rule(
     impl = _system_rust_toolchain_impl,
     attrs = {
+        "compiler": attrs.option(attrs.string(), default = "rustc"),
         "default_edition": attrs.option(attrs.string(), default = None),
         "extern_html_root_url_prefix": attrs.option(attrs.string(), default = None),
         "failure_filter_action": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//rust/tools:failure_filter_action")),


### PR DESCRIPTION
This makes the built-in system rust toolchain configurable, matching `system_python_toolchain`:

https://github.com/facebook/buck2/blob/main/prelude/toolchains/python.bzl#L75

I need this personally because I want to use a toolchain from `rustup` instead of my real system toolchain, but I don't want to manually configure the toolchain