### PR TITLE
: simply opam setup to just one link

### DIFF
--- a/examples/with_prelude/README.md
+++ b/examples/with_prelude/README.md
@@ -17,7 +17,7 @@ Now all targets aside from OCaml related ones are ready to be built.
 
 The information in this section is (at this time) Linux and macOS specific.
 
-The commands in `setup.sh` assume an activated [opam](https://opam.ocaml.org/) installation. Their effect is to create symlinks in the 'third-party/opam' directory. These symlinks support building the example OCaml targets. If any of the symlinks are found to already exist, they will not be overwritten.
+The commands in `ocaml-setup.sh` assume an activated [opam](https://opam.ocaml.org/) installation. Their effect is to create a symlink in the 'third-party/opam' directory. This symlink supports building the example OCaml targets. If the symlink is found to already exist, it will not be overwritten.
 
 ## Sample commands
 

--- a/examples/with_prelude/ocaml-setup.sh
+++ b/examples/with_prelude/ocaml-setup.sh
@@ -27,21 +27,6 @@ if [ -z "$OPAM_SWITCH_PREFIX" ]; then
 fi
 set -u
 
-# Check for ocamlopt.opt.
-if ! command -v ocamlopt.opt &> /dev/null
-then
-    echo "Failed to run 'ocamlopt.opt'."
-    exit 1
-fi
-
-# Link 'third-party/ocaml/standard_library'.
-if [ ! -L third-party/ocaml/standard_library ]; then
-  (cd third-party/ocaml && ln -s "$(ocamlopt.opt -config | grep standard_library: | awk '{ print $2 }' )" standard_library)
-else
-    echo "Link 'third-party/ocaml/standard_library' exists. To overwrite it, first remove it and run $0 again"
-    exit 2
-fi
-
 # Link 'third-party/ocaml/opam'.
 if [ ! -L third-party/ocaml/opam ]; then
   (cd third-party/ocaml && ln -s "$OPAM_SWITCH_PREFIX" opam)

--- a/examples/with_prelude/third-party/ocaml/BUCK
+++ b/examples/with_prelude/third-party/ocaml/BUCK
@@ -1,7 +1,7 @@
 # buildifier: disable=no-effect
 prebuilt_cxx_library(
     name = "ocaml-dev",
-    header_dirs = ["standard_library"],
+    header_dirs = ["opam/lib/ocaml"],
     header_only = True,
     visibility = ["PUBLIC"],
 ) if not host_info().os.is_windows else None
@@ -27,9 +27,9 @@ prebuilt_ocaml_library(
 # buildifier: disable=no-effect
 prebuilt_ocaml_library(
     name = "ocaml.compiler-libs.common",
-    bytecode_lib = "standard_library/compiler-libs/ocamlcommon.cma",
-    include_dir = "standard_library/compiler-libs",
-    native_lib = "standard_library/compiler-libs/ocamlcommon.cmxa",
+    bytecode_lib = "opam/lib/ocaml/compiler-libs/ocamlcommon.cma",
+    include_dir = "opam/lib/ocaml/compiler-libs",
+    native_lib = "opam/lib/ocaml/compiler-libs/ocamlcommon.cmxa",
     visibility = ["PUBLIC"],
     deps = [],
 ) if not host_info().os.is_windows else None


### PR DESCRIPTION
Summary: i convinced myself that creating a link to the ocaml standard library directory as extracted from `ocamlopt.opt -config` was necessary and that we can't just assume `$OPAM_SWITCH/lib/ocaml` but have failed to prove that to myself today. together with ocaml-scripts issue [#2](https://github.com/facebook/ocaml-scripts/issues/2) and similar past questions from vsiles i'm motivated to attempt to remove it so that we create but one link into .opam.

Differential Revision: D50082445


