### PR TITLE
: fixup for fs-err

### DIFF
--- a/shim/third-party/rust/fixups/fs-err/fixups.toml
+++ b/shim/third-party/rust/fixups/fs-err/fixups.toml
@@ -1,0 +1,2 @@
+[[buildscript]]
+[buildscript.rustc_flags]


### PR DESCRIPTION
Summary:
picks up from D54376752. fixes warning
```
[WARN  reindeer::fixups] fs-err-2.11.0 has a build script, but I don't know what to do with it: Unresolved build script at ../../../../../.cargo/registry/src/index.crates.io-6f17d22bba15001f/fs-err-2.11.0/build.rs.
```

Differential Revision: D54377916


