### PR TITLE
buck2/oss: update TEMP folder in CircleCI job on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,11 +79,9 @@ commands:
           name: Write Powershell profile
           command: |
             $psProfileContent = @'
-            $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-            $msvcVersion = (Get-Content -raw (Join-Path $vsPath "VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt")).Trim()
-            $msvcBinPath = Join-Path $vsPath "VC\Tools\MSVC\$msvcVersion\bin\Hostx64\x64"
+            $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
             $llvmPath = Join-Path $vsPath "VC\Tools\Llvm\x64\bin"
-            $env:PATH = "$env:USERPROFILE\.cargo\bin;$msvcBinPath;$llvmPath;" + $env:PATH
+            $env:PATH = "$env:USERPROFILE\.cargo\bin;$llvmPath;" + $env:PATH
             # In CircleCI username here is shortened and this breaks some tests.
             $env:TEMP = "$env:USERPROFILE\AppData\Local\Temp"
             $env:TMP = $env:TEMP

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,9 @@ commands:
             $llvmPath = Join-Path $vsPath "VC\Tools\Llvm\x64\bin"
             $env:PATH = "$env:USERPROFILE\.cargo\bin;$llvmPath;" + $env:PATH
             # In CircleCI username here is shortened and this breaks some tests.
-            $env:TEMP = "$env:USERPROFILE\AppData\Local\Temp"
+            $env:TEMP = "$env:LOCALAPPDATA\Temp"
             $env:TMP = $env:TEMP
+            # Empty line to have proper line ending for the previous line.
             '@
             Add-Content "$PsHome\profile.ps1" $psProfileContent
       - print_versions

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -83,6 +83,7 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
                 linker_flags = additional_linker_flags + ctx.attrs.link_flags,
                 archiver = RunInfo(args = archiver_args),
                 archiver_type = archiver_type,
+                archiver_supports_argfiles = True,
                 generate_linker_maps = False,
                 lto_mode = LtoMode("none"),
                 type = linker_type,


### PR DESCRIPTION
Summary:
Doctests for `starlark` crate are flaky.

They fail with:
```
error: couldn't create a temp dir: The system cannot find the path specified. (os error 3) at path "C:\\Users\\circleci.PACKER-64B08804\\AppData\\Local\\Temp\\rustdoctestYSRag4\\rmetaqmtrb0"`
```

I noticed `profile.ps1` has carriage return without newline character in the last line. Checking if this helps.

Examples:
1. https://app.circleci.com/pipelines/github/facebook/buck2/9557/workflows/19ada447-5135-478d-abe0-ddad8fe00212/jobs/25368
2. https://app.circleci.com/pipelines/github/facebook/buck2/9550/workflows/24f9c196-83a6-42b0-8936-3af658ff8c33/jobs/25348
3. https://app.circleci.com/pipelines/github/facebook/buck2/9564/workflows/cbf5de0d-6563-48ae-a56d-052aa6c648b8/jobs/25390

Differential Revision: D47754152

