### PR TITLE
chore(nix): use mold for linking inside 'nix develop' shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687977148,
-        "narHash": "sha256-gUcXiU2GgjYIc65GOIemdBJZ+lkQxuyIh7OkR9j0gCo=",
+        "lastModified": 1689352711,
+        "narHash": "sha256-xWYFt8vWnstDIVsZ26y9mf6h3714lVmXd6l+hTQz6tw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "60a783e00517fce85c42c8c53fe0ed05ded5b2a4",
+        "rev": "2047c642ce0f75307e8a0f2ec94715218c481184",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688005946,
-        "narHash": "sha256-aEK0CNCIfE6ALQuztj86sl4PZUzMDnbp68r6I5YW+AE=",
+        "lastModified": 1689302058,
+        "narHash": "sha256-yD74lcHTrw4niXcE9goJLbzsgyce48rQQoy5jK5ZK40=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2925988bbc95f94e7b2f822b914ac5612a636e93",
+        "rev": "7b8dbbf4c67ed05a9bf3d9e658c12d4108bc24c8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,10 +39,15 @@
           Security
         ]);
         packages = [ pkgs.cargo-bloat my-rust-bin pkgs.mold pkgs.reindeer pkgs.lld_16 pkgs.clang_16 ];
-        shellHook = ''
-          export BUCK2_BUILD_PROTOC=${pkgs.protobuf}/bin/protoc
-          export BUCK2_BUILD_PROTOC_INCLUDE=${pkgs.protobuf}/include
-        '';
+        shellHook = 
+          ''
+            export BUCK2_BUILD_PROTOC=${pkgs.protobuf}/bin/protoc
+            export BUCK2_BUILD_PROTOC_INCLUDE=${pkgs.protobuf}/include
+          ''
+          # enable mold for linux users, for more tolerable link times
+          + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            export RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=mold $RUSTFLAGS"
+          '';
       };
     });
 }


### PR DESCRIPTION
Summary: when using Linux, and developing with `nix develop` or `direnv`, go ahead and enable mold as the default linker.

We modify `RUSTFLAGS` in the shell environment to do this so that we don't have to fiddle with the internal `.cargo/config.toml` file; and because it's only for development anyway, this is strictly used only while developing, not while running `nix build`.

On my Ryzen 5600X, versus the default linker settings, this takes the link time for the (debug) buck2 executable from 32s to 3s.