### PR TITLE
: workaround macos aarch64 homebrew lib issues

### DIFF
--- a/examples/with_prelude/ocaml/embed/BUCK
+++ b/examples/with_prelude/ocaml/embed/BUCK
@@ -10,6 +10,7 @@ ocaml_object(
 cxx_binary(
     name = "fib-cpp",
     srcs = ["fib.cpp"],
+    linker_flags = ["-L/opt/homebrew/lib"] if host_info().os.is_macos else [],
     deps = [
         ":fib-ml",
         "//third-party/ocaml:ocaml-dev",
@@ -22,6 +23,7 @@ rust_binary(
     srcs = ["fib.rs"],
     crate_root = "fib.rs",
     link_style = "static",
+    linker_flags = ["-L/opt/homebrew/lib"] if host_info().os.is_macos else [],
     deps = [":fib-ml"],
 ) if not host_info().os.is_windows else None
 


### PR DESCRIPTION
Summary: ocaml embed examples have been [failing in circleci](https://app.circleci.com/pipelines/github/facebook/buck2/12405/workflows/10b422e0-56a3-4166-9062-c581e177f768/jobs/31388 ). this is a provisional fix while i work out if/how it can be done better.

Differential Revision: D49823879


