### PR TITLE
Set protobuf environment variables in Nix shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,10 @@
           Security
         ]);
         packages = [ pkgs.cargo-bloat my-rust-bin ];
+        shellHook = ''
+          export BUCK2_BUILD_PROTOC=${pkgs.protobuf}/bin/protoc
+          export BUCK2_BUILD_PROTOC_INCLUDE=${pkgs.protobuf}/include
+        '';
       };
     });
 }


### PR DESCRIPTION
Without this building on NixOS (in the Nix shell) will hit the issue described in the README. This add environment overrides to use the protobuf toolchain from Nixpkgs instead of `protoc-bin-vendored`.