### PR TITLE
: upgrade oss examples to ocaml-5.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
       - run:
           name: Init opam
           command: |
-            opam init --compiler=5.1.0 --disable-sandboxing -y
+            opam init --compiler=5.1.1 --disable-sandboxing -y
             opam install menhir ppxlib -y
       - run:
           name: OCaml Configuration Info

--- a/examples/with_prelude/ocaml/ppx/BUCK
+++ b/examples/with_prelude/ocaml/ppx/BUCK
@@ -16,6 +16,8 @@ ocaml_binary(
     compiler_flags = [
         "-linkall",
         "-cclib",
+        "-L/opt/homebrew/lib",
+        "-cclib",
         "-lzstd",
     ],
     deps = [


### PR DESCRIPTION
Summary:
supercaml are close to getting onto 5.1.1 which is a bug-fix release of 5.1.0 ([release notes](https://ocaml.org/releases/5.1.1)).

of particular interest is the reverted standard library change that required ocamlopt generated executables risk link with `-lzstd`.

Differential Revision: D52803075


