### PR TITLE
rust-project: Fix un-truncated line endings with the rustup sysroot getter

### DIFF
--- a/integrations/rust-project/src/sysroot.rs
+++ b/integrations/rust-project/src/sysroot.rs
@@ -116,7 +116,8 @@ pub fn resolve_rustup_sysroot() -> Result<Sysroot, anyhow::Error> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let output = utf8_output(cmd.output(), &cmd)?;
+    let mut output = utf8_output(cmd.output(), &cmd)?;
+    truncate_line_ending(&mut output);
     let sysroot = PathBuf::from(output);
 
     let sysroot = Sysroot {


### PR DESCRIPTION
Sysroots from rustup currently include the trailing newline, needs trimming. The .buckconfig-based sysroot setting is also broken without fb-specific tooling (xplat etc).