### PR TITLE
Fix multi-line doc generation

### DIFF
--- a/prelude/decls/apple_common.bzl
+++ b/prelude/decls/apple_common.bzl
@@ -53,22 +53,20 @@ def _header_path_prefix_arg():
      using
 
     ```
-
     apple_library(
         name = "Library",
         headers = glob(["**/*.h"]),
         header_path_prefix = "Lib",
     )
-
     ```
+
     can be imported using following mapping
 
     ```
-
     Library/SubDir/Header1.h -> Lib/Header1.h
     Library/Header2.h -> Lib/Header2.h
-
     ```
+
     Defaults to the short name of the target. Can contain forward slashes (`/`), but
      cannot start with one. See `headers` for more information.
 """),

--- a/prelude/decls/ios_rules.bzl
+++ b/prelude/decls/ios_rules.bzl
@@ -347,7 +347,8 @@ apple_bundle = prelude_rule(
         {
             "asset_catalogs_compilation_options": attrs.dict(key = attrs.string(), value = attrs.any(), default = {}, doc = """
                 A dict holding parameters for asset catalogs compiler (actool). Its options include:
-                 * `notices` (defaults to `True`)
+
+                * `notices` (defaults to `True`)
                 * `warnings` (defaults to `True`)
                 * `errors` (defaults to `True`)
                 * `compress_pngs` (defaults to `True`)

--- a/prelude/linking/execution_preference.bzl
+++ b/prelude/linking/execution_preference.bzl
@@ -36,17 +36,16 @@ _ActionExecutionAttributes = record(
 def link_execution_preference_attr():
     # The attribute is optional, allowing for None to represent that no preference has been set and we should fallback on the toolchain.
     return attrs.option(attrs.one_of(attrs.enum(LinkExecutionPreferenceTypes), attrs.dep(providers = [LinkExecutionPreferenceDeterminatorInfo])), default = None, doc = """
-    The execution preference for linking.
+    The execution preference for linking. Options are:
 
-      Options are:
-        - any : No preference is set, and the link action will be performed based on buck2's executor configuration.\n
-        - full_hybrid : The link action will execute both locally and remotely, regardless of buck2's executor configuration (if\n
-          the executor is capable of hybrid execution). The use_limited_hybrid setting of the hybrid executor is ignored.\n
-        - local : The link action will execute locally if compatible on current host platform.\n
-        - local_only : The link action will execute locally, and error if the current platform is not compatible.\n
-        - remote : The link action will execute remotely if a compatible remote platform exists, otherwise locally.\n
+    - any : No preference is set, and the link action will be performed based on buck2's executor configuration.
+    - full_hybrid : The link action will execute both locally and remotely, regardless of buck2's executor configuration (if
+        the executor is capable of hybrid execution). The use_limited_hybrid setting of the hybrid executor is ignored.
+    - local : The link action will execute locally if compatible on current host platform.
+    - local_only : The link action will execute locally, and error if the current platform is not compatible.
+    - remote : The link action will execute remotely if a compatible remote platform exists, otherwise locally.
 
-      The default is None, expressing that no preference has been set on the target itself.
+    The default is None, expressing that no preference has been set on the target itself.
     """)
 
 def get_link_execution_preference(ctx, links: list[Label]) -> LinkExecutionPreference:

--- a/starlark-rust/starlark/src/docs/markdown.rs
+++ b/starlark-rust/starlark/src/docs/markdown.rs
@@ -146,7 +146,15 @@ fn render_function_parameters(params: &[DocParam]) -> Option<String> {
         })
         .fold(String::new(), |mut output, (name, docs)| {
             let docs = render_doc_string(DSOpts::Combined, docs).unwrap_or_default();
-            let _ = writeln!(output, "* `{name}`: {docs}");
+
+            let mut lines_iter = docs.lines();
+            let first_line = lines_iter.next().unwrap();
+            let rest_of_lines: Vec<&str> = lines_iter.collect();
+
+            let _ = writeln!(output, "* `{name}`: {first_line}");
+            for line in &rest_of_lines {
+                let _ = writeln!(output, "  {line}");
+            }
             output
         });
     Some(param_list)


### PR DESCRIPTION
When generating a parameter list item the doc generator now indents the rest of the docstring to match the level of the list item.

examples:

```md
* `resources_from_deps`: Set of build targets whose transitive `apple_resource`s should be considered as part of the current resource when collecting resources for bundles.

  Usually, an `apple_bundle` collects all `apple_resource` rules transitively
  reachable through apple\_library rules. This field allows for resources which are not reachable
  using the above traversal strategy to be considered for inclusion in the bundle.
```

```md
* `asset_catalogs_compilation_options`: A dict holding parameters for asset catalogs compiler (actool). Its options include:

  * `notices` (defaults to `True`)
  * `warnings` (defaults to `True`)
  * `errors` (defaults to `True`)
  * `compress_pngs` (defaults to `True`)
  * `optimization` (defaults to `'space'`)
  * `output_format` (defaults to `'human-readable-text'`)
  * `extra_flags` (defaults to `[]`)
* `deps`: A list of dependencies of this bundle as build targets. You can embed application extensions by specifying the extension's bundle target. To include a WatchKit app, append the flavor `#watch` to the target specification. Buck will automatically substitute the appropriate platform flavor (either `watchsimulator` or `watchos`) based on the parent.
```

````md
* `header_path_prefix`: A path prefix when including headers of this target. For example, headers from a library defined using

  ```
  apple_library(
      name = "Library",
      headers = glob(["**/*.h"]),
      header_path_prefix = "Lib",
  )
  ```

  can be imported using following mapping

  ```
  Library/SubDir/Header1.h -> Lib/Header1.h
  Library/Header2.h -> Lib/Header2.h
  ```

  Defaults to the short name of the target. Can contain forward slashes (`/`), but
   cannot start with one. See `headers` for more information.
````