### PR TITLE
Modernize name of Cargo configuration files (.cargo/config -> .cargo/config.toml)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,8 @@ commands:
           command: |
             choco uninstall -y rust
             choco install -y rustup.install
-            write-output "[net]`ngit-fetch-with-cli = true" | out-file -append -encoding utf8 $Env:USERPROFILE/.cargo/config
-            type $Env:USERPROFILE/.cargo/config
+            write-output "[net]`ngit-fetch-with-cli = true" | out-file -append -encoding utf8 $Env:USERPROFILE/.cargo/config.toml
+            type $Env:USERPROFILE/.cargo/config.toml
       - run:
           name: Create python3 symlink
           command: |


### PR DESCRIPTION
Summary: `.cargo/config.toml` is the modern, editor-friendly name preferred since Rust 1.39. See https://doc.rust-lang.org/1.71.0/cargo/reference/config.html.

Differential Revision: D48341560

