### PR TITLE
buck2/examples: enable C++ and Rust targets for Windows in with_prelude

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,10 @@ commands:
           command: |
             $psProfileContent = @'
             $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-            $msvcPath = (Get-ChildItem (Join-Path $vsPath "VC\Tools\MSVC") -Directory).FullName
-            $msvcBinPath = Join-Path $msvcPath "bin\Hostx64\x64"
-            $env:PATH = "$env:USERPROFILE\.cargo\bin;$msvcBinPath;" + $env:PATH
+            $msvcVersion = (Get-Content -raw (Join-Path $vsPath "VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt")).Trim()
+            $msvcBinPath = Join-Path $vsPath "VC\Tools\MSVC\$msvcVersion\bin\Hostx64\x64"
+            $llvmPath = Join-Path $vsPath "VC\Tools\Llvm\x64\bin"
+            $env:PATH = "$env:USERPROFILE\.cargo\bin;$msvcBinPath;$llvmPath;" + $env:PATH
             # In CircleCI username here is shortened and this breaks some tests.
             $env:TEMP = "$env:USERPROFILE\AppData\Local\Temp"
             $env:TMP = $env:TEMP
@@ -244,9 +245,7 @@ jobs:
           name: Build example/no_prelude directory
           command: |
             cd examples/no_prelude
-            # TODO: Fix //cpp on CircleCI, some C++ includes are missing from the system
-            /tmp/artifacts/buck2 build //go/... -v 2
-            /tmp/artifacts/buck2 build //rust/... -v 2
+            /tmp/artifacts/buck2 build //... -v 2
       - setup_reindeer
       # TODO: Fix buck2 bootstrap for Windows
       # - run:

--- a/examples/with_prelude/cpp/hello_world/BUCK
+++ b/examples/with_prelude/cpp/hello_world/BUCK
@@ -1,16 +1,14 @@
 load("//test_utils.bzl", "assert_output")
 
-# buildifier: disable=no-effect
 cxx_binary(
     name = "main",
     srcs = ["main.cpp"],
     link_style = "static",
     deps = ["//cpp/library:print"],
-) if not host_info().os.is_windows else None
+)
 
-# buildifier: disable=no-effect
 assert_output(
     name = "check_main",
     command = "$(exe_target :main)",
     output = "hello world from cpp toolchain",
-) if not host_info().os.is_windows else None
+)

--- a/examples/with_prelude/cpp/library/BUCK
+++ b/examples/with_prelude/cpp/library/BUCK
@@ -1,7 +1,6 @@
-# buildifier: disable=no-effect
 cxx_library(
     name = "print",
     srcs = glob(["**/*.cpp"]),
     exported_headers = glob(["**/*.hpp"]),
     visibility = ["PUBLIC"],
-) if not host_info().os.is_windows else None
+)

--- a/examples/with_prelude/cpp/library/library.cpp
+++ b/examples/with_prelude/cpp/library/library.cpp
@@ -9,6 +9,12 @@
 
 #include <iostream>
 
-void print_hello() {
+#ifdef _WIN32
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+DLLEXPORT void print_hello() {
   std::cout << "hello world from cpp toolchain" << std::endl;
 }

--- a/examples/with_prelude/rust/BUCK
+++ b/examples/with_prelude/rust/BUCK
@@ -1,17 +1,15 @@
 load("//test_utils.bzl", "assert_output")
 
-# buildifier: disable=no-effect
 rust_binary(
     name = "main",
     srcs = glob(
         ["src/**/*.rs"],
     ),
     crate_root = "src/main.rs",
-) if not host_info().os.is_windows else None
+)
 
-# buildifier: disable=no-effect
 assert_output(
     name = "check_main",
     command = "$(exe_target :main)",
     output = "hello world from rust toolchain",
-) if not host_info().os.is_windows else None
+)


### PR DESCRIPTION
Summary: These should work on CircleCI with MSVC toolchain.

Differential Revision: D47477812

