### PR TITLE
buck2/toolchains: disable archiver_supports_argfiles for MacOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,9 @@ commands:
             $llvmPath = Join-Path $vsPath "VC\Tools\Llvm\x64\bin"
             $env:PATH = "$env:USERPROFILE\.cargo\bin;$llvmPath;" + $env:PATH
             # In CircleCI username here is shortened and this breaks some tests.
-            $env:TEMP = "$env:USERPROFILE\AppData\Local\Temp"
+            $env:TEMP = "$env:LOCALAPPDATA\Temp"
             $env:TMP = $env:TEMP
+            # Empty line to have proper line ending for the previous line.
             '@
             Add-Content "$PsHome\profile.ps1" $psProfileContent
       - print_versions

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -28,6 +28,7 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
     """
     archiver_args = ["ar", "rcs"]
     archiver_type = "gnu"
+    archiver_supports_argfiles = True
     asm_compiler = ctx.attrs.compiler
     asm_compiler_type = ctx.attrs.compiler_type
     compiler = ctx.attrs.compiler
@@ -42,6 +43,7 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
     shared_library_versioned_name_format = "lib{}.so.{}"
     additional_linker_flags = []
     if host_info().os.is_macos:
+        archiver_supports_argfiles = False
         linker_type = "darwin"
         pic_behavior = PicBehavior("always_enabled")
     elif host_info().os.is_windows:
@@ -83,7 +85,7 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
                 linker_flags = additional_linker_flags + ctx.attrs.link_flags,
                 archiver = RunInfo(args = archiver_args),
                 archiver_type = archiver_type,
-                archiver_supports_argfiles = True,
+                archiver_supports_argfiles = archiver_supports_argfiles,
                 generate_linker_maps = False,
                 lto_mode = LtoMode("none"),
                 type = linker_type,


### PR DESCRIPTION
Summary:
It seems that `ar` on Mac doesn't support argfiles:
https://app.circleci.com/pipelines/github/facebook/buck2/9578/workflows/99f2b8e5-77bb-4615-a739-82f8e2f3699b/jobs/25422

Reviewed By: krallin

Differential Revision: D47757074

