### PR TITLE
chore(nix): update flake, add a few packages to `nix develop` shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686979235,
-        "narHash": "sha256-gBlBtk+KrezFkfMrZw6uwTuA7YWtbFciiS14mEoTCo0=",
+        "lastModified": 1687977148,
+        "narHash": "sha256-gUcXiU2GgjYIc65GOIemdBJZ+lkQxuyIh7OkR9j0gCo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7cc30fd5372ddafb3373c318507d9932bd74aafe",
+        "rev": "60a783e00517fce85c42c8c53fe0ed05ded5b2a4",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686968542,
-        "narHash": "sha256-Gjlj7UeHqMFRAYyefeoLnSjLo8V+0XheIamojNEyTbE=",
+        "lastModified": 1688005946,
+        "narHash": "sha256-aEK0CNCIfE6ALQuztj86sl4PZUzMDnbp68r6I5YW+AE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "01d84cd842e48e89be67e4c2d9dc46aa7709adc5",
+        "rev": "2925988bbc95f94e7b2f822b914ac5612a636e93",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
           IOKit
           Security
         ]);
-        packages = [ pkgs.cargo-bloat my-rust-bin ];
+        packages = [ pkgs.cargo-bloat my-rust-bin pkgs.mold pkgs.reindeer pkgs.lld_16 pkgs.clang_16 ];
         shellHook = ''
           export BUCK2_BUILD_PROTOC=${pkgs.protobuf}/bin/protoc
           export BUCK2_BUILD_PROTOC_INCLUDE=${pkgs.protobuf}/include


### PR DESCRIPTION
This adds `reindeer`, `mold`, `clang` and `lld` to the shell environment provided by `nix develop`. These packages are enough to perform a self bootstrap of buck2-with-buck2 out of the box. `clang` and `lld` are needed as the default cxx toolchain and rust builds will mandate them.

The flake update is required to get a newer copy of `reindeer` from nixpkgs, which can correctly generate shim files capable of handling @krallin's fork of `perf-event` while `vendor = false`.

The inclusion of `mold` is not because I'm using it with buck2-on-buck2, but because in debug builds with `cargo`, re-linking buck2 is slower than I'd like, and that can be fixed with a tweak to the `.cargo/config.toml` file (which I might file separately.)