### PR TITLE
Fixed the example hello_world library generation.

### DIFF
--- a/examples/hello_world/BUCK
+++ b/examples/hello_world/BUCK
@@ -7,7 +7,7 @@ cxx_binary(
 
 cxx_library(
     name = "print",
-    srcs = glob(["**/*.cpp"]),
+    srcs = ["library.cpp"],
     exported_headers = glob(["**/*.hpp"]),
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
The "print" library incorrectly included the main.cpp file in its list of sources. The main.cpp file should be used only as a source for the final executable.

This resolves issue #480.
