### PR TITLE
chore: improve URI scheme error message

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -174,8 +174,9 @@ fn prepare_uri(uri: Uri, tls: bool) -> anyhow::Result<Uri> {
         Some("grpc") | Some("dns") | Some("ipv4") | Some("ipv6") | None => {}
         Some(scheme) => {
             return Err(anyhow::anyhow!(
-                "Invalid URI scheme: `{}` (you should omit it)",
-                scheme
+                "Invalid URI scheme: `{}` for `{}` (you should omit it)",
+                scheme,
+                uri,
             ));
         }
     };


### PR DESCRIPTION
I accidentally used http for a remote executor, and while the error message was good. I think it is even better show the full string that is incorrect.

```
2023-06-29T15:54:32.628171Z  WARN buck2_execute::re::client: Failed to connect to RE, retrying after sleeping 1 seconds: Error {
    context: "RE: creating client",
    source: Error {
        context: "Error creating Execution client",
        source: Error {
            context: "Invalid URI",
            source: "Invalid URI scheme: `http` (you should omit it)",
        },
    },
}
```

This changes the print to:
```
            source: "Invalid URI scheme: `http` for `http://localhost:18980/` (you should omit it)",
```