### PR TITLE
Make cyclic dependency error message more readable

### DIFF
--- a/dice/dice/src/api/error.rs
+++ b/dice/dice/src/api/error.rs
@@ -47,7 +47,7 @@ impl DiceError {
 
 #[derive(Debug, Error, Allocative)]
 pub(crate) enum DiceErrorImpl {
-    #[error("Cyclic computation detected when computing key `{}`, which forms a cycle in computation chain: `{}`", trigger, cyclic_keys.iter().join(","))]
+    #[error("Cyclic computation detected when computing key `{}`, which forms a cycle in computation chain: `{}`", trigger, cyclic_keys.iter().join(" -> "))]
     Cycle {
         trigger: Arc<dyn RequestedKey>,
         cyclic_keys: IndexSet<Arc<dyn RequestedKey>>,


### PR DESCRIPTION
Summary:
The current cyclic dependency error message is separated by commas with no spaces making it quite hard to read. This is just a quick mitigation to add separation between the cyclic keys to make it more readable.

Buck1's circular dependency error was cleaner with " -> " separation.

Reviewed By: krallin

Differential Revision: D45294883

