### PR TITLE
include runtime dep link flags in binary rule

### DIFF
--- a/examples/with_prelude/ocaml/ppx/BUCK
+++ b/examples/with_prelude/ocaml/ppx/BUCK
@@ -17,10 +17,6 @@ ocaml_binary(
     srcs = ["ppx_driver.ml"],
     compiler_flags = [
         "-linkall",
-        "-cclib",
-        "-L/opt/homebrew/lib",
-        "-cclib",
-        "-lzstd",
     ],
     deps = [
         ":ppx-record-selectors",

--- a/prelude/ocaml/ocaml.bzl
+++ b/prelude/ocaml/ocaml.bzl
@@ -722,6 +722,7 @@ def ocaml_library_impl(ctx: AnalysisContext) -> list[Provider]:
 
 def ocaml_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     ocaml_toolchain = ctx.attrs._ocaml_toolchain[OCamlToolchainInfo]
+    ocaml_toolchain_runtime_deps = ocaml_toolchain.runtime_dep_link_extras
 
     env = _mk_env(ctx)
     ocamlopt = _mk_ocaml_compiler(ctx, env, BuildMode("native"))
@@ -757,6 +758,9 @@ def ocaml_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     # dependencies of the link step.
     cmd_nat.hidden(cmxs, cmis_nat, cmts_nat, cmtis_nat, objs, link_args_output.hidden)
     binary_nat = ctx.actions.declare_output(ctx.attrs.name + ".opt")
+
+    cmd_nat.hidden(ocaml_toolchain_runtime_deps)
+    cmd_nat.add([cmd_args(["-cclib", f]) for f in ocaml_toolchain.runtime_dep_link_flags])
     cmd_nat.add("-cclib", "-lpthread")
     cmd_nat.add("-o", binary_nat.as_output())
     local_only = link_cxx_binary_locally(ctx)
@@ -770,6 +774,8 @@ def ocaml_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     cmd_byt.hidden(cmos, cmis_byt, cmts_byt, cmtis_byt, link_args_output.hidden)
     binary_byt = ctx.actions.declare_output(ctx.attrs.name)
     cmd_byt.add("-custom")
+    cmd_byt.hidden(ocaml_toolchain_runtime_deps)
+    cmd_byt.add([cmd_args(["-cclib", f]) for f in ocaml_toolchain.runtime_dep_link_flags])
     cmd_byt.add("-cclib", "-lpthread")
     cmd_byt.add("-o", binary_byt.as_output())
     local_only = link_cxx_binary_locally(ctx)


### PR DESCRIPTION
if we always put the runtime dep link flags on the link line (even if not strictly required) we avoid having to restate them on  individual targets (when they are) e.g. ppx