### PR TITLE
Fix warnings and format issues from an OSS build perspective

### DIFF
--- a/app/buck2/src/lib.rs
+++ b/app/buck2/src/lib.rs
@@ -157,6 +157,7 @@ impl BeforeSubcommandOptions {
     }
 }
 
+#[rustfmt::skip]
 fn help() -> &'static str {
     concat!(
         "A build system\n",

--- a/app/buck2_client_ctx/src/subscribers/recorder.rs
+++ b/app/buck2_client_ctx/src/subscribers/recorder.rs
@@ -23,7 +23,6 @@ mod imp {
     use std::collections::HashSet;
     use std::future::Future;
     use std::io::Write;
-    use std::path::Path;
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
@@ -85,6 +84,7 @@ mod imp {
         cache_upload_count: u64,
         cache_upload_attempt_count: u64,
         resolved_target_patterns: Option<buck2_data::ResolvedTargetPatterns>,
+        #[allow(dead_code)]
         invocation_root_path: AbsNormPathBuf,
         filesystem: Option<String>,
         watchman_version: Option<String>,
@@ -450,9 +450,9 @@ mod imp {
                     _ => 0,
                 };
             self.command_end = Some(command);
-            let root = Path::to_owned(self.invocation_root_path.as_ref());
             #[cfg(any(fbcode_build, cargo_internal_build))]
             {
+                let root = std::path::Path::to_owned(self.invocation_root_path.as_ref());
                 if detect_eden::is_eden(root).unwrap_or(false) {
                     self.filesystem = Some("eden".to_owned());
                 } else {

--- a/app/buck2_server/src/daemon/state.rs
+++ b/app/buck2_server/src/daemon/state.rs
@@ -31,7 +31,6 @@ use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
 use buck2_core::quiet_soft_error;
 use buck2_core::rollout_percentage::RolloutPercentage;
-use buck2_core::soft_error;
 use buck2_events::dispatch::EventDispatcher;
 use buck2_events::sink::scribe;
 use buck2_events::sink::tee::TeeSink;
@@ -643,6 +642,7 @@ impl DaemonState {
     async fn validate_buck_out_mount(&self) -> anyhow::Result<()> {
         #[cfg(any(fbcode_build, cargo_internal_build))]
         {
+            use buck2_core::soft_error;
             use fsinfo::FsType;
 
             let project_root = self.paths.project_root().root().to_path_buf();


### PR DESCRIPTION
These are the fixes that `cargo build/fmt` need to issue no warnings or spurious changes from an open source only build.