### PR TITLE
Limit the number of simultaneous http requests

### DIFF
--- a/app/buck2_execute/src/materialize/http.rs
+++ b/app/buck2_execute/src/materialize/http.rs
@@ -112,6 +112,7 @@ impl AsHttpError for HttpDownloadError {
 }
 
 pub async fn http_head(client: &HttpClient, url: &str) -> anyhow::Result<Response<()>> {
+    client.permit().await;
     let response = http_retry(
         || async {
             client
@@ -134,6 +135,7 @@ pub async fn http_download(
     checksum: &Checksum,
     executable: bool,
 ) -> anyhow::Result<TrackedFileDigest> {
+    client.permit().await;
     let abs_path = fs.resolve(path);
     if let Some(dir) = abs_path.parent() {
         fs_util::create_dir_all(fs.resolve(dir))?;

--- a/app/buck2_http/src/client/builder.rs
+++ b/app/buck2_http/src/client/builder.rs
@@ -24,6 +24,7 @@ use hyper_timeout::TimeoutConnector;
 use rustls::ClientConfig;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
+use tokio::sync::Semaphore;
 use tokio_rustls::TlsConnector;
 
 use super::HttpClient;
@@ -264,6 +265,7 @@ impl HttpClientBuilder {
     pub fn build(&self) -> HttpClient {
         HttpClient {
             inner: self.build_inner(),
+            limit: Arc::new(Semaphore::new(10)),
             max_redirects: self.max_redirects,
             supports_vpnless: self.supports_vpnless,
             stats: HttpNetworkStats::new(),


### PR DESCRIPTION
Summary:
Don't like where this is. Hoping it is sufficient to fix the CI, and if it is, can refine. See https://app.circleci.com/pipelines/github/facebook/buck2/12793/workflows/d26eba5f-4c61-48a1-bd67-9b24da170515/jobs/32248 which says:

```
Action failed: shim//third-party/rust:chrono-0.4.31.crate (download_file archive.tar.gz)
Internal error: create_file(/Users/distiller/project/buck-out/v2/gen/shim/213ed1b7ab869379/third-party/rust/__chrono-0.4.31.crate__/archive.tar.gz): Too many open files (os error 24)
```

Differential Revision: D50300838


