### PR TITLE
fix oss windows build of buck2

### DIFF
--- a/app/buck2_client_ctx/src/subscribers/event_log/write.rs
+++ b/app/buck2_client_ctx/src/subscribers/event_log/write.rs
@@ -368,7 +368,7 @@ async fn start_persist_subprocess(
     let current_exe = std::env::current_exe().context("No current_exe")?;
     let mut command = buck2_util::process::async_background_command(current_exe);
     // @oss-disable: #[cfg(unix)]
-    #[cfg(tokio_unstable)] // @oss-enable
+    #[cfg(all(tokio_unstable, unix))] // @oss-enable
     {
         // Ensure that if we get CTRL-C, the persist-event-logs process does not get it.
         command.process_group(0);


### PR DESCRIPTION
Summary:
CircleCI jobs are failing: https://app.circleci.com/pipelines/github/facebook/buck2/7153/workflows/3fa94157-9e71-4929-a83d-e6a37b5fd977/jobs/19166

(I should really get OSS ci for windows/mac :/ )

They pass now, checked locally and will trigger a PR off of this diff.

Differential Revision: D46367471

