### PR TITLE
: increase open file limit on macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,12 @@ commands:
           name: Install Rustup
           command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run:
+          name: Increase open file descriptor limit
+          command: |
+            # Avoid "too many open files" error.
+            echo 'sudo launchctl limit maxfiles 9000000 9999999' >> "$BASH_ENV"
+            echo 'ulimit -Sn 9000000' >> "$BASH_ENV"
+      - run:
           name: Brew install
           command: |
             brew install cmake coreutils opam llvm protobuf zstd
@@ -189,7 +195,7 @@ jobs:
     description: |
       Build all with cargo for macOS
     macos:
-      xcode: "14.2.0"
+      xcode: "14.2.0" # macOS version 12.6 (see https://circleci.com/docs/using-macos/)
     resource_class: macos.m1.medium.gen1
     steps:
       - checkout


### PR DESCRIPTION
Summary:
[recent CI builds](https://app.circleci.com/pipelines/github/facebook/buck2/12852/workflows/21353e0d-b872-41d6-8360-074ffd56ac37/jobs/32397) have been failing on macOS building buck2 with buck2 with message "Too many open files (os error 24)".

this diff  attempts to increase the limit on the maximum number of open file descriptors.

Differential Revision: D50345243


