### PR TITLE
feat(cargo): set codegen-units=1 for the release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,6 +368,7 @@ buck2_eden = { path = "app/buck2_eden" }
 [profile.release]
 incremental = true
 panic = "abort"
+codegen-units = 1
 # The line below increases build times from 50s to 84s, with no observed impact on runtime speed.
 # But maybe for some benchmarks it will show more noticeable variation.
 # lto = "thin"


### PR DESCRIPTION
Summary: I experimented with this option back when #133 was opened, and after review it can reduce binary size in --release mode by about 25% -- from 101MiB to 79MiB, while having a marginal build time increase (5m45s -> 6m20s) on my 12-core Ryzen 5600X.

While I suspect this will have little impact in practice on overall wall-clock time when running `buck2`, who doesn't love cheap and easy wins?
