### PR TITLE
When a soft error occurs continue onto the next dep file.

### DIFF
--- a/app/buck2_action_impl/src/actions/impls/write_json.rs
+++ b/app/buck2_action_impl/src/actions/impls/write_json.rs
@@ -169,14 +169,9 @@ impl Action for WriteJsonAction {
     }
 
     fn aquery_attributes(&self, fs: &ExecutorFs) -> IndexMap<String, String> {
-        let res: anyhow::Result<String> = try { String::from_utf8(self.get_contents(fs)?)? };
-        // TODO(cjhopman): We should change this api to support returning a Result.
-        indexmap! {
-            "contents".to_owned() => match res {
-                Ok(v) => v,
-                Err(e) => format!("ERROR: constructing contents ({})", e)
-            }
-        }
+        let contents = (|| Ok(String::from_utf8(self.get_contents(fs)?)?))()
+            .unwrap_or_else(|e: anyhow::Error| format!("ERROR: constructing contents ({e})"));
+        indexmap! { "contents".to_owned() => contents }
     }
 }
 

--- a/app/buck2_action_impl/src/actions/impls/write_json.rs
+++ b/app/buck2_action_impl/src/actions/impls/write_json.rs
@@ -169,7 +169,9 @@ impl Action for WriteJsonAction {
     }
 
     fn aquery_attributes(&self, fs: &ExecutorFs) -> IndexMap<String, String> {
-        let contents = (|| Ok(String::from_utf8(self.get_contents(fs)?)?))()
+        let contents = self
+            .get_contents(fs)
+            .and_then(|c| Ok(String::from_utf8(c)?))
             .unwrap_or_else(|e: anyhow::Error| format!("ERROR: constructing contents ({e})"));
         indexmap! { "contents".to_owned() => contents }
     }


### PR DESCRIPTION
Moves the code from a try block to a separate function to make
expressing this cleaner, as early exits in try blocks exit the outer
function.

Also converts another try block to a smaller & cleaner style.