### PR TITLE
Add tar.bz2 support in http_archive

### DIFF
--- a/prelude/http_archive/http_archive.bzl
+++ b/prelude/http_archive/http_archive.bzl
@@ -13,6 +13,7 @@ load(":exec_deps.bzl", "HttpArchiveExecDeps")
 # Flags to apply to decompress the various types of archives.
 _TAR_FLAGS = {
     "tar": [],
+    "tar.bz2": [],
     "tar.gz": ["-z"],
     "tar.xz": ["-J"],
     "tar.zst": ["--use-compress-program=unzstd"],


### PR DESCRIPTION
This commit adds support for unpacking .tar.bz2 extension files using http_archive rule. 

As mentioned [here](https://buck2.build/docs/api/rules/#http_archive), tar.bz2 support is present but it's actually missing!

Change-Id: I85bfc441ff2d81efabf6201707ecbae88e33cb09