### PR TITLE
Add wasm32 + wasi platforms

### DIFF
--- a/prelude/rust/cargo_package.bzl
+++ b/prelude/rust/cargo_package.bzl
@@ -52,6 +52,20 @@ DEFAULT_PLATFORM_TEMPLATES = {
             "config//abi:msvc": True,
         }),
     }),
+    "wasm32": select({
+        "DEFAULT": False,
+        "config//os:none": select({
+            "DEFAULT": False,
+            "config//cpu:wasm32": True,
+        }),
+    }),
+    "wasi": select({
+        "DEFAULT": False,
+        "config//os:wasi": select({
+            "DEFAULT": False,
+            "config//cpu:wasm32": True,
+        }),
+    }),
 }
 
 def apply_platform_attrs(


### PR DESCRIPTION
This allows cargo.rust_library/bin rules to have wasm32/wasi specific attributes, notably `deps`, without extra fiddling.

eg. `buck2 build --target-platforms platforms//:wasm32 //third-party:ahash`

```python
load("@prelude//rust:cargo_package.bzl", "cargo")

alias(
    name = "ahash",
    actual = ":ahash-0.8.3",
    visibility = ["PUBLIC"],
)

http_archive(
    name = "ahash-0.8.3.crate",
    sha256 = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f",
    strip_prefix = "ahash-0.8.3",
    urls = ["https://crates.io/api/v1/crates/ahash/0.8.3/download"],
    visibility = [],
)

cargo.rust_library(
    name = "ahash-0.8.3",
    srcs = [":ahash-0.8.3.crate"],
    crate = "ahash",
    crate_root = "ahash-0.8.3.crate/src/lib.rs",
    edition = "2018",
    features = [
        "no-rng",
        "serde",
        "std",
    ],
    platform = {
        "linux-arm64": dict(
            deps = [":once_cell-1.18.0"],
        ),
        "linux-x86_64": dict(
            deps = [":once_cell-1.18.0"],
        ),
        "macos-arm64": dict(
            deps = [":once_cell-1.18.0"],
        ),
        "macos-x86_64": dict(
            deps = [":once_cell-1.18.0"],
        ),
        "wasm32": dict(
            deps = [":once_cell-1.18.0"],
        ),
        "windows-gnu": dict(
            deps = [":once_cell-1.18.0"],
        ),
        "windows-msvc": dict(
            deps = [":once_cell-1.18.0"],
        ),
    },
    visibility = [],
    deps = [
        ":cfg-if-1.0.0",
        ":serde-1.0.188",
    ],
)
```

Would give 

```
buck2 build --target-platforms platforms//:wasm32 //third-party:ahash                                                                                                                                        3 ↵
Action failed: root//third-party:ahash-0.8.3 (rustc rlib-static-static-metadata/ahash-metadata rlib,static,metadata [diag])
Local command returned non-zero exit code 1
Reproduce locally: `env -- "BUCK_SCRATCH_PATH=buck-out/v2/tmp/root/3295263a5955aa9b/third-party/__ahash-0.8.3__/rustc/_b ...<omitted>... ot/3295263a5955aa9b/third-party/__ahash-0.8.3__/rlib-static-static-metadata/ahash-metadata-diag.args (run `buck2 log what-failed` to get the full command)`
stdout:
stderr:
error[E0433]: failed to resolve: use of undeclared crate or module `once_cell`
   --> ./third-party/ahash-0.8.3.crate/src/random_state.rs:115:13
    |
115 |         use once_cell::race::OnceBox;
    |             ^^^^^^^^^ use of undeclared crate or module `once_cell`


error: aborting due to previous error


For more information about this error, try `rustc --explain E0433`.

Build ID: 814134a8-9a8f-4ef1-ab66-a347a26f3d40
Network: Up: 0B  Down: 0B
Jobs completed: 3. Time elapsed: 0.1s.
Cache hits: 0%. Commands: 1 (cached: 0, remote: 0, local: 1)
BUILD FAILED
Failed to build 'root//third-party:ahash-0.8.3 (platforms//:wasm32#3295263a5955aa9b)'
```

But with the additional platform templates

```
buck2 build --target-platforms platforms//:wasm32 //third-party:ahash                                                                                                                                        3 ↵
File changed: prelude//rust/cargo_package.bzl
Build ID: 616896ed-7294-4631-8f25-e543e7c8700b
Network: Up: 0B  Down: 0B
Jobs completed: 11. Time elapsed: 0.2s.
Cache hits: 0%. Commands: 1 (cached: 0, remote: 0, local: 1)
BUILD SUCCEEDED
```