### PR TITLE
Fix attrs.list(attrs.one_of(attrs.source(), xxx)))

### DIFF
--- a/app/buck2_analysis/src/attrs/resolve/configured_attr.rs
+++ b/app/buck2_analysis/src/attrs/resolve/configured_attr.rs
@@ -110,7 +110,7 @@ impl ConfiguredAttrExt for ConfiguredAttr {
             ConfiguredAttr::Tuple(list) => {
                 let mut values = Vec::with_capacity(list.len());
                 for v in list.iter() {
-                    values.append(&mut v.resolve(pkg.dupe(), ctx)?);
+                    values.push(v.resolve_single(pkg.dupe(), ctx)?);
                 }
                 Ok(ctx.heap().alloc(AllocTuple(values)))
             }

--- a/app/buck2_analysis/src/attrs/resolve/configured_attr.rs
+++ b/app/buck2_analysis/src/attrs/resolve/configured_attr.rs
@@ -81,6 +81,8 @@ impl ConfiguredAttrExt for ConfiguredAttr {
         match self {
             // SourceLabel is special since it is the only type that can be expand to many
             ConfiguredAttr::SourceLabel(src) => SourceAttrType::resolve_label(ctx, src),
+            // OneOf could contain a SourceLabel
+            ConfiguredAttr::OneOf(box l, _) => l.resolve(pkg, ctx),
             _ => Ok(vec![self.resolve_single(pkg, ctx)?]),
         }
     }


### PR DESCRIPTION
In #520, I was wondering why you couldn't pass a label with multiple `default_outputs` to `cxx_library`. This is why:

https://github.com/facebook/buck2/blob/c7637e656536d9e5a4cdeb2f6c801e71c40c0df6/prelude/decls/cxx_common.bzl#L17


The srcs attr was exercising this code here, and hitting the error "Expected a single artifact".

Note that this will not help with `attrs.tuple(attrs.source(), xxx)`. That still has weird behaviour. For the [example](https://github.com/facebook/buck2/issues/520#issuecomment-1855376386) I posted, if you use `srcs = [(":id", ["-Wall"])]` instead, you get this:

> Value `<source scratch/two.cpp>` of type `artifact` does not match the type annotation `list[resolved_macro]` for argument `flags`

You would have to add some third variant to the one_of with `attrs.tuple(attrs.list(attrs.source), ...)` to handle that case.