### PR TITLE
Add a "wasm" LinkerType/linker_type.

### DIFF
--- a/prelude/cxx/cxx_toolchain_types.bzl
+++ b/prelude/cxx/cxx_toolchain_types.bzl
@@ -13,7 +13,7 @@ load("@prelude//cxx:debug.bzl", "SplitDebugMode")
 # executable can access those.
 RichLinkerRunInfo = provider(fields = ["exe", "flags"])
 
-LinkerType = ["gnu", "darwin", "windows"]
+LinkerType = ["gnu", "darwin", "windows", "wasm"]
 
 ShlibInterfacesMode = enum("disabled", "enabled", "defined_only")
 

--- a/prelude/cxx/linker.bzl
+++ b/prelude/cxx/linker.bzl
@@ -56,6 +56,14 @@ LINKERS = {
         shared_library_name_linker_flags_format = [],
         shared_library_flags = ["/DLL"],
     ),
+    "wasm": Linker(
+        default_shared_library_extension = "wasm",
+        default_shared_library_versioned_extension_format = "{}.wasm",
+        shared_library_name_linker_flags_format = [],
+        # lld supports this, at least.
+        # See https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md#llvm-implementation
+        shared_library_flags = ["-shared"],
+    ),
 }
 
 PDB_SUB_TARGET = "pdb"

--- a/prelude/rust/build_params.bzl
+++ b/prelude/rust/build_params.bzl
@@ -143,6 +143,7 @@ def _executable_prefix_suffix(linker_type: str, target_os_type: OsLookup) -> (st
         "darwin": ("", ""),
         "gnu": ("", ".exe") if target_os_type.platform == "windows" else ("", ""),
         "windows": ("", ".exe"),
+        "wasm": ("", ".wasm"),
     }[linker_type]
 
 def _library_prefix_suffix(linker_type: str, target_os_type: OsLookup) -> (str, str):
@@ -150,6 +151,7 @@ def _library_prefix_suffix(linker_type: str, target_os_type: OsLookup) -> (str, 
         "darwin": ("lib", ".dylib"),
         "gnu": ("", ".dll") if target_os_type.platform == "windows" else ("lib", ".so"),
         "windows": ("", ".dll"),
+        "wasm": ("", ".wasm"),
     }[linker_type]
 
 _BUILD_PARAMS = {


### PR DESCRIPTION
Why?
1. We want to emit `.wasm` files, so the filenames need configuration. LinkerType is how we do that.

2. Wasm needs to avoid all the `== "darwin"`, `== "gnu"` checks throughout the cxx toolchain code.

3. There are new flags supported by `wasm-ld`, LLVM's wasm linker, which we may wish to support.

4. LLD has `-flavor wasm`. (The other linker_types map 1:1 to LLD flavors.  "windows" is just a much better name than `-flavor link` is. Etc.)

`-flavor wasm` isn't passed anywhere in buck's rules, but rustc natively sends that flag when it's assuming your linker is `rust-lld`. This is a bit of a roundabout way of configuring it; it would be nice to tell rustc "we got this" and configure every flag ourselves. I also got the impression that linker_type should simply be describing how the `linker` executable behaves, so both should be configured in tandem i.e. `cxx_toolchain_override(..., linker_type = "darwin", linker = RunInfo(args = cmd_args("lld", "-flavor", "darwin")))`. Let me know if I'm on the wrong track there.

I have a separate PR coming that improves the zig toolchain + sets the linker_type to a select(). I can't currently get zig to link it, but you can combine it with cxx_toolchain_override that sets the linker to rust-lld from a rustup distribution. (Buckifying rust-toolchain.toml and constructing a sysroot is also done, PR coming soon.)

For linkage, ref #391 