### PR TITLE
Fixes for remote execution

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -135,6 +135,7 @@ pub struct Buck2OssReConfiguration {
     pub cas_address: Option<String>,
     pub engine_address: Option<String>,
     pub action_cache_address: Option<String>,
+    pub instance_name: Option<String>,
     /// Path to a CA certificates bundle. This must be PEM-encoded. If none is set, a default
     /// bundle will be used.
     ///
@@ -188,6 +189,8 @@ impl Buck2OssReConfiguration {
             .parse_list(BUCK2_RE_CLIENT_CFG_SECTION, "http_headers")?
             .unwrap_or_default(); // Empty list is as good None.
 
+        let instance_name = legacy_config.parse(BUCK2_RE_CLIENT_CFG_SECTION, "instance_name")?;
+
         // if the set the 'address' field, just use that for everything
         let default_address: Option<String> =
             legacy_config.parse(BUCK2_RE_CLIENT_CFG_SECTION, "address")?;
@@ -199,6 +202,7 @@ impl Buck2OssReConfiguration {
                     .parse(BUCK2_RE_CLIENT_CFG_SECTION, "engine_address")?,
                 action_cache_address: legacy_config
                     .parse(BUCK2_RE_CLIENT_CFG_SECTION, "action_cache_address")?,
+                instance_name,
                 tls_ca_certs,
                 tls_client_cert,
                 http_headers,
@@ -207,6 +211,7 @@ impl Buck2OssReConfiguration {
                 cas_address: Some(address.clone()),
                 engine_address: Some(address.clone()),
                 action_cache_address: Some(address.clone()),
+                instance_name,
                 tls_ca_certs,
                 tls_client_cert,
                 http_headers,

--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -135,6 +135,7 @@ pub struct Buck2OssReConfiguration {
     pub cas_address: Option<String>,
     pub engine_address: Option<String>,
     pub action_cache_address: Option<String>,
+    pub bytestream_address: Option<String>,
     pub instance_name: Option<String>,
     /// Path to a CA certificates bundle. This must be PEM-encoded. If none is set, a default
     /// bundle will be used.
@@ -202,6 +203,8 @@ impl Buck2OssReConfiguration {
                     .parse(BUCK2_RE_CLIENT_CFG_SECTION, "engine_address")?,
                 action_cache_address: legacy_config
                     .parse(BUCK2_RE_CLIENT_CFG_SECTION, "action_cache_address")?,
+                bytestream_address: legacy_config
+                    .parse(BUCK2_RE_CLIENT_CFG_SECTION, "bytestream_address")?,
                 instance_name,
                 tls_ca_certs,
                 tls_client_cert,
@@ -211,6 +214,7 @@ impl Buck2OssReConfiguration {
                 cas_address: Some(address.clone()),
                 engine_address: Some(address.clone()),
                 action_cache_address: Some(address.clone()),
+                bytestream_address: Some(address.clone()),
                 instance_name,
                 tls_ca_certs,
                 tls_client_cert,

--- a/remote_execution/oss/re_grpc/Cargo.toml
+++ b/remote_execution/oss/re_grpc/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 once_cell = { workspace = true }
+uuid = { workspace = true }
 
 gazebo_lint.version = "0.1"
 gazebo_lint.optional = true

--- a/remote_execution/oss/re_grpc_proto/build.rs
+++ b/remote_execution/oss/re_grpc_proto/build.rs
@@ -13,10 +13,12 @@ fn main() -> io::Result<()> {
     let proto_files = &[
         "proto/build/bazel/remote/execution/v2/remote_execution.proto",
         "proto/build/bazel/semver/semver.proto",
+        "proto/google/bytestream/bytestream.proto",
         "proto/google/api/annotations.proto",
         "proto/google/api/client.proto",
         "proto/google/api/http.proto",
         "proto/google/longrunning/operations.proto",
+        "proto/google/protobuf/wrappers.proto",
         "proto/google/rpc/code.proto",
         "proto/google/rpc/status.proto",
     ];

--- a/remote_execution/oss/re_grpc_proto/proto/google/bytestream/bytestream.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/bytestream/bytestream.proto
@@ -1,0 +1,181 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.bytestream;
+
+import "google/api/annotations.proto";
+import "google/protobuf/wrappers.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/bytestream;bytestream";
+option java_outer_classname = "ByteStreamProto";
+option java_package = "com.google.bytestream";
+
+// #### Introduction
+//
+// The Byte Stream API enables a client to read and write a stream of bytes to
+// and from a resource. Resources have names, and these names are supplied in
+// the API calls below to identify the resource that is being read from or
+// written to.
+//
+// All implementations of the Byte Stream API export the interface defined here:
+//
+// * `Read()`: Reads the contents of a resource.
+//
+// * `Write()`: Writes the contents of a resource. The client can call `Write()`
+//   multiple times with the same resource and can check the status of the write
+//   by calling `QueryWriteStatus()`.
+//
+// #### Service parameters and metadata
+//
+// The ByteStream API provides no direct way to access/modify any metadata
+// associated with the resource.
+//
+// #### Errors
+//
+// The errors returned by the service are in the Google canonical error space.
+service ByteStream {
+  // `Read()` is used to retrieve the contents of a resource as a sequence
+  // of bytes. The bytes are returned in a sequence of responses, and the
+  // responses are delivered as the results of a server-side streaming RPC.
+  rpc Read(ReadRequest) returns (stream ReadResponse);
+
+  // `Write()` is used to send the contents of a resource as a sequence of
+  // bytes. The bytes are sent in a sequence of request protos of a client-side
+  // streaming RPC.
+  //
+  // A `Write()` action is resumable. If there is an error or the connection is
+  // broken during the `Write()`, the client should check the status of the
+  // `Write()` by calling `QueryWriteStatus()` and continue writing from the
+  // returned `committed_size`. This may be less than the amount of data the
+  // client previously sent.
+  //
+  // Calling `Write()` on a resource name that was previously written and
+  // finalized could cause an error, depending on whether the underlying service
+  // allows over-writing of previously written resources.
+  //
+  // When the client closes the request channel, the service will respond with
+  // a `WriteResponse`. The service will not view the resource as `complete`
+  // until the client has sent a `WriteRequest` with `finish_write` set to
+  // `true`. Sending any requests on a stream after sending a request with
+  // `finish_write` set to `true` will cause an error. The client **should**
+  // check the `WriteResponse` it receives to determine how much data the
+  // service was able to commit and whether the service views the resource as
+  // `complete` or not.
+  rpc Write(stream WriteRequest) returns (WriteResponse);
+
+  // `QueryWriteStatus()` is used to find the `committed_size` for a resource
+  // that is being written, which can then be used as the `write_offset` for
+  // the next `Write()` call.
+  //
+  // If the resource does not exist (i.e., the resource has been deleted, or the
+  // first `Write()` has not yet reached the service), this method returns the
+  // error `NOT_FOUND`.
+  //
+  // The client **may** call `QueryWriteStatus()` at any time to determine how
+  // much data has been processed for this resource. This is useful if the
+  // client is buffering data and needs to know which data can be safely
+  // evicted. For any sequence of `QueryWriteStatus()` calls for a given
+  // resource name, the sequence of returned `committed_size` values will be
+  // non-decreasing.
+  rpc QueryWriteStatus(QueryWriteStatusRequest)
+      returns (QueryWriteStatusResponse);
+}
+
+// Request object for ByteStream.Read.
+message ReadRequest {
+  // The name of the resource to read.
+  string resource_name = 1;
+
+  // The offset for the first byte to return in the read, relative to the start
+  // of the resource.
+  //
+  // A `read_offset` that is negative or greater than the size of the resource
+  // will cause an `OUT_OF_RANGE` error.
+  int64 read_offset = 2;
+
+  // The maximum number of `data` bytes the server is allowed to return in the
+  // sum of all `ReadResponse` messages. A `read_limit` of zero indicates that
+  // there is no limit, and a negative `read_limit` will cause an error.
+  //
+  // If the stream returns fewer bytes than allowed by the `read_limit` and no
+  // error occurred, the stream includes all data from the `read_offset` to the
+  // end of the resource.
+  int64 read_limit = 3;
+}
+
+// Response object for ByteStream.Read.
+message ReadResponse {
+  // A portion of the data for the resource. The service **may** leave `data`
+  // empty for any given `ReadResponse`. This enables the service to inform the
+  // client that the request is still live while it is running an operation to
+  // generate more data.
+  bytes data = 10;
+}
+
+// Request object for ByteStream.Write.
+message WriteRequest {
+  // The name of the resource to write. This **must** be set on the first
+  // `WriteRequest` of each `Write()` action. If it is set on subsequent calls,
+  // it **must** match the value of the first request.
+  string resource_name = 1;
+
+  // The offset from the beginning of the resource at which the data should be
+  // written. It is required on all `WriteRequest`s.
+  //
+  // In the first `WriteRequest` of a `Write()` action, it indicates
+  // the initial offset for the `Write()` call. The value **must** be equal to
+  // the `committed_size` that a call to `QueryWriteStatus()` would return.
+  //
+  // On subsequent calls, this value **must** be set and **must** be equal to
+  // the sum of the first `write_offset` and the sizes of all `data` bundles
+  // sent previously on this stream.
+  //
+  // An incorrect value will cause an error.
+  int64 write_offset = 2;
+
+  // If `true`, this indicates that the write is complete. Sending any
+  // `WriteRequest`s subsequent to one in which `finish_write` is `true` will
+  // cause an error.
+  bool finish_write = 3;
+
+  // A portion of the data for the resource. The client **may** leave `data`
+  // empty for any given `WriteRequest`. This enables the client to inform the
+  // service that the request is still live while it is running an operation to
+  // generate more data.
+  bytes data = 10;
+}
+
+// Response object for ByteStream.Write.
+message WriteResponse {
+  // The number of bytes that have been processed for the given resource.
+  int64 committed_size = 1;
+}
+
+// Request object for ByteStream.QueryWriteStatus.
+message QueryWriteStatusRequest {
+  // The name of the resource whose write status is being requested.
+  string resource_name = 1;
+}
+
+// Response object for ByteStream.QueryWriteStatus.
+message QueryWriteStatusResponse {
+  // The number of bytes that have been processed for the given resource.
+  int64 committed_size = 1;
+
+  // `complete` is `true` only if the client has sent a `WriteRequest` with
+  // `finish_write` set to true, and the server has processed that request.
+  bool complete = 2;
+}

--- a/remote_execution/oss/re_grpc_proto/proto/google/protobuf/wrappers.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/protobuf/wrappers.proto
@@ -1,0 +1,123 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Wrappers for primitive (non-message) types. These types are useful
+// for embedding primitives in the `google.protobuf.Any` type and for places
+// where we need to distinguish between the absence of a primitive
+// typed field and its default value.
+//
+// These wrappers have no meaningful use within repeated fields as they lack
+// the ability to detect presence on individual elements.
+// These wrappers have no meaningful use within a map or a oneof since
+// individual entries of a map or fields of a oneof can already detect presence.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/protobuf/types/known/wrapperspb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "WrappersProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+
+// Wrapper message for `double`.
+//
+// The JSON representation for `DoubleValue` is JSON number.
+message DoubleValue {
+  // The double value.
+  double value = 1;
+}
+
+// Wrapper message for `float`.
+//
+// The JSON representation for `FloatValue` is JSON number.
+message FloatValue {
+  // The float value.
+  float value = 1;
+}
+
+// Wrapper message for `int64`.
+//
+// The JSON representation for `Int64Value` is JSON string.
+message Int64Value {
+  // The int64 value.
+  int64 value = 1;
+}
+
+// Wrapper message for `uint64`.
+//
+// The JSON representation for `UInt64Value` is JSON string.
+message UInt64Value {
+  // The uint64 value.
+  uint64 value = 1;
+}
+
+// Wrapper message for `int32`.
+//
+// The JSON representation for `Int32Value` is JSON number.
+message Int32Value {
+  // The int32 value.
+  int32 value = 1;
+}
+
+// Wrapper message for `uint32`.
+//
+// The JSON representation for `UInt32Value` is JSON number.
+message UInt32Value {
+  // The uint32 value.
+  uint32 value = 1;
+}
+
+// Wrapper message for `bool`.
+//
+// The JSON representation for `BoolValue` is JSON `true` and `false`.
+message BoolValue {
+  // The bool value.
+  bool value = 1;
+}
+
+// Wrapper message for `string`.
+//
+// The JSON representation for `StringValue` is JSON string.
+message StringValue {
+  // The string value.
+  string value = 1;
+}
+
+// Wrapper message for `bytes`.
+//
+// The JSON representation for `BytesValue` is JSON string.
+message BytesValue {
+  // The bytes value.
+  bytes value = 1;
+}

--- a/remote_execution/oss/re_grpc_proto/src/lib.rs
+++ b/remote_execution/oss/re_grpc_proto/src/lib.rs
@@ -11,6 +11,9 @@ pub mod google {
     pub mod api {
         tonic::include_proto!("google.api");
     }
+    pub mod bytestream {
+        tonic::include_proto!("google.bytestream");
+    }
     pub mod longrunning {
         tonic::include_proto!("google.longrunning");
     }


### PR DESCRIPTION
These three commits add three features:

- `buck2_re_client.address` to serve as a "catch all" address in `.buckconfig`, useful to make the config shorter and less redundant
- instance name support #180
- an upload path that doesn't choke on the 4MB gRPC decode limit in e.g. buildbarn (#170

I don't know if these commits should be made into a stacked PR instead to make the Meta import easier, but let me know and I can do that.

The first two patches are quite simple. The third commit is a bit more detailed. TL;DR it probably performs worse on small files and file batches for now, but with these changes I can at least get to the point where I can upload `nixpkgs.tar.gz` and the un-tar'd files as well! (~160MB, 34k files.) So I think that's good for now, but I'll keep prodding at it as I find things...