### PR TITLE
Remove outdated TODO comment

### DIFF
--- a/app/buck2_server/src/ctx.rs
+++ b/app/buck2_server/src/ctx.rs
@@ -222,7 +222,6 @@ pub struct ServerCommandContext<'a> {
     /// Sanitized argument vector from the CLI from the client side.
     pub(crate) sanitized_argv: Vec<String>,
 
-    // TODO(bobyf) ServerCommandContext should have lifetime and this be a reference
     cancellations: &'a CancellationContext,
 }
 


### PR DESCRIPTION
Since ServerCommandContext now has a lifetime, the comment / TODO on cancellations seem not relevant anymore