### PR TITLE
dotslash: use `-linux-musl` builds instead of `linux-gnu`

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -8,8 +8,8 @@
             "path": "buck2-aarch64-apple-darwin"
           },
           "linux-aarch64": {
-            "regex": "^buck2-aarch64-unknown-linux-gnu.zst$",
-            "path": "buck2-aarch64-unknown-linux-gnu"
+            "regex": "^buck2-aarch64-unknown-linux-musl.zst$",
+            "path": "buck2-aarch64-unknown-linux-musl"
           },
           "macos-x86_64": {
             "regex": "^buck2-x86_64-apple-darwin.zst$",
@@ -20,8 +20,8 @@
             "path": "buck2-x86_64-pc-windows-msvc.exe"
           },
           "linux-x86_64": {
-            "regex": "^buck2-x86_64-unknown-linux-gnu.zst$",
-            "path": "buck2-x86_64-unknown-linux-gnu"
+            "regex": "^buck2-x86_64-unknown-linux-musl.zst$",
+            "path": "buck2-x86_64-unknown-linux-musl"
           }
         }
       }


### PR DESCRIPTION
Prebuilt `linux-gnu` buck2 binaries will not work on systems with non- traditional FHS layouts and `ld.so` locations, like NixOS, Guix, or your favorite 10 year old distro release with an old glibc. Use `linux-musl` builds instead to fix this.