### PR TITLE
Added example using Buck with Visual Studio Code on Windows

### DIFF
--- a/examples/visual_studio/.buckconfig
+++ b/examples/visual_studio/.buckconfig
@@ -1,0 +1,17 @@
+[repositories]
+root = .
+prelude = prelude
+toolchains = toolchains
+none = none
+
+[repository_aliases]
+config = prelude
+fbcode = none
+fbsource = none
+buck = none
+
+[parser]
+target_platform_detector_spec = target:root//...->toolchains//:default
+
+[build]
+execution_platforms = prelude//platforms:default

--- a/examples/visual_studio/.gitignore
+++ b/examples/visual_studio/.gitignore
@@ -1,0 +1,4 @@
+/buck-out
+/compile_commands.json
+/install
+/.cache

--- a/examples/visual_studio/.vscode/extensions.json
+++ b/examples/visual_studio/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["llvm-vs-code-extensions.vscode-clangd", "vadimcn.vscode-lldb"]
+}

--- a/examples/visual_studio/.vscode/launch.json
+++ b/examples/visual_studio/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug main.exe",
+            "preLaunchTask": "Build and create compilation database",
+            "program": "${workspaceFolder}/install/main.exe",
+            "cwd": "${workspaceFolder}/install"
+        }
+    ]
+}

--- a/examples/visual_studio/.vscode/settings.json
+++ b/examples/visual_studio/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "C_Cpp.intelliSenseEngine": "disabled",
+    "search.followSymlinks": false
+}

--- a/examples/visual_studio/.vscode/tasks.json
+++ b/examples/visual_studio/.vscode/tasks.json
@@ -1,0 +1,55 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build Main",
+            "type": "shell",
+            "command": "buck2",
+            "args": [
+                "build",
+                "--console",
+                "simple",
+                "--no-interactive-console",
+                "--fail-fast",
+                "--show-full-output",
+                ":main",
+                "|",
+                "powershell",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "buck2_utils/install.ps1",
+                "install"
+            ]
+        },
+        {
+            "label": "Create compilation database",
+            "type": "shell",
+            "command": "buck2",
+            "args": [
+                "bxl",
+                "buck2_utils/create_compile_commands.bxl:gen_compilation_database",
+                "--",
+                "--directory",
+                "${workspaceFolder}",
+                "|",
+                "powershell",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "buck2_utils/copy.ps1"
+            ]
+        },
+        {
+            "label": "Build and create compilation database",
+            "dependsOn": [
+                "Create compilation database",
+                "Build Main"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/examples/visual_studio/BUCK
+++ b/examples/visual_studio/BUCK
@@ -1,0 +1,15 @@
+cxx_binary(
+    name = "main",
+    srcs = ["main.c"],
+    link_style = "shared",
+    deps = [":print"],
+    resources = [":print[shared]"]
+)
+
+cxx_library(
+    name = "print",
+    srcs = ["library.cpp"],
+    exported_headers = glob(["**/*.hpp"]),
+    preprocessor_flags = ["-DLIBRARY_EXPORT"],
+    visibility = ["PUBLIC"],
+)

--- a/examples/visual_studio/README.md
+++ b/examples/visual_studio/README.md
@@ -1,0 +1,8 @@
+## An example showing how Buck2 can be used in Visual Studio Code on Windows
+
+After completing the setup, below, click F5 to run with the debugger attached. You can also use Ctrl + Shift + B to build. By default it compiles with the "debug" configuration. To compile in release pass "-c release" to Buck2's build command.
+
+## Setup
+
+Run `buck2 init --git`.
+Open this folder in Visual Studio Code and install the recommended extensions.

--- a/examples/visual_studio/buck2_utils/configuration/BUCK
+++ b/examples/visual_studio/buck2_utils/configuration/BUCK
@@ -1,0 +1,16 @@
+constraint_setting(
+    name = "configuration",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "debug",
+    constraint_setting = ":configuration",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "release",
+    constraint_setting = ":configuration",
+    visibility = ["PUBLIC"],
+)

--- a/examples/visual_studio/buck2_utils/copy.ps1
+++ b/examples/visual_studio/buck2_utils/copy.ps1
@@ -1,0 +1,5 @@
+param(
+  [parameter(Mandatory=$true)] [String] $FilePath
+)
+
+New-Item -ItemType HardLink -Force -Path compile_commands.json -Target $FilePath.Trim() | Out-Null

--- a/examples/visual_studio/buck2_utils/create_compile_commands.bxl
+++ b/examples/visual_studio/buck2_utils/create_compile_commands.bxl
@@ -1,0 +1,133 @@
+load("@prelude//:paths.bzl", "paths")
+
+def group_by_category(actions):
+    groups = {}
+    for a in actions:
+        category = a.attrs.category.value()
+        if category in groups:
+            groups[category].append(a)
+        else:
+            groups[category] = [a]
+    return groups
+
+def create_compilation_database_entry(directory, buildfile_folder, argsfiles, action):
+    # the "cmd" attribute looks like a list.  For example, it might be something like:
+    #   cmd = [cl.exe, -c, foo.cpp]
+    # but in reality this is quite literally the string "[cl.exe, -c, foo.cpp]".  We need
+    # it as an actual list, so we have to employ this unfortunate hack of stripping the brackets,
+    # splitting on comma operator, and then stripping spaces from each entry to make an actual
+    # list.  Hopefully this doesn't fail in any weird edge cases, but it seems to be the best we
+    # can do until buck2 upstream actually stores a Starlark list as the value of this attribute.
+    cmd = action.attrs.cmd.value()
+    cmd = cmd.strip("[]").split(',')
+    cmd = list(map(lambda x: x.strip(), cmd))
+
+    compiler = cmd[0].replace(".bat", ".exe")
+
+    # Find the argsfile.  On Windows it might contain backslashes, so convert those to forward
+    # slashes.  Hopefully we don't have any filenames with actual backslashes in them.  Then
+    # strip off the directory name so we just have the filename of the argsfile.
+    argsfile = filter(lambda x: x.startswith("@"), cmd)[0][1:]
+    identifier = paths.basename(argsfile.replace("\\", "/"))
+
+    # Get the path of the source file relative to the project root by appending the identifier
+    # to the directory of the BUCK file.
+    project_rel_path = paths.join(buildfile_folder, action.attrs.identifier.value())
+
+    # Using the previously computed list of argfiles referenced by this target, find the one
+    # that this particular action references.
+    arguments = []
+    if identifier in argsfiles:
+        arguments = argsfiles[identifier]
+
+    # Now build the compilation database entry
+    entry = {
+        "file": project_rel_path,
+        "directory": directory,
+        "arguments": [compiler] + arguments
+    }
+    return entry
+
+def gen_compilation_database_impl(ctx):
+    # Generate compilation database for all targets unless user requests a more narrow set
+    target_filter = ctx.cli_args.targets or '...'
+    targets = ctx.configured_targets(target_filter, target_platform=ctx.cli_args.platform)
+    aquery = ctx.aquery()
+
+    entries = {}
+    for target in targets:
+        target_actions = list(aquery.all_actions(target.label))
+
+        # The individual compilation actions only identify the source files relative to where
+        # the BUCK file is.  So to build a path relative to the root of the project, we need
+        # to get the BUCK file path and append the source file path to it.
+        buildfile_path = ctx.fs.project_rel_path(target.buildfile_path)
+        buildfile_folder = paths.dirname(buildfile_path)
+
+        # In order to generate a compilation database entry for a file, we need this target
+        # to satisfy two conditions:
+        #    1. It has compilations
+        #    2. It writes an argsfile.
+        #
+        # The second requirement is necessary because the argsfile is where buck2 includes
+        # important command line arguments such as preprocessor definitions and include
+        # paths.  If both conditions are not satisfied, we should skip this target because
+        # either it doesn't have source files anyway, or we don't understand how to write
+        # compilation database entries for them.
+        actions_by_category = group_by_category(target_actions)
+
+        if not "write" in actions_by_category:
+            continue
+        if not "cxx_compile" in actions_by_category:
+            continue
+
+        argsfiles = {}
+
+        # There are lots of kinds of "write" actions, but we are interested specifically in argsfile
+        # write actions.  This is because the source file compilation actions will reference them,
+        # so for each source file we need to map it back to the argsfile that its command line references
+        # so we can write those arguments to the compilation database entry.  Build this mapping here.
+        for write_action in actions_by_category["write"]:
+            identifier = write_action.attrs.identifier.value()
+            if identifier.endswith(".argsfile"):
+                # The content of the argsfile is a newline separated list.  We need a Starlark list.  So
+                # split on newline.
+                arguments = write_action.attrs.contents.value()
+                arguments = arguments.split("\n")
+
+                # For whatever reason, there are a lot of unnecessary quotes and double slashes.  Probably
+                # something to do with the nature of the tools requiring shell-escaped values.  Since we're
+                # storing this in a JSON array and the tool that processes the compilation database does its
+                # own escaping of these values, we can undo all of this.  Convert double backslash to
+                # single forward slash, and remove quotes at the beginning and end of entries.
+                arguments = list(map(lambda x: x.strip('"').replace("\\\\", "/"), arguments))
+                argsfiles[identifier] = arguments
+
+        # Now walk each compilation action and generate a compilation database entry for it.
+        for action in actions_by_category["cxx_compile"]:
+            entry = create_compilation_database_entry(ctx.cli_args.directory, buildfile_folder, argsfiles, action)
+            is_pic = entry["file"].endswith(" (pic)")
+            file_name = entry["file"].removesuffix(" (pic)")
+            entry["file"] = file_name
+            entry["is_pic"] = is_pic
+            existing_entry = entries.get(file_name)
+            if existing_entry == None or existing_entry["is_pic"]:
+                entries[file_name] = entry
+
+    for entry in entries.values():
+        entry.pop("is_pic")
+
+    actions = ctx.bxl_actions(target_platform = ctx.cli_args.platform).actions
+    db_artifact = actions.write_json("compile_commands.json", entries.values())
+    db_artifact_ensured = ctx.output.ensure(db_artifact)
+
+    ctx.output.print(db_artifact_ensured)
+
+gen_compilation_database = bxl_main(
+    impl = gen_compilation_database_impl,
+    cli_args = {
+        "directory": cli_args.string(),
+        "targets": cli_args.option(cli_args.target_expr()),
+        "platform": cli_args.option(cli_args.target_label())
+    }
+)

--- a/examples/visual_studio/buck2_utils/install.ps1
+++ b/examples/visual_studio/buck2_utils/install.ps1
@@ -1,0 +1,69 @@
+param(
+	[parameter(Mandatory=$true)] [String] $InstallDirectory,
+	[parameter(Mandatory=$true,ValueFromPipeline=$true)] [String] $Buck2Output
+)
+
+begin
+{
+	$ErrorActionPreference = "Stop"
+
+	function Copy-Directory
+	{
+		param(
+			[parameter(Mandatory=$true)] [String] $SourcePath,
+			[parameter(Mandatory=$true)] [String] $TargetPath
+		)
+		robocopy /MIR "$SourcePath" "$TargetPath" | Out-Null
+	}
+
+	function Copy-File
+	{
+		param(
+			[parameter(Mandatory=$true)] [String] $SourcePath,
+			[parameter(Mandatory=$true)] [String] $TargetPath
+		)
+		Copy-Item $SourcePath -Destination $TargetPath
+	}
+}
+process
+{
+	$OutputSplit = $input.Split(" ")
+	$TargetPath = $OutputSplit[0].Trim()
+	$ExecutablePath = $OutputSplit[1].Trim()
+	$ResourcesPath = $ExecutablePath + ".resources.json"
+
+	$CopySource = $ExecutablePath
+	$CopyTarget = Join-Path -Path $InstallDirectory -ChildPath (Split-Path -Leaf $ExecutablePath)
+	Copy-File $CopySource $CopyTarget
+
+	try
+	{
+		$ResourcesContent = Get-Content $ResourcesPath -ErrorAction Stop | ConvertFrom-Json
+		$HasResources = $true
+	}
+	catch [System.Management.Automation.ItemNotFoundException]
+	{
+		$ResourcesContent = @()
+		$HasResources = $false
+	}
+	if($HasResources)
+	{
+		foreach($ResourceProperty in $ResourcesContent.PSObject.Properties)
+		{
+			$ResourceTargetPath = $ResourceProperty.Name
+			$ResourceSourcePath = $ResourceProperty.Value
+			$CopySource = Join-Path -Path (Split-Path -Parent $ExecutablePath) -ChildPath $ResourceSourcePath
+			$CopyTarget = Join-Path -Path $InstallDirectory -ChildPath $ResourceTargetPath
+
+			$GetItemResult = Get-Item $CopySource
+			if($GetItemResult.PSIsContainer)
+			{
+				Copy-Directory $CopySource $CopyTarget
+			}
+			else
+			{
+				Copy-File $CopySource $CopyTarget
+			}
+		}
+	}
+}

--- a/examples/visual_studio/library.cpp
+++ b/examples/visual_studio/library.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+#include "library.hpp"
+
+#include <iostream>
+
+void print_hello() {
+  std::cout << "Hello from a C++ Buck2 program!" << std::endl;
+}

--- a/examples/visual_studio/library.hpp
+++ b/examples/visual_studio/library.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+#ifdef _WIN32
+#ifdef LIBRARY_EXPORT
+#define DLL_API __declspec(dllexport)
+#else
+#define DLL_API __declspec(dllimport)
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+DLL_API void print_hello();
+#ifdef __cplusplus
+}
+#endif

--- a/examples/visual_studio/main.c
+++ b/examples/visual_studio/main.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+#include "library.hpp"
+
+int main() {
+  print_hello();
+}

--- a/examples/visual_studio/toolchains/BUCK
+++ b/examples/visual_studio/toolchains/BUCK
@@ -1,0 +1,56 @@
+load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
+
+system_cxx_toolchain(
+    name = "cxx",
+    visibility = ["PUBLIC"],
+    link_style = "static",
+    #The flags in the below attributes' Windows config are copied from Visual Studio's project "Console App", with some changes listed in each attribute
+    c_flags = select({
+        #Copied from the C++ flags
+        "config//os:windows": ["/c", "/Z7", "/nologo", "/W3", "/WX-", "/diagnostics:column", "/sdl", "/D_CONSOLE", "/D_UNICODE", "/DUNICODE", "/EHsc", "/Zc:forScope", "/Zc:inline", "/permissive-", "/TC"] + select({
+            "root//buck2_utils/configuration:debug": ["/Od", "/D_DEBUG", "/RTC1", "/MDd"],
+            "root//buck2_utils/configuration:release": ["/O2", "/Oi", "/GL", "/DNDEBUG", "/MD", "/Gy"],
+        }),
+        "config//os:linux": [],
+    }),
+    cxx_flags = select({
+        #Added C++ 20 version flag
+        #Removed flags that are already the default: /GS, /fp:precise /Gd /Zc:wchar_t /Gm-
+        #Removed deprecated /errorReport:prompt
+        #Converted /ZI to /Z7 because I'm guessing /ZI won't play very well with remote execution
+        #Removed /FC because it probably doesn't work with remote execution
+        #Removed /external:W3 because it's redundant
+        #Removed /JMC because it doesn't work with lldb
+        "config//os:windows": ["/std:c++20", "/c", "/Z7", "/nologo", "/W3", "/WX-", "/diagnostics:column", "/sdl", "/D_CONSOLE", "/D_UNICODE", "/DUNICODE", "/EHsc", "/Zc:forScope", "/Zc:inline", "/permissive-", "/TP"] + select({
+            "root//buck2_utils/configuration:debug": ["/Od", "/D_DEBUG", "/RTC1", "/MDd"],
+            "root//buck2_utils/configuration:release": ["/O2", "/Oi", "/GL", "/DNDEBUG", "/MD", "/Gy"],
+        }),
+        "config//os:linux": ["-std=c++20"],
+    }),
+    link_flags = select({
+        #Removed flags that are already the default: /TLBID:1 /DYNAMICBASE /NXCOMPAT /ERRORREPORT:PROMPT /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /SUBSYSTEM:CONSOLE
+        #Removed /manifest:embed because I don't know what it does
+        #Removed default extra libs that are unnecessary most of the time: kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib
+        #Added /INCREMENTAL:NO to force non-incremental mode
+        "config//os:windows": ["/NOLOGO", "/DEBUG", "/INCREMENTAL:NO"] + select({
+            "root//buck2_utils/configuration:debug": [],
+            #Converted /LTCG:incremental to /LTCG because I'm guessing incremental actions won't work well with Buck2
+            "root//buck2_utils/configuration:release": ["/OPT:REF", "/OPT:ICF", "/LTCG"],
+        }),
+        "config//os:linux": [],
+    }),
+)
+
+system_python_bootstrap_toolchain(
+    name = "python_bootstrap",
+    visibility = ["PUBLIC"],
+)
+
+configuration = read_config("cxx", "configuration", "debug")
+
+platform(
+    name = "default",
+    deps = ["prelude//platforms:default"],
+    constraint_values = ["root//buck2_utils/configuration:release"] if configuration == "release" else ["root//buck2_utils/configuration:debug"],
+)

--- a/prelude/platforms/BUCK.v2
+++ b/prelude/platforms/BUCK.v2
@@ -9,6 +9,7 @@ execution_platform(
     cpu_configuration = host_configuration.cpu,
     os_configuration = host_configuration.os,
     use_windows_path_separators = host_info().os.is_windows,
+    visibility = ["PUBLIC"],
 )
 
 prelude.constraint_setting(

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -67,7 +67,6 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
         shared_library_name_default_prefix = ""
         shared_library_name_format = "{}.dll"
         shared_library_versioned_name_format = "{}.dll"
-        additional_linker_flags = ["msvcrt.lib"]
         pic_behavior = PicBehavior("not_supported")
     elif ctx.attrs.linker == "g++" or ctx.attrs.cxx_compiler == "g++":
         pass


### PR DESCRIPTION
1. I made the default platform in the prelude public so it can be inherited from. I don't know why it wasn't already like that. Maybe I'm misunderstanding how to use it
2. Not sure if I'm using the config_setting and constraint_setting properly since it seems duplicated.
3. The script to generate the compile_commands.json was more or less copied from #510.

There are still a lot of improvements to be made but I think this is good enough to be merged:
1. With MSVC the compilation should probably be done with /Z7 by default and then, if the "stripped" sub-target is asked for, that flag is removed.
2. The cxx toolchain needs the compilation options looked at, not sure if Linux's defaults work properly.
3. The Install.ps1 and Copy.ps1 need to be ported to Linux.