### PR TITLE
Set relative command path

### DIFF
--- a/app/buck2_client/src/commands/init.rs
+++ b/app/buck2_client/src/commands/init.rs
@@ -177,7 +177,7 @@ fn initialize_root_buck(repo_root: &Path, prelude: bool) -> anyhow::Result<()> {
         writeln!(buck, "genrule(")?;
         writeln!(buck, "    name = \"hello_world\",")?;
         writeln!(buck, "    out = \"out.txt\",")?;
-        writeln!(buck, "    cmd = \"echo BUILT BY BUCK2> $OUT\",")?;
+        writeln!(buck, "    cmd = \"echo BUILT BY BUCK2> ./$OUT\",")?;
         writeln!(buck, ")")?;
     }
     // TODO: Add a doc pointers for rules
@@ -379,7 +379,7 @@ prelude = prelude
 genrule(
     name = \"hello_world\",
     out = \"out.txt\",
-    cmd = \"echo BUILT BY BUCK2> $OUT\",
+    cmd = \"echo BUILT BY BUCK2> ./$OUT\",
 )
 ";
         assert_eq!(actual_buck, expected_buck);


### PR DESCRIPTION
If one moves the BUCK file from the initial root location, then buck build fails to find the out file.

This change was needed when I moved the example into a subdirectory because I wanted to keep it. It may be that I'm misunderstanding how to use buck2. By merging this change, it may reduce the number of issues brand new users encounter if they `buck2 init --git` and then move the buck file into a subdirectory immediately afterwards. (For reasons such as to be the first 'app' of a multi-app repo, which all generally reuse the prelude and toolchains.) I want to be able to run `buck2 build //init-app:hello_world` from any child directory of `.buckroot` and it works.