### PR TITLE
Pin windows_x86_64_msvc

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -200,6 +200,7 @@ unicode-segmentation = "1.7"
 uuid = { version = "1.2", features = ["v4"] }
 walkdir = "2.3.2"
 which = "4.3.0"
+windows_x86_64_msvc = "=0.48.0"  # our fixup only works if we are on precisely 0.48.0
 winapi = { version = "0.3", features = ["everything"] }
 xattr = "0.2.2"
 zip = "0.5"


### PR DESCRIPTION
Summary: This create has a fixup which only works on specific versions of windows_x86_64_msvc, as it specifies `windows.0.48.0.lib`, so we need exactly that version. Our CI broke when a new patch release was made.

Differential Revision: D48724761


