### PR TITLE
Pass correct rpath origin setting to linker on Darwin for Haskell

### DIFF
--- a/prelude/haskell/haskell.bzl
+++ b/prelude/haskell/haskell.bzl
@@ -14,6 +14,10 @@ load(
     "get_auto_link_group_specs",
 )
 load(
+    "@prelude//cxx:cxx_context.bzl",
+    "get_cxx_toolchain_info",
+)
+load(
     "@prelude//cxx:cxx_toolchain_types.bzl",
     "CxxToolchainInfo",
     "PicBehavior",
@@ -33,6 +37,7 @@ load(
 load(
     "@prelude//cxx:linker.bzl",
     "LINKERS",
+    "get_rpath_origin",
     "get_shared_library_flags",
 )
 load(
@@ -1054,7 +1059,9 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
 
     if link_style == LinkStyle("shared") or link_group_info != None:
         sos_dir = "__{}__shared_libs_symlink_tree".format(ctx.attrs.name)
-        link.add("-optl", "-Wl,-rpath", "-optl", "-Wl,$ORIGIN/{}".format(sos_dir))
+        rpath_ref = get_rpath_origin(get_cxx_toolchain_info(ctx).linker_info.type)
+        rpath_ldflag = "-Wl,{}/{}".format(rpath_ref, sos_dir)
+        link.add("-optl", "-Wl,-rpath", "-optl", rpath_ldflag)
         symlink_dir = ctx.actions.symlinked_dir(sos_dir, {n: o.output for n, o in sos.items()})
         run.hidden(symlink_dir)
 


### PR DESCRIPTION
This is a follow-up to #536 which fixes a problem on Darwin when trying to execute a haskell_binary fails with:

```
dyld[13654]: Library not loaded: @rpath/lib_backend.dylib
  Referenced from: <no uuid> /Users/runner/work/buck-out/v2/gen/root/6e975d09ae66fe71/backend/one-off-task/__one-off-task__/one-off-task
  Reason: tried: '$ORIGIN/__one-off-task__shared_libs_symlink_tree/lib_backend.dylib' (no such file), '$ORIGIN/__one-off-task__shared_libs_symlink_tree/lib_backend.dylib' (no such file), '/usr/local/lib/lib_backend.dylib' (no such file), '/usr/lib/lib_backend.dylib' (no such file, not in dyld cache)
```
