### PR TITLE
buck2/oss: don't override TEMP for Windows in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,6 @@ commands:
             $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
             $llvmPath = Join-Path $vsPath "VC\Tools\Llvm\x64\bin"
             $env:PATH = "$env:USERPROFILE\.cargo\bin;$llvmPath;" + $env:PATH
-            # In CircleCI username here is shortened and this breaks some tests.
-            $env:TEMP = "$env:LOCALAPPDATA\Temp"
-            $env:TMP = $env:TEMP
-            # Empty line to have proper line ending for the previous line.
             '@
             Add-Content "$PsHome\profile.ps1" $psProfileContent
       - print_versions


### PR DESCRIPTION
Summary:
Windows may use shortened username in `%TEMP%` e.g.:
```
> echo $env:TMP
C:\Users\SAYFUT~1\AppData\Local\Temp
```

This makes path comparison more difficult.

Instead of changing `TEMP` on CircleCI, canonicalize all paths. This also fixes local workflows.

This could help with flakiness of doc tests on CircleCI as well.

Differential Revision: D47873443

