### PR TITLE
Fix repositories link in key concepts doc

### DIFF
--- a/docs/concepts/key_concepts.md
+++ b/docs/concepts/key_concepts.md
@@ -49,7 +49,7 @@ where Buck2 is invoked, or if that directory doesn't contain a `.buckconfig`,
 the project is defined by the `.buckconfig` in the nearest ancestor directory.
 The `.buckconfig` for the project specifies the cells that constitute the Buck2
 project. Specifically, these cells are specified in the
-`[repositories]`(buckconfig.md#repositories) section of the `.buckconfig`. Note
+[repositories](buckconfig.md#repositories) section of the `.buckconfig`. Note
 that the directory tree rooted at this `.buckconfig` is automatically considered
 a cell by Buck2; in other words, the project's `.buckconfig` doesn't need to
 specify the project cell explicitly—although it is a good practice to do so.


### PR DESCRIPTION
I'm assuming the backticks were accidental

manually verified it works in the markdown, I assume that will work for the rendered site as well.