### PR TITLE
Fix issue in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -39,7 +39,7 @@ Buck2 itself via `cargo`:
 git clone https://github.com/facebook/buck2.git
 cd buck2/
 nix develop . # add 'rustc' and 'cargo' to $PATH
-cargo build --release
+cargo build --release --bin=buck2
 ```
 
 A Nix package (e.g. `nix build .#buck2`) does not yet exist.

--- a/HACKING.md
+++ b/HACKING.md
@@ -39,7 +39,7 @@ Buck2 itself via `cargo`:
 git clone https://github.com/facebook/buck2.git
 cd buck2/
 nix develop . # add 'rustc' and 'cargo' to $PATH
-cargo build --release --path=app/buck2
+cargo build --release
 ```
 
 A Nix package (e.g. `nix build .#buck2`) does not yet exist.


### PR DESCRIPTION
Closes #338.

Before:
```text
$ cargo build --release --path=app/buck2
error: unexpected argument '--path' found

Usage: cargo build --release

For more information, try '--help'.
```
After:
```
$ cargo build --release --bin=buck2
< successful build ... >
```