### PR TITLE
Make `CxxToolchainInfo.mk_comp_db` optional.

### DIFF
--- a/prelude/cxx/comp_db.bzl
+++ b/prelude/cxx/comp_db.bzl
@@ -32,7 +32,10 @@ def create_compilation_database(
         ctx: AnalysisContext,
         src_compile_cmds: list[CxxSrcCompileCommand],
         identifier: str) -> DefaultInfo:
-    mk_comp_db = get_cxx_toolchain_info(ctx).mk_comp_db[RunInfo]
+    mk_comp_db = get_cxx_toolchain_info(ctx).mk_comp_db
+    if mk_comp_db == None:
+        return DefaultInfo()
+    mk_comp_db = mk_comp_db[RunInfo]
 
     # Generate the per-source compilation DB entries.
     entries = {}


### PR DESCRIPTION
Make `CxxToolchainInfo.mk_comp_db` optional.

According to [the documentation], constructing a [`CxxToolchainInfo`] requires
at least C/C++ compiler info along with linker info.
It means that [`CxxToolchainInfo.mk_comp_db`] should be optional. By the way,
its definition is set to `default = None`.

A `None` value in [`CxxToolchainInfo.mk_comp_db`] leads to an error:

```
Caused by:
    Traceback (most recent call last):
      File <builtin>, in <module>
      * prelude/rules.bzl:101, in buck2_compatibility_shim
          return impl(ctx)
      * prelude/cxx/cxx.bzl:191, in cxx_library_impl
          output = cxx_library_parameterized(ctx, params)
      * prelude/cxx/cxx_library.bzl:425, in cxx_library_parameterized
          comp_db = create_compilation_database(ctx, compiled_srcs.compile_cmds.src_com...
    error: Operation `[]` not supported for types `NoneType` and `run_info_callable`
      --> prelude/cxx/comp_db.bzl:34:18
       |
    34 |     mk_comp_db = get_cxx_toolchain_info(ctx).mk_comp_db[RunInfo]
       |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
```

This commit fixes this small bug by allowing `None` in [`CxxToolchainInfo.mk_comp_db`].

[the documentation]: https://github.com/facebook/buck2/blob/1e89af6622344c46543a9e3781a556e058471043/prelude/cxx/cxx_toolchain_types.bzl#L251-L255
[`CxxToolchainInfo`]: https://github.com/facebook/buck2/blob/1e89af6622344c46543a9e3781a556e058471043/prelude/cxx/cxx_toolchain_types.bzl#L167
[`CxxToolchainInfo.mk_comp_db`]: https://github.com/facebook/buck2/blob/1e89af6622344c46543a9e3781a556e058471043/prelude/cxx/cxx_toolchain_types.bzl#L183
