### PR TITLE
Remove unnecessary unstable feature `named-profiles`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ['named-profiles']
-
 [workspace]
 resolver = "2"
 members = [


### PR DESCRIPTION
As of Oct 16 2023, the version of rust in use is `nightly-2023-07-10`. `named-profiles` has been stabilized in 1.57, which predates the toolchain in use.

I assume that we don't need this anymore.