### PR TITLE
refactor(buck2_common): don't overload the user with HTTP retry backoff warnings 

### DIFF
--- a/app/buck2_client_ctx/src/manifold.rs
+++ b/app/buck2_client_ctx/src/manifold.rs
@@ -22,6 +22,7 @@ use buck2_common::http::find_certs::find_tls_cert;
 use buck2_common::http::retries::http_retry;
 use buck2_common::http::retries::AsHttpError;
 use buck2_common::http::retries::HttpError;
+use buck2_common::http::retries::NoopDispatchableHttpRetryWarning;
 use buck2_common::http::HttpClient;
 use buck2_core::fs::paths::abs_path::AbsPath;
 use bytes::Bytes;
@@ -467,6 +468,8 @@ impl ManifoldClient {
         }
 
         let res = http_retry(
+            &url,
+            NoopDispatchableHttpRetryWarning::new(),
             || async {
                 self.client
                     .put(&url, buf.clone(), headers.clone())
@@ -499,6 +502,8 @@ impl ManifoldClient {
         );
 
         let res = http_retry(
+            &url,
+            NoopDispatchableHttpRetryWarning::new(),
             || async {
                 self.client
                     .post(&url, buf.clone(), vec![])

--- a/app/buck2_client_ctx/src/manifold.rs
+++ b/app/buck2_client_ctx/src/manifold.rs
@@ -21,8 +21,8 @@ use buck2_common::http::counting_client::CountingHttpClient;
 use buck2_common::http::find_certs::find_tls_cert;
 use buck2_common::http::retries::http_retry;
 use buck2_common::http::retries::AsHttpError;
+use buck2_common::http::retries::DispatchableHttpRetryWarning;
 use buck2_common::http::retries::HttpError;
-use buck2_common::http::retries::NoopDispatchableHttpRetryWarning;
 use buck2_common::http::HttpClient;
 use buck2_core::fs::paths::abs_path::AbsPath;
 use bytes::Bytes;
@@ -429,6 +429,25 @@ pub struct ManifoldClient {
     manifold_url: Option<String>,
 }
 
+struct ManifoldDispatchableHttpRetryWarning {}
+
+impl ManifoldDispatchableHttpRetryWarning {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl DispatchableHttpRetryWarning for ManifoldDispatchableHttpRetryWarning {
+    fn dispatch(&self, backoff: &Duration, retries: usize, url: &str) {
+        tracing::warn!(
+            "HTTP request to {} failed; {} retries. Retrying in {} seconds",
+            url,
+            retries,
+            &backoff.as_secs(),
+        );
+    }
+}
+
 impl ManifoldClient {
     pub fn new() -> anyhow::Result<Self> {
         Ok(Self {
@@ -469,7 +488,7 @@ impl ManifoldClient {
 
         let res = http_retry(
             &url,
-            NoopDispatchableHttpRetryWarning::new(),
+            ManifoldDispatchableHttpRetryWarning::new(),
             || async {
                 self.client
                     .put(&url, buf.clone(), headers.clone())
@@ -503,7 +522,7 @@ impl ManifoldClient {
 
         let res = http_retry(
             &url,
-            NoopDispatchableHttpRetryWarning::new(),
+            ManifoldDispatchableHttpRetryWarning::new(),
             || async {
                 self.client
                     .post(&url, buf.clone(), vec![])

--- a/app/buck2_common/src/http/retries.rs
+++ b/app/buck2_common/src/http/retries.rs
@@ -45,6 +45,30 @@ pub trait AsHttpError {
     fn as_http_error(&self) -> Option<&HttpError>;
 }
 
+/// Used to dispatch warnings to the event log in the case in the case of a
+/// retryable HTTP error. This often occurs when some level of exponential
+/// backoff is happening due to a lot of concurrent http_archive() requests for
+/// a single host; see GH-316 and GH-321 for background.
+pub trait DispatchableHttpRetryWarning {
+    /// Fire off a warning. This might go to the console, event log, or
+    /// some other place.
+    fn dispatch(&self, dur: &Duration, retries: usize, url: &str);
+}
+
+/// No-op implementation of DispatchableHttpRetryWarning. This does nothing at
+/// all when a retry occurs; useful for mock tests.
+pub struct NoopDispatchableHttpRetryWarning {}
+
+impl NoopDispatchableHttpRetryWarning {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl DispatchableHttpRetryWarning for NoopDispatchableHttpRetryWarning {
+    fn dispatch(&self, _backoff: &Duration, _retries: usize, _url: &str) {}
+}
+
 pub async fn http_retry<Exec, F, T, E>(exec: Exec, mut intervals: Vec<Duration>) -> Result<T, E>
 where
     Exec: Fn() -> F,

--- a/app/buck2_data/data.proto
+++ b/app/buck2_data/data.proto
@@ -161,6 +161,11 @@ message CommandOptions {
   uint64 concurrency = 1;
 }
 
+message HttpRequestRetried {
+  uint64 backoff_duration_secs = 1;
+  string url = 2;
+}
+
 // An event that represents a single point in time.
 message InstantEvent {
   reserved 8, 9, 13, 22;
@@ -236,6 +241,9 @@ message InstantEvent {
 
     // Log options that are command-level and processed by the daemon.
     CommandOptions comand_options = 31;
+
+    // Warnings of HTTP retries and exponential backoff
+    HttpRequestRetried http_request_retried = 32;
   }
 
   reserved 12; // Log

--- a/app/buck2_execute/src/materialize/http.rs
+++ b/app/buck2_execute/src/materialize/http.rs
@@ -21,6 +21,7 @@ use buck2_common::http::counting_client::CountingHttpClient;
 use buck2_common::http::retries::http_retry;
 use buck2_common::http::retries::AsHttpError;
 use buck2_common::http::retries::HttpError;
+use buck2_common::http::retries::NoopDispatchableHttpRetryWarning;
 use buck2_common::http::HttpClient;
 use buck2_core::fs::fs_util;
 use buck2_core::fs::project::ProjectRoot;
@@ -101,6 +102,8 @@ impl AsHttpError for HttpDownloadError {
 
 pub async fn http_head(client: &dyn HttpClient, url: &str) -> anyhow::Result<Response<()>> {
     let response = http_retry(
+        url,
+        NoopDispatchableHttpRetryWarning::new(),
         || async {
             client
                 .head(url)
@@ -128,6 +131,8 @@ pub async fn http_download(
     }
 
     Ok(http_retry(
+        url,
+        NoopDispatchableHttpRetryWarning::new(),
         || async {
             let file = fs_util::create_file(&abs_path).map_err(HttpDownloadError::IoError)?;
 


### PR DESCRIPTION
Summary: Another attempt at GH-316 after feedback given on GH-321 by @krallin. This introduces a new trait to dispatch these warnings, and two trait impls: one used in the materializer codepath that now writes buck events to the log, and another one used in the manifold client path to just warn to the console, like we do now.

Test Plan: Build a project that uses `reindeer` with `buck2`, as that causes a lot of warnings. Observe lots of warnings. Apply patches. Rebuild with new buck2. Observe no warnings. Run `buck2 log show | grep HttpRequestRetried` and see that all the new log events actually did get emitted and go where intended.

Fixes GH-316.