### PR TITLE
Include macOS-specific dependencies in nix devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,12 @@
 
     in {
       devShells.default = pkgs.mkShell {
+        buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+          CoreFoundation
+          CoreServices
+          IOKit
+          Security
+        ]);
         packages = [ pkgs.cargo-bloat my-rust-bin ];
       };
     });


### PR DESCRIPTION
#145 added a nix flake with a `devShell` that supports building buck via `cargo` (thanks @thoughtpolice!); this PR adds some inputs that are necessary for building buck on macOS.

As I understand it, nix's version of `clang` doesn't add macOS's standard SDK directories to the linker's search paths, and instead expects to use frameworks built by nix (informed by [this SO post](https://stackoverflow.com/questions/51161225/how-can-i-make-macos-frameworks-available-to-clang-in-a-nix-environment), [this discourse post](https://discourse.nixos.org/t/cannot-build-rust-binary-on-macos-m1/27630)). Without this patch, the linker complains it can't find the frameworks (initially when building the `sysinfo` crate):
```sh
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/nix/store/q64jzfxjhpn2fdydhmywk4r9gkhw2gmj-rust-default-1.70.0-nightly-2023-03-07/lib/rustlib/aarch64-apple-darwin/bin: ... (omitted) ... "-liconv" "-framework" "CoreFoundation" "-lSystem" "-lc" "-lm" "-L" "/nix/store/q64jzfxjhpn2fdydhmywk4r9gkhw2gmj-rust-default-1.70.0-nightly-2023-03-07/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/Users/jschear/dev/buck2/target/debug/deps/libsysinfo-5a9c91f1a3e84c86.dylib" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-nodefaultlibs"
  = note: ld: framework not found IOKit
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `sysinfo` due to previous error
```
