### PR TITLE
ppx-record-selectors-test switch from -pp to -ppx

### DIFF
--- a/examples/prelude/ocaml/ppx/BUCK
+++ b/examples/prelude/ocaml/ppx/BUCK
@@ -27,8 +27,8 @@ ocaml_binary(
     name = "ppx-record-selectors-test",
     srcs = ["ppx_record_selectors_test.ml"],
     compiler_flags = [
-        "-pp",
-        "$(exe :ppx)",
+        "-ppx",
+        "$(exe :ppx) --as-ppx"
     ],
 ) if not host_info().os.is_windows else None
 


### PR DESCRIPTION
write `-ppx PPX --as-ppx` rather than the more general `-pp PPX`. the latter will result in compiler error locations not being in user source. the differences between `-pp` and `-ppx` are described [here](https://v2.ocaml.org/manual/native.html)