### PR TITLE
Disable stripping stage if no strip binary was provided.

### DIFF
--- a/prelude/cxx/cxx_library.bzl
+++ b/prelude/cxx/cxx_library.bzl
@@ -1095,9 +1095,16 @@ def _strip_objects(ctx: AnalysisContext, objects: list[Artifact]) -> list[Artifa
     Return new objects with debug info stripped.
     """
 
+    cxx_toolchain_info = get_cxx_toolchain_info(ctx)
+
     # Stripping is not supported on Windows
-    linker_type = get_cxx_toolchain_info(ctx).linker_info.type
+    linker_type = cxx_toolchain_info.linker_info.type
     if linker_type == "windows":
+        return objects
+
+    # Disable stripping if no `strip` binary was provided by the toolchain.
+    if cxx_toolchain_info.binary_utilities_info == None or \
+       cxx_toolchain_info.binary_utilities_info.strip == None:
         return objects
 
     outs = []


### PR DESCRIPTION
Disable stripping stage if no strip binary was provided.

[`CxxToolchainInfo`] has a field called [`binary_utilities_info`] which
points to some binary utilities such as [`strip`] or [`objcopy`].

Similar to https://github.com/facebook/buck2/pull/594, according to
[the documentation](https://github.com/facebook/buck2/blob/1e89af6622344c46543a9e3781a556e058471043/prelude/cxx/cxx_toolchain_types.bzl#L251-L255),
[`CxxToolchainInfo.binary_utilities_info`] is optional.

However, in the [`cxx_library` implementation], [`_strip_objects`] is called
regardless of the [`CxxToolchainInfo.binary_utilities_info`] value.

This leads to the following error:

```
Caused by:
    Traceback (most recent call last):
      File <builtin>, in <module>
      * prelude/rules.bzl:101, in buck2_compatibility_shim
          return impl(ctx)
      * prelude/cxx/cxx.bzl:191, in cxx_library_impl
          output = cxx_library_parameterized(ctx, params)
      * prelude/cxx/cxx_library.bzl:371, in cxx_library_parameterized
          compiled_srcs = cxx_compile_srcs(
      * prelude/cxx/cxx_library.bzl:914, in cxx_compile_srcs
          pic = _get_library_compile_output(ctx, pic_cxx_outs, impl_params.extra_link_i...
      * prelude/cxx/cxx_library.bzl:866, in _get_library_compile_output
          stripped_objects = _strip_objects(ctx, objects)
      * prelude/cxx/cxx_library.bzl:1108, in _strip_objects
          outs.append(strip_debug_info(ctx, base + ".stripped.o", obj))
      * prelude/linking/strip.bzl:67, in strip_debug_info
          return _strip_debug_info(
    error: Object of type `NoneType` has no attribute `strip`
      --> prelude/linking/strip.bzl:16:13
       |
    16 |     strip = cxx_toolchain.binary_utilities_info.strip
       |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

This commit prevents this bug from happening by making [`CxxToolchainInfo.binary_utilities_info`]
truely optional.

[`CxxToolchainInfo`]: https://github.com/facebook/buck2/blob/6b2b497907676c662baa2f39d7622241da6f0081/prelude/cxx/cxx_toolchain_types.bzl#L167
[`binary_utilities_info`]: https://github.com/facebook/buck2/blob/6b2b497907676c662baa2f39d7622241da6f0081/prelude/cxx/cxx_toolchain_types.bzl#L176
[`CxxToolchainInfo.binary_utilities_info`]: https://github.com/facebook/buck2/blob/6b2b497907676c662baa2f39d7622241da6f0081/prelude/cxx/cxx_toolchain_types.bzl#L176
[`strip`]: https://github.com/facebook/buck2/blob/6b2b497907676c662baa2f39d7622241da6f0081/prelude/cxx/cxx_toolchain_types.bzl#L77
[`objcopy`]: https://github.com/facebook/buck2/blob/6b2b497907676c662baa2f39d7622241da6f0081/prelude/cxx/cxx_toolchain_types.bzl#L75
[`cxx_library` implementation]: https://github.com/facebook/buck2/blob/6b2b497907676c662baa2f39d7622241da6f0081/prelude/cxx/cxx_library.bzl#L866
[`_strip_objects`]: https://github.com/facebook/buck2/blob/6b2b497907676c662baa2f39d7622241da6f0081/prelude/cxx/cxx_library.bzl#L1093
