### PR TITLE
Mark http_archive and http_file examples as executable where appropriate

### DIFF
--- a/prelude/decls/core_rules.bzl
+++ b/prelude/decls/core_rules.bzl
@@ -700,6 +700,7 @@ http_archive = prelude_rule(
           name = 'thrift-compiler-bin',
           out = 'thrift',
           cmd = 'cp $(location :thrift-archive)/bin/thrift $OUT',
+          executable = True,
         )
 
         genrule(
@@ -825,6 +826,7 @@ http_file = prelude_rule(
           name = 'thrift-compiler-bin',
           url = 'https://internal-mirror.example.com/bin/thrift-compiler',
           sha256 = 'c24932ccabb66fffb2d7122298f7f1f91e0b1f14e05168e3036333f84bdf58dc',
+          executable = True,
         )
 
         ```


### PR DESCRIPTION
Otherwise, if you copy these examples down and try to run them locally you'll get an error like this:

```
Error running analysis for `root//src:esbuild-version (prelude//platforms:default#213ed1b7ab869379)`

Caused by:
    0: Error resolving `$(exe root//src:esbuild-bin (prelude//platforms:default#213ed1b7ab869379))`.
    1: Expected a RunInfo provider from target `root//src:esbuild-bin (prelude//platforms:default#213ed1b7ab869379)`.
```

Also discussed in [the buck2 fans Discord](https://discord.com/channels/1100487223746510850/1100487225889796118/1124034662713532546).