### PR TITLE
fix(cargo): update bumpalo 3.8.0 -> 3.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ backtrace = "0.3.51"
 base64 = "0.13.0"
 bincode = "1.3.3"
 blake3 = { version = "1.3.1", features = [ "default", "digest", "rayon", "std", "traits-preview" ] }
-bumpalo = "3.8"
+bumpalo = "3.11.1"
 byteorder = "1.4.3"
 bytes = "1.0"
 bytesize = "1.1.0"

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -41,7 +41,7 @@ backtrace = "0.3.51"
 base64 = "0.13.0"
 bincode = "1.3.3"
 blake3 = { version = "1.3.1", features = [ "default", "digest", "rayon", "std", "traits-preview" ] }
-bumpalo = "=3.8.0"
+bumpalo = "=3.11.1"
 byteorder = "1.4.3"
 bytes = "1.0"
 bytesize = "1.1.0"


### PR DESCRIPTION
Summary: Fixes an inconsistency between the version used for allocative, Cargo.toml, and the shim Cargo.toml.

I found this while doing some experiments with #308, and figured it might be nice to have.

There is also an inconsistency in the `starlark-rust` crate (which uses 3.8), but I'm not fixing that here unless asked because I believe those fixes need to go to the starlark repository.