### PR TITLE
Fix `system_go_toolchain` and add examples

### DIFF
--- a/.github/actions/setup_linux_env/action.yml
+++ b/.github/actions/setup_linux_env/action.yml
@@ -22,3 +22,7 @@ runs:
   - name: Install conan
     run: sudo pip3 install conan==1.*
     shell: bash
+  - uses: actions/checkout@v4
+  - uses: actions/setup-go@v5
+    with:
+      go-version: '~1.22.0'

--- a/examples/with_prelude/go/hello/BUCK
+++ b/examples/with_prelude/go/hello/BUCK
@@ -1,0 +1,10 @@
+_SUPPORTED = not host_info().os.is_windows
+
+# buildifier: disable=no-effect
+go_binary(
+    name = "hello",
+    srcs = glob(["*.go"]),
+    deps = [
+        "//go/hello/greeting:greeting",
+    ],
+) if _SUPPORTED else None

--- a/examples/with_prelude/go/hello/greeting/BUCK
+++ b/examples/with_prelude/go/hello/greeting/BUCK
@@ -1,0 +1,14 @@
+_SUPPORTED = not host_info().os.is_windows
+
+# buildifier: disable=no-effect
+go_library(
+    name = "greeting",
+    srcs = glob(["*.go"]),
+    visibility = ["PUBLIC"],
+) if _SUPPORTED else None
+
+# buildifier: disable=no-effect
+go_test(
+    name = "greeting_test",
+    srcs = glob(["*.go"]),
+) if _SUPPORTED else None

--- a/examples/with_prelude/go/hello/greeting/greeting.go
+++ b/examples/with_prelude/go/hello/greeting/greeting.go
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+package greeting
+
+// Greeting returns a greeting message
+func Greeting() string {
+	return "Hello, world!"
+}

--- a/examples/with_prelude/go/hello/greeting/greeting_test.go
+++ b/examples/with_prelude/go/hello/greeting/greeting_test.go
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+package greeting
+
+import "testing"
+
+func TestHello(t *testing.T) {
+	if Greeting() != "Hello, world!" {
+		t.Errorf("Greeting() = %v, want \"Hello, world!\"", Greeting())
+	}
+}

--- a/examples/with_prelude/go/hello/main.go
+++ b/examples/with_prelude/go/hello/main.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"go/hello/greeting"
+)
+
+func main() {
+	fmt.Println(greeting.Greeting())
+}

--- a/prelude/go/tools/go_wrapper.py
+++ b/prelude/go/tools/go_wrapper.py
@@ -32,7 +32,9 @@ def main(argv):
 
     env = os.environ.copy()
     # Make paths absolute, otherwise go build will fail.
-    env["GOROOT"] = os.path.realpath(env["GOROOT"])
+    if "GOROOT" in env:
+        env["GOROOT"] = os.path.realpath(env["GOROOT"])
+
     env["GOCACHE"] = os.path.realpath(env["BUCK_SCRATCH_PATH"])
 
     cwd = os.getcwd()

--- a/prelude/toolchains/demo.bzl
+++ b/prelude/toolchains/demo.bzl
@@ -7,6 +7,7 @@
 
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
 load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
+load("@prelude//toolchains:go.bzl", "system_go_toolchain")
 load("@prelude//toolchains:haskell.bzl", "system_haskell_toolchain")
 load("@prelude//toolchains:ocaml.bzl", "system_ocaml_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
@@ -25,6 +26,11 @@ def system_demo_toolchains():
 
     system_genrule_toolchain(
         name = "genrule",
+        visibility = ["PUBLIC"],
+    )
+
+    system_go_toolchain(
+        name = "go",
         visibility = ["PUBLIC"],
     )
 

--- a/prelude/toolchains/go.bzl
+++ b/prelude/toolchains/go.bzl
@@ -6,11 +6,9 @@
 # of this source tree.
 
 load("@prelude//go:toolchain.bzl", "GoToolchainInfo")
+load("@prelude//utils:cmd_script.bzl", "ScriptOs", "cmd_script")
 
 def _system_go_toolchain_impl(ctx):
-    go_root = ctx.attrs.go_root
-    go_binary = go_root + "/bin/go"
-
     arch = host_info().arch
     if arch.is_aarch64:
         go_arch = "arm64"
@@ -18,37 +16,41 @@ def _system_go_toolchain_impl(ctx):
         go_arch = "amd64"
     else:
         fail("Unsupported go arch: {}".format(arch))
+
     os = host_info().os
     if os.is_macos:
         go_os = "darwin"
     elif os.is_linux:
         go_os = "linux"
+    elif os.is_windows:
+        go_os = "windows"
     else:
         fail("Unsupported go os: {}".format(os))
 
-    get_go_tool = lambda go_tool: "{}/pkg/tool/{}_{}/{}".format(go_root, go_os, go_arch, go_tool)
+    script_os = ScriptOs("windows" if os.is_windows else "unix")
+    go = "go.exe" if os.is_windows else "go"
+
     return [
         DefaultInfo(),
         GoToolchainInfo(
-            assembler = get_go_tool("asm"),
-            cgo = get_go_tool("cgo"),
-            cgo_wrapper = ctx.attrs.cgo_wrapper,
-            compile_wrapper = ctx.attrs.compile_wrapper,
-            concat_files = ctx.attrs.concat_files,
-            compiler = get_go_tool("compile"),
-            cover = get_go_tool("cover"),
-            cover_srcs = ctx.attrs.cover_srcs,
+            assembler = RunInfo(cmd_script(ctx, "asm", cmd_args(go, "tool", "asm"), script_os)),
+            cgo = RunInfo(cmd_script(ctx, "cgo", cmd_args(go, "tool", "cgo"), script_os)),
+            cgo_wrapper = ctx.attrs.cgo_wrapper[RunInfo],
+            compile_wrapper = ctx.attrs.compile_wrapper[RunInfo],
+            concat_files = ctx.attrs.concat_files[RunInfo],
+            compiler = RunInfo(cmd_script(ctx, "compile", cmd_args(go, "tool", "compile"), script_os)),
+            cover = RunInfo(cmd_script(ctx, "cover", cmd_args(go, "tool", "cover"), script_os)),
+            cover_srcs = ctx.attrs.cover_srcs[RunInfo],
             cxx_toolchain_for_linking = None,
             env_go_arch = go_arch,
             env_go_os = go_os,
-            env_go_root = go_root,
-            external_linker_flags = None,
-            filter_srcs = ctx.attrs.filter_srcs,
-            gen_stdlib_importcfg = ctx.attrs.gen_stdlib_importcfg,
-            go = go_binary,
-            go_wrapper = ctx.attrs.go_wrapper,
-            linker = get_go_tool("link"),
-            packer = get_go_tool("pack"),
+            external_linker_flags = [],
+            filter_srcs = ctx.attrs.filter_srcs[RunInfo],
+            gen_stdlib_importcfg = ctx.attrs.gen_stdlib_importcfg[RunInfo],
+            go = RunInfo(cmd_script(ctx, "go", cmd_args(go), script_os)),
+            go_wrapper = ctx.attrs.go_wrapper[RunInfo],
+            linker = RunInfo(cmd_script(ctx, "link", cmd_args(go, "tool", "link"), script_os)),
+            packer = RunInfo(cmd_script(ctx, "pack", cmd_args(go, "tool", "pack"), script_os)),
             tags = [],
             linker_flags = [],
             assembler_flags = [],
@@ -61,7 +63,6 @@ system_go_toolchain = rule(
     doc = """Example system go toolchain rules (WIP). Usage:
   system_go_toolchain(
       name = "go",
-      go_root = "/opt/homebrew/Cellar/go/1.20.4/libexec",
       visibility = ["PUBLIC"],
   )""",
     attrs = {
@@ -71,7 +72,6 @@ system_go_toolchain = rule(
         "cover_srcs": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//go/tools:cover_srcs")),
         "filter_srcs": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//go/tools:filter_srcs")),
         "gen_stdlib_importcfg": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//go/tools:gen_stdlib_importcfg")),
-        "go_root": attrs.string(),
         "go_wrapper": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//go/tools:go_wrapper")),
     },
     is_toolchain_rule = True,


### PR DESCRIPTION
Summary:
- Enabled `system_go_toolchain` to work with `go` binary from PATH for Linux and MacOS
- Added examples of go_library, go_binary and go_test to `examples/with_prelude/go/hello`
- Added the same version of Go as we use at Meta to CI
- Added go ~1.22.0 to Github actions CI

Reviewed By: ndmitchell

Differential Revision: D54364160


