### PR TITLE
buck2/oss: do not add MSVC to PATH in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,11 +79,9 @@ commands:
           name: Write Powershell profile
           command: |
             $psProfileContent = @'
-            $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-            $msvcVersion = (Get-Content -raw (Join-Path $vsPath "VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt")).Trim()
-            $msvcBinPath = Join-Path $vsPath "VC\Tools\MSVC\$msvcVersion\bin\Hostx64\x64"
+            $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
             $llvmPath = Join-Path $vsPath "VC\Tools\Llvm\x64\bin"
-            $env:PATH = "$env:USERPROFILE\.cargo\bin;$msvcBinPath;$llvmPath;" + $env:PATH
+            $env:PATH = "$env:USERPROFILE\.cargo\bin;$llvmPath;" + $env:PATH
             # In CircleCI username here is shortened and this breaks some tests.
             $env:TEMP = "$env:USERPROFILE\AppData\Local\Temp"
             $env:TMP = $env:TEMP

--- a/prelude/cxx/tools/linker_wrapper.py
+++ b/prelude/cxx/tools/linker_wrapper.py
@@ -8,11 +8,9 @@
 
 import codecs
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
-import winreg
 
 
 def unquote(argument):
@@ -58,38 +56,6 @@ def expand_args(arguments):
     return expanded
 
 
-def find_windows_sdk(arch):
-    registry = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
-    key_name = "SOFTWARE\\WOW6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0"
-    registry_key = winreg.OpenKey(registry, key_name)
-    installation_folder = winreg.QueryValueEx(registry_key, "InstallationFolder")[0]
-    sdk_version = winreg.QueryValueEx(registry_key, "ProductVersion")[0]
-    # Folder name has extra suffix.
-    sdk_version += ".0"
-    sdk_path = os.path.join(installation_folder, "Lib", sdk_version)
-    sdk_libpath = []
-    sdk_libpath.append(os.path.join(sdk_path, "ucrt", arch))
-    sdk_libpath.append(os.path.join(sdk_path, "um", arch))
-    return sdk_libpath
-
-
-def find_msvc_libpath(linker):
-    libpath = []
-    linker_path = shutil.which(linker)
-    if linker_path is None:
-        raise FileNotFoundError("{} not found".format(linker))
-    parts = os.path.normpath(linker_path).split(os.sep)
-    arch = parts[-2]
-    assert arch in ["x86", "x64"], "Unsupported MSVC setup"
-    libpath.append(os.sep.join(parts[:-4] + ["lib", arch]))
-    try:
-        libpath.extend(find_windows_sdk(arch))
-    except FileNotFoundError:
-        print("Windows SDK is not installed")
-        sys.exit(1)
-    return ["/LIBPATH:" + p for p in libpath]
-
-
 def main():
     linker_real, rest = sys.argv[1], sys.argv[2:]
     working_dir = os.getcwd()
@@ -116,10 +82,6 @@ def main():
             argument = os.path.join(working_dir, argument)
 
         new_args.append(argument)
-
-    # Dynamically find LIBPATH for the current linker from system toolchain.
-    if linker_real in ["link.exe", "link"]:
-        new_args.extend(find_msvc_libpath(linker_real))
 
     # Based on rustc's @linker-arguments file construction.
     # https://github.com/rust-lang/rust/blob/1.69.0/compiler/rustc_codegen_ssa/src/back/link.rs#L1383-L1407

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -22,7 +22,7 @@ load("@prelude//linking:lto.bzl", "LtoMode")
 load("@prelude//toolchains/msvc:tools.bzl", "VisualStudio")
 load("@prelude//utils:cmd_script.bzl", "ScriptOs", "cmd_script")
 
-def _system_cxx_toolchain_impl(ctx):
+def _system_cxx_toolchain_impl(ctx: AnalysisContext):
     """
     A very simple toolchain that is hardcoded to the current environment.
     """
@@ -53,7 +53,9 @@ def _system_cxx_toolchain_impl(ctx):
         if compiler == "cl.exe":
             compiler = msvc_tools.cl_exe
         cxx_compiler = compiler
-        linker = _windows_linker_wrapper(ctx)
+        if linker == "link.exe":
+            linker = msvc_tools.link_exe
+        linker = _windows_linker_wrapper(ctx, linker)
         linker_type = "windows"
         binary_extension = "exe"
         object_file_extension = "obj"
@@ -139,7 +141,7 @@ def _system_cxx_toolchain_impl(ctx):
         CxxPlatformInfo(name = "x86_64"),
     ]
 
-def _windows_linker_wrapper(ctx: AnalysisContext) -> cmd_args:
+def _windows_linker_wrapper(ctx: AnalysisContext, linker: cmd_args) -> cmd_args:
     # Linkers pretty much all support @file.txt argument syntax to insert
     # arguments from the given text file, usually formatted one argument per
     # line.
@@ -157,7 +159,7 @@ def _windows_linker_wrapper(ctx: AnalysisContext) -> cmd_args:
         name = "windows_linker",
         cmd = cmd_args(
             ctx.attrs.linker_wrapper[RunInfo],
-            ctx.attrs.linker,
+            linker,
         ),
         os = ScriptOs("windows"),
     )

--- a/prelude/toolchains/msvc/tools.bzl
+++ b/prelude/toolchains/msvc/tools.bzl
@@ -14,18 +14,22 @@ VisualStudio = provider(fields = [
     "lib_exe",
     # ml64.exe
     "ml64_exe",
+    # link.exe
+    "link_exe",
 ])
 
 def _find_msvc_tools_impl(ctx: AnalysisContext) -> ["provider"]:
     cl_exe_json = ctx.actions.declare_output("cl.exe.json")
     lib_exe_json = ctx.actions.declare_output("lib.exe.json")
     ml64_exe_json = ctx.actions.declare_output("ml64.exe.json")
+    link_exe_json = ctx.actions.declare_output("link.exe.json")
 
     cmd = [
         ctx.attrs.vswhere[RunInfo],
         cmd_args("--cl=", cl_exe_json.as_output(), delimiter = ""),
         cmd_args("--lib=", lib_exe_json.as_output(), delimiter = ""),
         cmd_args("--ml64=", ml64_exe_json.as_output(), delimiter = ""),
+        cmd_args("--link=", link_exe_json.as_output(), delimiter = ""),
     ]
 
     ctx.actions.run(
@@ -53,6 +57,12 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> ["provider"]:
         cmd = cmd_args(run_msvc_tool, ml64_exe_json),
         os = ScriptOs("windows"),
     )
+    link_exe_script = cmd_script(
+        ctx = ctx,
+        name = "link",
+        cmd = cmd_args(run_msvc_tool, link_exe_json),
+        os = ScriptOs("windows"),
+    )
 
     return [
         # Supports `buck2 run prelude//toolchains/msvc:msvc_tools[cl.exe]`
@@ -70,6 +80,12 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> ["provider"]:
                     "json": [DefaultInfo(default_output = lib_exe_json)],
                 }),
             ],
+            "link.exe": [
+                RunInfo(args = [link_exe_script]),
+                DefaultInfo(sub_targets = {
+                    "json": [DefaultInfo(default_output = link_exe_json)],
+                }),
+            ],
             "ml64.exe": [
                 RunInfo(args = [ml64_exe_script]),
                 DefaultInfo(sub_targets = {
@@ -81,6 +97,7 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> ["provider"]:
             cl_exe = cl_exe_script,
             lib_exe = lib_exe_script,
             ml64_exe = ml64_exe_script,
+            link_exe = link_exe_script,
         ),
     ]
 

--- a/prelude/toolchains/msvc/vswhere.py
+++ b/prelude/toolchains/msvc/vswhere.py
@@ -25,6 +25,7 @@ class OutputJsonFiles(NamedTuple):
     cl: IO[str]
     lib: IO[str]
     ml64: IO[str]
+    link: IO[str]
 
 
 class Tool(NamedTuple):
@@ -96,7 +97,7 @@ def find_with_vswhere_exe():
         lib_path = tools_path / "lib" / "x64"
         include_path = tools_path / "include"
 
-        exe_names = "cl.exe", "lib.exe", "ml64.exe"
+        exe_names = "cl.exe", "lib.exe", "ml64.exe", "link.exe"
         if not all(bin_path.joinpath(exe).exists() for exe in exe_names):
             continue
 
@@ -204,6 +205,7 @@ def main():
     parser.add_argument("--cl", type=argparse.FileType("w"), required=True)
     parser.add_argument("--lib", type=argparse.FileType("w"), required=True)
     parser.add_argument("--ml64", type=argparse.FileType("w"), required=True)
+    parser.add_argument("--link", type=argparse.FileType("w"), required=True)
     output = OutputJsonFiles(**vars(parser.parse_args()))
 
     # If vcvars has been run, it puts these tools onto $PATH.
@@ -211,12 +213,14 @@ def main():
         cl_exe = find_in_path("cl.exe")
         lib_exe = find_in_path("lib.exe")
         ml64_exe = find_in_path("ml64.exe")
+        link_exe = find_in_path("link.exe")
     else:
-        cl_exe, lib_exe, ml64_exe = find_with_vswhere_exe()
+        cl_exe, lib_exe, ml64_exe, link_exe = find_with_vswhere_exe()
 
     write_tool_json(output.cl, cl_exe)
     write_tool_json(output.lib, lib_exe)
     write_tool_json(output.ml64, ml64_exe)
+    write_tool_json(output.link, link_exe)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: With `msvc_tools` we no longer need to have MSVC available in `PATH`.

Differential Revision: D47722369

