### PR TITLE
disable new tests failing on CircleCI

### DIFF
--- a/app/buck2_common/src/kill_util.rs
+++ b/app/buck2_common/src/kill_util.rs
@@ -117,6 +117,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[cfg(any(fbcode_build, cargo_internal_build))] // TODO(@akozhevnikov): Debug why this fails on CircleCI
     async fn test_graceful_termination() -> anyhow::Result<()> {
         let dir = tempfile::tempdir()?;
 


### PR DESCRIPTION
Summary:
These are recently added test that are failing on CircleCI (but passes in the internal open source ci-oss job. they both run `test.py --ci` and run on linux)
* https://app.circleci.com/pipelines/github/facebook/buck2/6578/workflows/d1f96a04-d9ab-4057-bbfc-efc5262098fc/jobs/17753
It may be a timing issue, blackm00n is going to take a look but disable in the meantime.

Differential Revision: D45815557

