### PR TITLE
nix: add rust-src to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
     rust-version = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
     my-rust-bin = rust-version.override {
-      extensions = [ "rust-analyzer" ];
+      extensions = [ "rust-analyzer" "rust-src" ];
     };
 
     in {


### PR DESCRIPTION
..in order to fix the following `rust-analyzer` error:
```
[ERROR project_model::workspace] Failed to find sysroot for Cargo.toml file /home/oleh/src/buck2-upstream/./Cargo.toml. Is rust-src installed? e=can't load standard library from sysroot
/nix/store/d92bh46p85l310vg43xfai43xd0gmfp8-rust-default-1.70.0-nightly-2023-03-07
(discovered via `rustc --print sysroot`)
try installing the Rust source the same way you installed rustc
```