### PR TITLE
Fixed issues with re_grpc client

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -79,7 +79,7 @@ use crate::response::*;
 // in the Capabilities message query.
 const CONCURRENT_UPLOAD_LIMIT: usize = 64;
 
-const DEFAULT_MAX_MSG_SIZE: usize = 4 * 1000 * 1000;
+const DEFAULT_MAX_MSG_SIZE: usize = 1 << 21;
 
 fn tdigest_to(tdigest: TDigest) -> Digest {
     Digest {
@@ -913,6 +913,8 @@ where
                 digests: std::mem::take(&mut curr_digests),
                 acceptable_compressors: vec![compressor::Value::Identity as i32],
             };
+            // curr_digests would only have the current digest at the end of this iteration
+            curr_size = digest.size_bytes;
             requests.push(read_blob_req);
         }
         curr_digests.push(digest.clone());


### PR DESCRIPTION
 * Lowered the default value of DEFAULT_MAX_MSG_SIZE from 4e6 to 1<<21 it turns out buildbarn doesn't set any limit but internally has a limit of 1 << 21 and 4e6 exceeds that causing issues
 * Minor bug in batching code, we were not setting curr_size to the current digest size even when we emptied curr_digests. This would've lead to smaller than expected batches after the first batch was made