### PR TITLE
fix(buck2_common): be less aggressive about HTTP retry warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,6 +270,7 @@ triomphe = "0.1.8"
 trybuild = "1.0.56"
 twox-hash = "1.6.1"
 unicode-segmentation = "1.7"
+url = "2.4.0"
 uuid = { version = "1.2", features = ["v4"] }
 walkdir = "2.3.2"
 which = "4.3.0"

--- a/app/buck2_client_ctx/src/manifold.rs
+++ b/app/buck2_client_ctx/src/manifold.rs
@@ -467,6 +467,7 @@ impl ManifoldClient {
         }
 
         let res = http_retry(
+            &url,
             || async {
                 self.client
                     .put(&url, buf.clone(), headers.clone())
@@ -499,6 +500,7 @@ impl ManifoldClient {
         );
 
         let res = http_retry(
+            &url,
             || async {
                 self.client
                     .post(&url, buf.clone(), vec![])

--- a/app/buck2_common/BUCK
+++ b/app/buck2_common/BUCK
@@ -81,6 +81,7 @@ rust_library(
         "fbsource//third-party/rust:tokio-util",
         "fbsource//third-party/rust:tonic",
         "fbsource//third-party/rust:tracing",
+        "fbsource//third-party/rust:url",
         "//buck2/allocative/allocative:allocative",
         "//buck2/app/buck2_core:buck2_core",
         "//buck2/app/buck2_data:buck2_data",

--- a/app/buck2_common/Cargo.toml
+++ b/app/buck2_common/Cargo.toml
@@ -48,6 +48,7 @@ parking_lot = { workspace = true }
 tokio-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 
 
 allocative = { workspace = true }

--- a/app/buck2_execute/src/materialize/http.rs
+++ b/app/buck2_execute/src/materialize/http.rs
@@ -101,6 +101,7 @@ impl AsHttpError for HttpDownloadError {
 
 pub async fn http_head(client: &dyn HttpClient, url: &str) -> anyhow::Result<Response<()>> {
     let response = http_retry(
+        url,
         || async {
             client
                 .head(url)
@@ -128,6 +129,7 @@ pub async fn http_download(
     }
 
     Ok(http_retry(
+        url,
         || async {
             let file = fs_util::create_file(&abs_path).map_err(HttpDownloadError::IoError)?;
 

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -195,6 +195,7 @@ triomphe = "0.1.8"
 trybuild = "1.0.56"
 twox-hash = "1.6.1"
 unicode-segmentation = "1.7"
+url = "2.4.0"
 uuid = { version = "1.2", features = ["v4"] }
 walkdir = "2.3.2"
 which = "4.3.0"


### PR DESCRIPTION
Summary: When downloading from sites like crates.io, we can pretty easily get rate-limited when a lot of our crates are uncached. Don't be so aggressive about warning; most small backoffs won't be too noticeable.

As a note, we _don't_ emit the error message we get from the callstack here in the message; the logic is that it's already a retriable error, so it doesn't make much sense to spam an error that we'd probably get again anyway, and that we ultimately are going to re-attempt. This should just make the UX a little more polished.

Also emit the domain name we're hitting problems with.

Test Plan: Change the new warning conditional from 30 seconds to zero seconds. Build buck2 with buck2. Observe the new error message, which helpfully points out we're connecting to crates.io. Change the conditional back to 30 seconds. Rebuild buck2 with buck2. Note that no warnings appear, because the exponential backoff only results in a few small 2-second retries.

GitHub Issue: Fixes #316