### PR TITLE
Add additional zig releases to zig toolchain

### DIFF
--- a/examples/toolchains/cxx_zig_toolchain/toolchains/BUCK
+++ b/examples/toolchains/cxx_zig_toolchain/toolchains/BUCK
@@ -3,7 +3,7 @@ load("@prelude//toolchains/cxx/zig:defs.bzl", "cxx_zig_toolchain", "download_zig
 
 download_zig_distribution(
     name = "zig",
-    version = "0.9.1",
+    version = "0.11.0",
 )
 
 cxx_zig_toolchain(

--- a/prelude/toolchains/cxx/zig/releases.bzl
+++ b/prelude/toolchains/cxx/zig/releases.bzl
@@ -595,45 +595,283 @@ releases = {
             "tarball": "https://ziglang.org/download/0.9.1/zig-windows-x86_64-0.9.1.zip",
         },
     },
-    "master": {
-        "aarch64-linux": {
-            "shasum": "a90b52a968b9176ab7c2d8fb1b7b84f0e7503dc03d7791d7c5286f1ed9ad5eed",
-            "size": "38035988",
-            "tarball": "https://ziglang.org/builds/zig-linux-aarch64-0.10.0-dev.4247+3234e8de3.tar.xz",
-        },
-        "aarch64-macos": {
-            "shasum": "d435855e9b62a6aee78e4d707debf137ac3e85a9662ffa47267be56149333f06",
-            "size": "40986992",
-            "tarball": "https://ziglang.org/builds/zig-macos-aarch64-0.10.0-dev.4247+3234e8de3.tar.xz",
-        },
-        "date": "2022-10-05",
-        "docs": "https://ziglang.org/documentation/master/",
+    "0.10.0": {
+        "date": "2022-10-31",
+        "docs": "https://ziglang.org/documentation/0.10.0/",
+        "stdDocs": "https://ziglang.org/documentation/0.10.0/std/",
+        "notes": "https://ziglang.org/download/0.10.0/release-notes.html",
         "src": {
-            "shasum": "1fe9fb34ef15d433bd1496782d1a645e3a2122455d6aad0294502ae2f416c7e4",
-            "size": "15824808",
-            "tarball": "https://ziglang.org/builds/zig-0.10.0-dev.4247+3234e8de3.tar.xz",
+            "tarball": "https://ziglang.org/download/0.10.0/zig-0.10.0.tar.xz",
+            "shasum": "d8409f7aafc624770dcd050c8fa7e62578be8e6a10956bca3c86e8531c64c136",
+            "size": "14530912"
         },
-        "stdDocs": "https://ziglang.org/documentation/master/std/",
-        "version": "0.10.0-dev.4247+3234e8de3",
+        "bootstrap": {
+            "tarball": "https://ziglang.org/download/0.10.0/zig-bootstrap-0.10.0.tar.xz",
+            "shasum": "c13dc70c4ff4c09f749adc0d473cbd3942991dd4d1bd2d860fbf257d8c1bbabf",
+            "size": "45625516"
+        },
         "x86_64-freebsd": {
-            "shasum": "2555d683f7c8ba903c55c218f64963783f769736b6d6a5a8382e575df82234b5",
-            "size": "40954156",
-            "tarball": "https://ziglang.org/builds/zig-freebsd-x86_64-0.10.0-dev.4247+3234e8de3.tar.xz",
+            "tarball": "https://ziglang.org/download/0.10.0/zig-freebsd-x86_64-0.10.0.tar.xz",
+            "shasum": "dd77afa2a8676afbf39f7d6068eda81b0723afd728642adaac43cb2106253d65",
+            "size": "44056504"
+        },
+        "aarch64-linux": {
+            "tarball": "https://ziglang.org/download/0.10.0/zig-linux-aarch64-0.10.0.tar.xz",
+            "shasum": "09ef50c8be73380799804169197820ee78760723b0430fa823f56ed42b06ea0f",
+            "size": "40387688"
+        },
+        "armv7a-linux": {
+            "tarball": "https://ziglang.org/download/0.10.0/zig-linux-armv7a-0.10.0.tar.xz",
+            "shasum": "7201b2e89cd7cc2dde95d39485fd7d5641ba67dc6a9a58c036cb4c308d2e82de",
+            "size": "50805936"
+        },
+        "i386-linux": {
+            "tarball": "https://ziglang.org/download/0.10.0/zig-linux-i386-0.10.0.tar.xz",
+            "shasum": "dac8134f1328c50269f3e50b334298ec7916cb3b0ef76927703ddd1c96fd0115",
+            "size": "48451732"
+        },
+        "riscv64-linux": {
+            "tarball": "https://ziglang.org/download/0.10.0/zig-linux-riscv64-0.10.0.tar.xz",
+            "shasum": "2a126f3401a7a7efc4b454f0a85c133db1af5a9dfee117f172213b7cbd47bfba",
+            "size": "42272968"
         },
         "x86_64-linux": {
-            "shasum": "5ce6b50eae7a787b7e6e002e3b14cb8a149359df1941cf701e99ded365c9895e",
-            "size": "44178932",
-            "tarball": "https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.4247+3234e8de3.tar.xz",
+            "tarball": "https://ziglang.org/download/0.10.0/zig-linux-x86_64-0.10.0.tar.xz",
+            "shasum": "631ec7bcb649cd6795abe40df044d2473b59b44e10be689c15632a0458ddea55",
+            "size": "44142400"
+        },
+        "aarch64-macos": {
+            "tarball": "https://ziglang.org/download/0.10.0/zig-macos-aarch64-0.10.0.tar.xz",
+            "shasum": "02f7a7839b6a1e127eeae22ea72c87603fb7298c58bc35822a951479d53c7557",
+            "size": "40602664"
         },
         "x86_64-macos": {
-            "shasum": "81d7a9615b00bce617602fd40fe4e0b3bb962ff0bb4595cf78be067385bce135",
-            "size": "44180748",
-            "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.10.0-dev.4247+3234e8de3.tar.xz",
+            "tarball": "https://ziglang.org/download/0.10.0/zig-macos-x86_64-0.10.0.tar.xz",
+            "shasum": "3a22cb6c4749884156a94ea9b60f3a28cf4e098a69f08c18fbca81c733ebfeda",
+            "size": "45175104"
         },
         "x86_64-windows": {
-            "shasum": "555ac169c7e35f1dd98ea86bc514e80f7527b242c22d44a34a166c80d4441ceb",
-            "size": "69140534",
-            "tarball": "https://ziglang.org/builds/zig-windows-x86_64-0.10.0-dev.4247+3234e8de3.zip",
+            "tarball": "https://ziglang.org/download/0.10.0/zig-windows-x86_64-0.10.0.zip",
+            "shasum": "a66e2ff555c6e48781de1bcb0662ef28ee4b88af3af2a577f7b1950e430897ee",
+            "size": "73181558"
         },
+        "aarch64-windows": {
+            "tarball": "https://ziglang.org/download/0.10.0/zig-windows-aarch64-0.10.0.zip",
+            "shasum": "1bbda8d123d44f3ae4fa90d0da04b1e9093c3f9ddae3429a4abece1e1c0bf19a",
+            "size": "69332389"
+        }
     },
+    "0.10.1": {
+        "date": "2023-01-19",
+        "docs": "https://ziglang.org/documentation/0.10.1/",
+        "stdDocs": "https://ziglang.org/documentation/0.10.1/std/",
+        "notes": "https://ziglang.org/download/0.10.1/release-notes.html",
+        "src": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-0.10.1.tar.xz",
+            "shasum": "69459bc804333df077d441ef052ffa143d53012b655a51f04cfef1414c04168c",
+            "size": "15143112"
+        },
+        "bootstrap": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-bootstrap-0.10.1.tar.xz",
+            "shasum": "9f5781210b9be8f832553d160851635780f9bd71816065351ab29cfd8968f5e9",
+            "size": "43971816"
+        },
+        "x86_64-macos": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-macos-x86_64-0.10.1.tar.xz",
+            "shasum": "02483550b89d2a3070c2ed003357fd6e6a3059707b8ee3fbc0c67f83ca898437",
+            "size": "45119596"
+        },
+        "aarch64-macos": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-macos-aarch64-0.10.1.tar.xz",
+            "shasum": "b9b00477ec5fa1f1b89f35a7d2a58688e019910ab80a65eac2a7417162737656",
+            "size": "40517896"
+        },
+        "x86_64-linux": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-linux-x86_64-0.10.1.tar.xz",
+            "shasum": "6699f0e7293081b42428f32c9d9c983854094bd15fee5489f12c4cf4518cc380",
+            "size": "44085596"
+        },
+        "aarch64-linux": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-linux-aarch64-0.10.1.tar.xz",
+            "shasum": "db0761664f5f22aa5bbd7442a1617dd696c076d5717ddefcc9d8b95278f71f5d",
+            "size": "40321280"
+        },
+        "riscv64-linux": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-linux-riscv64-0.10.1.tar.xz",
+            "shasum": "9db5b59a5112b8beb995094ba800e88b0060e9cf7cfadf4dc3e666c9010dc77b",
+            "size": "42196008"
+        },
+        "i386-linux": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-linux-i386-0.10.1.tar.xz",
+            "shasum": "8c710ca5966b127b0ee3efba7310601ee57aab3dd6052a082ebc446c5efb2316",
+            "size": "48367388"
+        },
+        "x86_64-windows": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-windows-x86_64-0.10.1.zip",
+            "shasum": "5768004e5e274c7969c3892e891596e51c5df2b422d798865471e05049988125",
+            "size": "73259729"
+        },
+        "aarch64-windows": {
+            "tarball": "https://ziglang.org/download/0.10.1/zig-windows-aarch64-0.10.1.zip",
+            "shasum": "ece93b0d77b2ab03c40db99ef7ccbc63e0b6bd658af12b97898960f621305428",
+            "size": "69417459"
+        }
+    },
+    "0.11.0": {
+        "date": "2023-08-04",
+        "docs": "https://ziglang.org/documentation/0.11.0/",
+        "stdDocs": "https://ziglang.org/documentation/0.11.0/std/",
+        "notes": "https://ziglang.org/download/0.11.0/release-notes.html",
+        "src": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-0.11.0.tar.xz",
+            "shasum": "72014e700e50c0d3528cef3adf80b76b26ab27730133e8202716a187a799e951",
+            "size": "15275316"
+        },
+        "bootstrap": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-bootstrap-0.11.0.tar.xz",
+            "shasum": "38dd9e17433c7ce5687c48fa0a757462cbfcbe75d9d5087d14ebbe00efd21fdc",
+            "size": "43227592"
+        },
+        "x86_64-freebsd": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-freebsd-x86_64-0.11.0.tar.xz",
+            "shasum": "ea430327f9178377b79264a1d492868dcff056cd76d43a6fb00719203749e958",
+            "size": "46432140"
+        },
+        "x86_64-macos": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-macos-x86_64-0.11.0.tar.xz",
+            "shasum": "1c1c6b9a906b42baae73656e24e108fd8444bb50b6e8fd03e9e7a3f8b5f05686",
+            "size": "47189164"
+        },
+        "aarch64-macos": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+            "shasum": "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2",
+            "size": "43855096"
+        },
+        "x86_64-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz",
+            "shasum": "2d00e789fec4f71790a6e7bf83ff91d564943c5ee843c5fd966efc474b423047",
+            "size": "44961892"
+        },
+        "aarch64-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+            "shasum": "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6",
+            "size": "41492432"
+        },
+        "armv7a-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-armv7a-0.11.0.tar.xz",
+            "shasum": "aebe8bbeca39f13f9b7304465f9aee01ab005d243836bd40f4ec808093dccc9b",
+            "size": "42240664"
+        },
+        "riscv64-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-riscv64-0.11.0.tar.xz",
+            "shasum": "24a478937eddb507e96d60bd4da00de9092b3f0920190eb45c4c99c946b00ed5",
+            "size": "43532324"
+        },
+        "powerpc64le-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-powerpc64le-0.11.0.tar.xz",
+            "shasum": "75260e87325e820a278cf9e74f130c7b3d84c0b5197afb2e3c85eff3fcedd48d",
+            "size": "44656184"
+        },
+        "powerpc-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-powerpc-0.11.0.tar.xz",
+            "shasum": "70a5f9668a66fb2a91a7c3488b15bcb568e1f9f44b95cd10075c138ad8c42864",
+            "size": "44539972"
+        },
+        "x86-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86-0.11.0.tar.xz",
+            "shasum": "7b0dc3e0e070ae0e0d2240b1892af6a1f9faac3516cae24e57f7a0e7b04662a8",
+            "size": "49824456"
+        },
+        "x86_64-windows": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86_64-0.11.0.zip",
+            "shasum": "142caa3b804d86b4752556c9b6b039b7517a08afa3af842645c7e2dcd125f652",
+            "size": "77216743"
+        },
+        "aarch64-windows": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-aarch64-0.11.0.zip",
+            "shasum": "5d4bd13db5ecb0ddc749231e00f125c1d31087d708e9ff9b45c4f4e13e48c661",
+            "size": "73883137"
+        },
+        "x86-windows": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86-0.11.0.zip",
+            "shasum": "e72b362897f28c671633e650aa05289f2e62b154efcca977094456c8dac3aefa",
+            "size": "81576961"
+        }
+    },
+    "master": {
+        "version": "0.12.0-dev.1298+da06269d7",
+        "date": "2023-10-27",
+        "docs": "https://ziglang.org/documentation/master/",
+        "stdDocs": "https://ziglang.org/documentation/master/std/",
+        "src": {
+            "tarball": "https://ziglang.org/builds/zig-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "2cb26538f672d11a5e8ec5f4ce777dfa275655eb88401cc7a959d07fe226911d",
+            "size": "15945864"
+        },
+        "bootstrap": {
+            "tarball": "https://ziglang.org/builds/zig-bootstrap-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "e69bbfe3393a39a4963c462ec1b56cea449671af55584f1eaa8be6dd14e2912f",
+            "size": "44387500"
+        },
+        "x86_64-macos": {
+            "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "8d27c61c36454ecffe56ae00055f8354289464c1ea507182cccab585ad31d115",
+            "size": "49203308"
+        },
+        "aarch64-macos": {
+            "tarball": "https://ziglang.org/builds/zig-macos-aarch64-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "5edd4f9e88eb6864f1818ecf81d2d489cb10845a4e84e6ebcee06566b205e769",
+            "size": "45715512"
+        },
+        "x86_64-linux": {
+            "tarball": "https://ziglang.org/builds/zig-linux-x86_64-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "3607099807dca909935fb9249c16f4bfed6e58872ec1a7fc1eb65776d6d32111",
+            "size": "46985312"
+        },
+        "aarch64-linux": {
+            "tarball": "https://ziglang.org/builds/zig-linux-aarch64-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "0f1cd21441d69d1379e9bb3c76e2039b10156dd7dcd920a08d0e8c998e1fdb62",
+            "size": "43357640"
+        },
+        "armv7a-linux": {
+            "tarball": "https://ziglang.org/builds/zig-linux-armv7a-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "a09495d944a31affb3bc1f9bde36e0924d54fd91d1aebba470368491d9e7451b",
+            "size": "44075000"
+        },
+        "riscv64-linux": {
+            "tarball": "https://ziglang.org/builds/zig-linux-riscv64-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "8fee2a5816ac923d7674f96c51bccf047aaa87b572fa6c285cf9f55336554cf5",
+            "size": "45362356"
+        },
+        "powerpc64le-linux": {
+            "tarball": "https://ziglang.org/builds/zig-linux-powerpc64le-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "703e302cca1580c55746d5374d160a936261243c5b0ae9712fa7faa6722554da",
+            "size": "46675648"
+        },
+        "powerpc-linux": {
+            "tarball": "https://ziglang.org/builds/zig-linux-powerpc-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "4f9bea964887426e5dc4ed2a17c5b283c3afbda01aa6bab1ff5789e555b8e1b0",
+            "size": "46468592"
+        },
+        "x86-linux": {
+            "tarball": "https://ziglang.org/builds/zig-linux-x86-0.12.0-dev.1298+da06269d7.tar.xz",
+            "shasum": "83feb8c5dcfc93b4d6261458d19804691595211984e2d5bda5793d98303e387f",
+            "size": "52006108"
+        },
+        "x86_64-windows": {
+            "tarball": "https://ziglang.org/builds/zig-windows-x86_64-0.12.0-dev.1298+da06269d7.zip",
+            "shasum": "057e0c412598bcedd941c5444c0439af321647be53ed274eed2a938d4699042f",
+            "size": "79585336"
+        },
+        "aarch64-windows": {
+            "tarball": "https://ziglang.org/builds/zig-windows-aarch64-0.12.0-dev.1298+da06269d7.zip",
+            "shasum": "bf3ec738e94a1db17df866590d4e6af4fce8f7150ea71fda0ce5d2656012134c",
+            "size": "76173076"
+        },
+        "x86-windows": {
+            "tarball": "https://ziglang.org/builds/zig-windows-x86-0.12.0-dev.1298+da06269d7.zip",
+            "shasum": "62dd4748a1fa794bf786a4b26496caca87f2fed43f8493920723406c0acaddb0",
+            "size": "84111935"
+        }
+    }
 }


### PR DESCRIPTION
More recent version of zig are required to compile code on modern versions of macOS (at least 13.x, and probably 14.x as well), otherwise zig seems to be unaware of the macOS version and errors out.

I tested this on Linux and it still works. It gets _further_ on macOS, but runs in to more problems with the linker even after #462. I'll file a separate issue for that once this is accepted so that the error can be reproduced on the main branch.