### PR TITLE
fix cxx_toolchain_override not handling missing fields on base toolchains

### DIFF
--- a/prelude/cxx/user/cxx_toolchain_override.bzl
+++ b/prelude/cxx/user/cxx_toolchain_override.bzl
@@ -16,7 +16,7 @@ load(
 load("@prelude//linking:lto.bzl", "LtoMode")
 load("@prelude//user:rule_spec.bzl", "RuleRegistrationSpec")
 load("@prelude//utils:pick.bzl", _pick = "pick", _pick_and_add = "pick_and_add", _pick_bin = "pick_bin", _pick_dep = "pick_dep")
-load("@prelude//utils:utils.bzl", "value_or")
+load("@prelude//utils:utils.bzl", "value_or", "map_val")
 
 def _cxx_toolchain_override(ctx):
     base_toolchain = ctx.attrs.base[CxxToolchainInfo]
@@ -89,7 +89,7 @@ def _cxx_toolchain_override(ctx):
         link_ordering = base_linker_info.link_ordering,
         linker = _pick_bin(ctx.attrs.linker, base_linker_info.linker),
         linker_flags = _pick(ctx.attrs.linker_flags, base_linker_info.linker_flags),
-        lto_mode = LtoMode(value_or(ctx.attrs.lto_mode, base_linker_info.lto_mode.value)),
+        lto_mode = value_or(map_val(LtoMode, ctx.attrs.lto_mode), base_linker_info.lto_mode),
         object_file_extension = base_linker_info.object_file_extension,
         shlib_interfaces = value_or(ctx.attrs.shared_library_interface_mode, base_linker_info.shlib_interfaces),
         mk_shlib_intf = _pick_dep(ctx.attrs.mk_shlib_intf, base_linker_info.mk_shlib_intf),

--- a/prelude/cxx/user/cxx_toolchain_override.bzl
+++ b/prelude/cxx/user/cxx_toolchain_override.bzl
@@ -21,15 +21,17 @@ load("@prelude//utils:utils.bzl", "value_or")
 def _cxx_toolchain_override(ctx):
     base_toolchain = ctx.attrs.base[CxxToolchainInfo]
     base_as_info = base_toolchain.as_compiler_info
-    as_info = AsCompilerInfo(
-        compiler = _pick_bin(ctx.attrs.as_compiler, base_as_info.compiler),
-        compiler_type = base_as_info.compiler_type,
-        compiler_flags = _pick(ctx.attrs.as_compiler_flags, base_as_info.compiler_flags),
-        preprocessor = _pick_bin(ctx.attrs.as_compiler, base_as_info.preprocessor),
-        preprocessor_type = base_as_info.preprocessor_type,
-        preprocessor_flags = _pick(ctx.attrs.as_preprocessor_flags, base_as_info.preprocessor_flags),
-        dep_files_processor = base_as_info.dep_files_processor,
-    )
+    as_info = None
+    if base_as_info != None:
+        as_info = AsCompilerInfo(
+            compiler = _pick_bin(ctx.attrs.as_compiler, base_as_info.compiler),
+            compiler_type = base_as_info.compiler_type,
+            compiler_flags = _pick(ctx.attrs.as_compiler_flags, base_as_info.compiler_flags),
+            preprocessor = _pick_bin(ctx.attrs.as_compiler, base_as_info.preprocessor),
+            preprocessor_type = base_as_info.preprocessor_type,
+            preprocessor_flags = _pick(ctx.attrs.as_preprocessor_flags, base_as_info.preprocessor_flags),
+            dep_files_processor = base_as_info.dep_files_processor,
+        )
     asm_info = base_toolchain.asm_compiler_info
     if asm_info != None:
         asm_info = AsmCompilerInfo(


### PR DESCRIPTION
The defaults for the `lto_mode` and `as_compiler_info` arguments to `cxx_toolchain_infos` are `None`. The zig cxx toolchain, for example, doesn't set them. These changes let you override the zig toolchain without erroring out in cxx_toolchain_override, which was trying to access fields on those Nones.