### PR TITLE
Add missing space in `writing_rules.md`

### DIFF
--- a/docs/rule_authors/writing_rules.md
+++ b/docs/rule_authors/writing_rules.md
@@ -8,7 +8,7 @@ This page describes how to write rules for Buck2 and explains the flow for imple
 For a list of the API functions available, see [Rule APIs](rule_api.md).
 
 :::note
-Rules such as `@fbcode_macros//build_defs:native_rules.bzl buck_genrule` are not actually rules, they are _macros_ (Starlark functions that eventually call out the underlying `genrule` _rule_).Macros in Buck2 are mostly compatible with Buck1 and should be written in the same way.
+Rules such as `@fbcode_macros//build_defs:native_rules.bzl buck_genrule` are not actually rules, they are _macros_ (Starlark functions that eventually call out the underlying `genrule` _rule_). Macros in Buck2 are mostly compatible with Buck1 and should be written in the same way.
 :::
 
 ## Workflow by example


### PR DESCRIPTION
There was a mission space after the period