### PR TITLE
Integrate with dotslash

### DIFF
--- a/.github/actions/publish_tag/action.yml
+++ b/.github/actions/publish_tag/action.yml
@@ -51,5 +51,5 @@ runs:
         cat <<EOF >> $GITHUB_STEP_SUMMARY
         # `${{ inputs.tag }}` Release Complete! :rocket:
         For the public download links of these build artifacts, please see:
-          <https://github.com/facebook/buck2/releases/tag/${{ inputs.tag }}>
+          <https://github.com/$GITHUB_REPOSITORY/releases/tag/${{ inputs.tag }}>
         EOF

--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -1,0 +1,29 @@
+{
+    "exclude-github-release-provider": true,
+    "outputs": {
+      "hermes": {
+        "platforms": {
+          "macos-aarch64": {
+            "regex": "^buck2-aarch64-apple-darwin.zst$",
+            "path": "buck2-aarch64-apple-darwin"
+          },
+          "linux-aarch64": {
+            "regex": "^buck2-aarch64-unknown-linux-gnu.zst$",
+            "path": "buck2-aarch64-unknown-linux-gnu"
+          },
+          "macos-x86_64": {
+            "regex": "^buck2-x86_64-apple-darwin.zst$",
+            "path": "buck2-x86_64-apple-darwin"
+          },
+          "windows-x86_64": {
+            "regex": "^buck2-x86_64-pc-windows-msvc.exe.zst$",
+            "path": "buck2-x86_64-pc-windows-msvc.exe"
+          },
+          "linux-x86_64": {
+            "regex": "^buck2-x86_64-unknown-linux-gnu.zst$",
+            "path": "buck2-x86_64-unknown-linux-gnu"
+          }
+        }
+      }
+    }
+  }

--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -1,7 +1,7 @@
 {
     "exclude-github-release-provider": true,
     "outputs": {
-      "hermes": {
+      "buck2": {
         "platforms": {
           "macos-aarch64": {
             "regex": "^buck2-aarch64-apple-darwin.zst$",

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -158,7 +158,7 @@ jobs:
       - id: get_tags_count
         name: Count the number of tags already published for this month
         run: |
-          url="https://api.github.com/repos/facebook/buck2/tags"
+          url="https://api.github.com/repos/$GITHUB_REPOSITORY/tags"
           curl --retry 5 -fsSL "$url" -o tags.txt
           tags=$(cat tags.txt |  jq -r ".[].name")
           tags_count=$(echo "$tags" | grep -c "${{ steps.get_date.outputs.month }}" || true)

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -149,7 +149,7 @@ jobs:
         name: Store date information so we stay consistent between the steps
         run: |
           month=$(date +%Y-%m)
-          day=$(date +%d)
+          day=$(date +%d | sed 's/^0*//')
           tag=$(date +%Y-%m-%d)
           echo "month=$month" >> "$GITHUB_OUTPUT"
           echo "day=$day" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -194,6 +194,12 @@ jobs:
         with:
           tag: ${{ needs.check_for_bi_monthly_release.outputs.tag }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: facebook/dotslash-publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .github/dotslash-config.json
+          tag: ${{ needs.check_for_bi_monthly_release.outputs.tag }}
 
   build_docs_job:
     name: Publish buck2.build


### PR DESCRIPTION
As discussed internally, we want to use dotslash as a distribution mechanism for bucks. This PR stands up the initial integration.

In order to test I had to fix some things in the GitHub Actions workflows, so I included those here.

Ref: https://dotslash-cli.com/
Ref: https://github.com/facebook/dotslash-publish-release

Tasks: T175738402

Test plan:

See this action on my fork: https://github.com/bigfootjon/buck2/actions/runs/7836463888/job/21385144587

Which created this release: https://github.com/bigfootjon/buck2/releases/tag/2024-02-08

It contains a correct dotslash file: https://gist.github.com/bigfootjon/39c63a3a6772f66fc13c84c9116a56d7

(this version predates a fix I made to use "buck2" as the filename instead of hermes, oops)

When run using the opensource version of dotslash it correctly downloads and runs the right binary!