### PR TITLE
Warn when no build patterns specified

### DIFF
--- a/app/buck2_client/src/commands/build.rs
+++ b/app/buck2_client/src/commands/build.rs
@@ -270,7 +270,11 @@ impl StreamingCommand for BuildCommand {
         let console = self.common_opts.console_opts.final_console();
 
         if success {
-            console.print_success("BUILD SUCCEEDED")?;
+            if self.patterns.is_empty() {
+                console.print_warning("NO BUILD TARGET PATTERNS SPECIFIED")?;
+            } else {
+                console.print_success("BUILD SUCCEEDED")?;
+            }
         } else {
             console.print_error("BUILD FAILED")?;
         }


### PR DESCRIPTION
```
> buck2 build
Build ID: 0d60bbbe-ed3f-44c5-a992-0c9c7b5ea0ec
Jobs completed: 2. Time elapsed: 0.0s.
BUILD SUCCEEDED
```

While it was fairly obvious what happened, in the interest of discoverability and UX, I think the messaging here can be a bit improved. Many other build tools go ahead and try to build some kind of default target when just given an untargeted `build` command, and I suspect this wouldn't be that uncommon an expectation among naive users.

I'm not super fond of the wording I came up with, so open to suggestions there. `buck2 test` prints `NO TESTS RAN` in the analogous case so I tried to be vaguely consistent with that.