### PR TITLE
Bump rust toolchain to nightly 2023-06-23

### DIFF
--- a/app/buck2_build_signals_impl/src/lib.rs
+++ b/app/buck2_build_signals_impl/src/lib.rs
@@ -97,7 +97,7 @@ assert_eq_size!(DeferredResolve, [usize; 4]);
 assert_eq_size!(ConfiguredTargetNodeKey, [usize; 2]);
 assert_eq_size!(InterpreterResultsKey, [usize; 1]);
 assert_eq_size!(BuildArtifact, [usize; 6]);
-assert_eq_size!(NodeKey, [usize; 8]);
+assert_eq_size!(NodeKey, [usize; 7]);
 
 impl NodeKey {
     fn from_any(key: &dyn Any) -> Option<Self> {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
 # Rustc version is read by `app/buck2_core/build.rs`. Update it when updating the channel below.
-# @rustc_version: rustc 1.71.0-nightly (b628260df 2023-04-22)
-channel = "nightly-2023-04-23"
+# @rustc_version: rustc 1.72.0-nightly (22e9fe644 2023-06-23)
+channel = "nightly-2023-06-24"
 components = ["llvm-tools-preview","rustc-dev","rust-src"]


### PR DESCRIPTION
* Fixes ICE in the Github CI
* NodeKey enum size decrease