### PR TITLE
Buildbarn example: use lowercase OSFamily values

### DIFF
--- a/examples/remote_execution/buildbarn/README.md
+++ b/examples/remote_execution/buildbarn/README.md
@@ -32,9 +32,9 @@ Buildbarn Scheduler
 Instance name                                    Platform properties                                    Size  Timeo
    prefix                                                                                               class
 
-"fuse"        OSFamily="Linux" container-image="docker://ghcr.io/catthehacker/                          0     ∞
+"fuse"        OSFamily="linux" container-image="docker://ghcr.io/catthehacker/                          0     ∞
               ubuntu:act-22.04@sha256:5f9c35c25db1d51a8ddaae5c0ba8d3c163c5e9a4a6cc97acd409ac7eae239448"
-"hardlinking" OSFamily="Linux" container-image="docker://ghcr.io/catthehacker/                          0     ∞
+"hardlinking" OSFamily="linux" container-image="docker://ghcr.io/catthehacker/                          0     ∞
               ubuntu:act-22.04@sha256:5f9c35c25db1d51a8ddaae5c0ba8d3c163c5e9a4a6cc97acd409ac7eae239448"
 ```
 

--- a/examples/remote_execution/buildbarn/platforms/defs.bzl
+++ b/examples/remote_execution/buildbarn/platforms/defs.bzl
@@ -20,7 +20,7 @@ def _platforms(ctx):
             use_limited_hybrid = True,
             # Set those up based on what workers you've registered with Buildbarn.
             remote_execution_properties = {
-                "OSFamily": "Linux",
+                "OSFamily": "linux",
                 "container-image": "docker://ghcr.io/catthehacker/ubuntu:act-22.04@sha256:5f9c35c25db1d51a8ddaae5c0ba8d3c163c5e9a4a6cc97acd409ac7eae239448",
             },
             remote_execution_use_case = "buck2-default",


### PR DESCRIPTION
In accordance with the REv2 API the standard value of the 'OSFamily' platform property should be lowercase.

See https://github.com/bazelbuild/remote-apis/blob/068363a3625e166056c155f6441cfb35ca8dfbf2/build/bazel/remote/execution/v2/platform.md 'bb-deployments' was recently changed to lowercase in:
https://github.com/buildbarn/bb-deployments/pull/94