### PR TITLE
Allow passthrough of arguments from CLI to test binary

### DIFF
--- a/app/buck2_test_runner/src/config.rs
+++ b/app/buck2_test_runner/src/config.rs
@@ -23,15 +23,13 @@ pub struct Config {
     #[clap(long, default_value = "600", parse(try_from_str=try_parse_timeout_from_str))]
     pub timeout: Duration,
 
-    #[clap(flatten)]
-    ignored_args: IgnoredArgs,
-}
-
-/// Ignored args included for backwards compatibility.
-#[derive(Debug, Parser)]
-struct IgnoredArgs {
+    /// Ignored arg included for backwards compatibility.
     #[clap(long, hidden = true)]
     buck_test_info: String,
+
+    /// Passthrough argments to test binary.
+    #[clap(long, multiple = true, allow_hyphen_values = true)]
+    pub arg: Vec<String>,
 }
 
 /// Uiltity that can be used to parse Env values from CLI arguments.

--- a/app/buck2_test_runner/src/runner.rs
+++ b/app/buck2_test_runner/src/runner.rs
@@ -118,6 +118,13 @@ impl Buck2TestRunner {
             testcases: Vec::new(),
         };
 
+        let config_args = self.config.arg.iter().map(|arg| ArgValue {
+            content: ArgValueContent::ExternalRunnerSpecValue(ExternalRunnerSpecValue::Verbatim(
+                arg.to_owned(),
+            )),
+            format: None,
+        });
+
         let command = spec
             .command
             .into_iter()
@@ -125,6 +132,7 @@ impl Buck2TestRunner {
                 content: ArgValueContent::ExternalRunnerSpecValue(spec_value),
                 format: None,
             })
+            .chain(config_args)
             .collect();
 
         let config_env = self.config.env.iter().map(|EnvValue { name, value }| {


### PR DESCRIPTION
Ex: buck2 test //path/to/test:target -- -- --gtest_filter=ARGS

Addresses #271 