### PR TITLE
Add build and test jobs for linux, macos, and windows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,30 @@ on:
   push:
   pull_request:
 jobs:
+  linux-build-and-test:
+    runs-on: 4-core-ubuntu
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: ./.github/actions/setup_linux_env
+    - uses: ./.github/actions/build_debug
+    - uses: ./.github/actions/run_test_py
+  macos-build-and-test:
+    runs-on: macos-latest
+    steps:
+    - uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        xcode-version: 14.2.0
+    - uses: actions/checkout@v4.1.0
+    - uses: ./.github/actions/setup_macos_env
+    - uses: ./.github/actions/build_debug
+    - uses: ./.github/actions/run_test_py
+  windows-build-and-test:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - uses: ./.github/actions/setup_windows_env
+    - uses: ./.github/actions/build_debug
+    - uses: ./.github/actions/run_test_py
   macos-build-examples:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
This pull request adds the following jobs to the github actions workflow:
```
linux-build-and-test
macos-build-and-test
windows-build-and-test
```

The `linux-build-and-test` requires a larger runner, else it will fail with the following error:

```
= note: /usr/bin/ld: final link failed: No space left on device
collect2: error: ld returned 1 exit status
```

The following runner group is needed:
- 4-core-ubuntu  (this can be renamed in the job to whatever you like)

For my testing, I have these runner groups populated with the following runners:
| Group       | Runner size                         | OS            |
|-------------|-------------------------------------|---------------|
| 4-core-ubuntu     | 4-cores · 16 GB RAM · 150 GB SSD | Ubuntu Latest |

View [the latest workflow run in my fork here](https://github.com/robandpdx-org/buck2/actions/runs/7589165213).  

https://fburl.com/workplace/f6mz6tmw  
