### PR TITLE
Removed misleading docs around default values for ExternalRunnerTestInfo fields

### DIFF
--- a/app/buck2_build_api/src/interpreter/rule_defs/provider/builtin/external_runner_test_info.rs
+++ b/app/buck2_build_api/src/interpreter/rule_defs/provider/builtin/external_runner_test_info.rs
@@ -73,12 +73,11 @@ pub struct ExternalRunnerTestInfoGen<V> {
     #[provider(field_type = Vec<String>)]
     contacts: V,
 
-    /// Whether this test should use relative paths. The default is not to.
+    /// Whether this test should use relative paths
     #[provider(field_type = Vec<bool>)]
     use_project_relative_paths: V,
 
-    /// Whether this test should run from the project root, as opposed to the cell root. The
-    /// default is not to.
+    /// Whether this test should run from the project root, as opposed to the cell root
     #[provider(field_type = Vec<bool>)]
     run_from_project_root: V,
 


### PR DESCRIPTION
As stated [here](https://github.com/facebook/buck2/blob/67c008f6144d303bc64fd0f5cc777b87cf917a40/docs/rule_authors/test_execution.md?plain=1#L75), the fields `use_project_relative_paths` and `run_from_project_root` both have different default values depending on whether the user is using the meta-internal version of buck2 or the open source version.  However, the inline docs state that the default value is what is used in the meta-internal version, making it incorrect for open source users

To solve this problem I opted to just not state default value in that case.
