### PR TITLE
Fix to support passing include directories to windows compiler

### DIFF
--- a/prelude/cxx/preprocessor.bzl
+++ b/prelude/cxx/preprocessor.bzl
@@ -437,6 +437,6 @@ def _remap_headers_to_basename(headers: list[CHeader.type]) -> list[CHeader.type
 def get_flags_for_compiler_type(compiler_type: str) -> list[str]:
     # MSVC requires this flag to enable external headers
     if compiler_type in ["windows"]:
-        return ["/experimental:external", "/nologo"]
+        return ["/experimental:external", "/nologo", "/external:W0"]
     else:
         return []


### PR DESCRIPTION
Without this fix, include directories are sometimes not forwarded properly by some rules like `prebuilt_cxx_library`

In those cases we get this warning:

`cl : Command line warning D9007 : '/external:I' requires '/external:W'; option ignored`

Which appears to cause include directories to be ignored, since we also get errors of the form: `foo\foo.c(1): fatal error C1083: Cannot open include file: 'lua.h': No such file or directory`, which go away with this fix

To ensure this isn't just a quirk of my project, I've put together a minimal example of the issue [here](https://github.com/svermeulen/buck2-windows-c-include-directory-issue-example).  If that repo is cloned on a windows machine, and then run `buck2 build //foo:foo` then the error should be shown.  I should note also that in my case I only have Visual Studio 2022 Professional installed, which I assume is what it is using.

If this fix is then added to the above example then the problem goes away and foo compiles successfully.   I don't fully understand why the fix is necessary since I would have expected "/experimental:external" flag to be sufficient, but it appears it is necessary to specify a warning level at least in the example above on my machine.