### PR TITLE
Make a bunch of python bootstraps exec deps

### DIFF
--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -181,9 +181,9 @@ system_cxx_toolchain = rule(
         "link_flags": attrs.list(attrs.string(), default = []),
         "link_style": attrs.string(default = "shared"),
         "linker": attrs.string(default = "link.exe" if host_info().os.is_windows else "clang++"),
-        "linker_wrapper": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:linker_wrapper")),
-        "make_comp_db": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:make_comp_db")),
-        "msvc_tools": attrs.default_only(attrs.dep(providers = [VisualStudio], default = "prelude//toolchains/msvc:msvc_tools")),
+        "linker_wrapper": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//cxx/tools:linker_wrapper")),
+        "make_comp_db": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//cxx/tools:make_comp_db")),
+        "msvc_tools": attrs.default_only(attrs.exec_dep(providers = [VisualStudio], default = "prelude//toolchains/msvc:msvc_tools")),
     },
     is_toolchain_rule = True,
 )

--- a/prelude/toolchains/msvc/tools.bzl
+++ b/prelude/toolchains/msvc/tools.bzl
@@ -104,7 +104,7 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
 find_msvc_tools = rule(
     impl = _find_msvc_tools_impl,
     attrs = {
-        "run_msvc_tool": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//toolchains/msvc:run_msvc_tool")),
-        "vswhere": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//toolchains/msvc:vswhere")),
+        "run_msvc_tool": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//toolchains/msvc:run_msvc_tool")),
+        "vswhere": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//toolchains/msvc:vswhere")),
     },
 )


### PR DESCRIPTION
See https://github.com/facebook/buck2/issues/391#issuecomment-1707865763

Issue consists of:

- using a target platform with `config//os:none`, e.g. webassembly
- the `system_python_bootstrap_toolchain` rule's default value for the interpreter select()ing from `config//os:linux`/macos/windows, but no default value
- Some msvc tools using regular deps for their python bootstrap deps
- Using a system_cxx_toolchain, which does the same
- So all the python bootstrap rules are configured for the target platform which has os:none. And thus you can't configure a python bootstrap toolchain. You can obviously just set `interpreter="python3"` yourself to make the error go away, but you can't select() a proper solution in there because the configs that are set are based on the target platform.

There are more places python bootstraps are used without being exec deps. E.g. [here](https://github.com/facebook/buck2/blob/959555e5f6eed689d88deceb460096ebde590421/prelude/cxx/cxx_toolchain.bzl#L218) which seems very complicated.

I suppose this would also be fixed by using a transition to exec platform on all python bootstrap binaries? Surely nobody ever needs a python bootstrap binary configured for a target platform, it would be pretty useless given the limitations of the python bootstrap rules. Anyway, this works.