### PR TITLE
Improve indentation in link_execution_preference docs

### DIFF
--- a/prelude/linking/execution_preference.bzl
+++ b/prelude/linking/execution_preference.bzl
@@ -36,15 +36,17 @@ _ActionExecutionAttributes = record(
 def link_execution_preference_attr():
     # The attribute is optional, allowing for None to represent that no preference has been set and we should fallback on the toolchain.
     return attrs.option(attrs.one_of(attrs.enum(LinkExecutionPreferenceTypes), attrs.dep(providers = [LinkExecutionPreferenceDeterminatorInfo])), default = None, doc = """
-    The execution preference for linking. Options are:\n
+    The execution preference for linking.
+
+      Options are:
         - any : No preference is set, and the link action will be performed based on buck2's executor configuration.\n
         - full_hybrid : The link action will execute both locally and remotely, regardless of buck2's executor configuration (if\n
-                        the executor is capable of hybrid execution). The use_limited_hybrid setting of the hybrid executor is ignored.\n
+          the executor is capable of hybrid execution). The use_limited_hybrid setting of the hybrid executor is ignored.\n
         - local : The link action will execute locally if compatible on current host platform.\n
         - local_only : The link action will execute locally, and error if the current platform is not compatible.\n
         - remote : The link action will execute remotely if a compatible remote platform exists, otherwise locally.\n
 
-    The default is None, expressing that no preference has been set on the target itself.
+      The default is None, expressing that no preference has been set on the target itself.
     """)
 
 def get_link_execution_preference(ctx, links: list[Label]) -> LinkExecutionPreference:


### PR DESCRIPTION
The doc generator doesn't handle a list item in the second line correctly, this works around the issue by splitting the first line.

Before:
![image](https://github.com/facebook/buck2/assets/347977/8507e943-284b-42ae-a149-8e8a8ab72d38)

After:
![image](https://github.com/facebook/buck2/assets/347977/b0893b97-f68c-455e-a55c-9f12ed6e237f)


Tested by running `docs.py`, building the website and verifying `docs/api/rules.generated.md`
