### PR TITLE
Added support for headers in the windows_resource rule

### DIFF
--- a/prelude/cxx/windows_resource.bzl
+++ b/prelude/cxx/windows_resource.bzl
@@ -5,13 +5,34 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//apple:xcode.bzl", "get_project_root_file")
 load("@prelude//cxx:cxx_context.bzl", "get_cxx_toolchain_info")
+load("@prelude//cxx:headers.bzl", "cxx_get_regular_cxx_headers_layout")
+load("@prelude//cxx:preprocessor.bzl", "cxx_merge_cpreprocessors", "cxx_private_preprocessor_info")
 load("@prelude//linking:link_groups.bzl", "LinkGroupLibInfo")
 load("@prelude//linking:link_info.bzl", "LibOutputStyle", "LinkInfo", "LinkInfos", "ObjectsLinkable", "create_merged_link_info")
 load("@prelude//linking:linkable_graph.bzl", "create_linkable_graph")
 load("@prelude//linking:shared_libraries.bzl", "SharedLibraryInfo")
 
 def windows_resource_impl(ctx: AnalysisContext) -> list[Provider]:
+    (own_non_exported_preprocessor_info, _) = cxx_private_preprocessor_info(
+            ctx = ctx,
+            headers_layout = cxx_get_regular_cxx_headers_layout(ctx),
+            project_root_file = get_project_root_file(ctx),
+            raw_headers = ctx.attrs.raw_headers,
+            extra_preprocessors = [],
+            non_exported_deps = [],
+            is_test = False,
+        )
+
+    preprocessor = cxx_merge_cpreprocessors(
+        ctx,
+        [own_non_exported_preprocessor_info],
+        [],
+    )
+
+    headers_tag = ctx.actions.artifact_tag()
+
     objects = []
 
     toolchain = get_cxx_toolchain_info(ctx)
@@ -24,6 +45,8 @@ def windows_resource_impl(ctx: AnalysisContext) -> list[Provider]:
             toolchain.rc_compiler_info.compiler,
             toolchain.rc_compiler_info.compiler_flags,
             cmd_args(rc_output.as_output(), format = "/fo{}"),
+            headers_tag.tag_artifacts(preprocessor.set.project_as_args("args")),
+            headers_tag.tag_artifacts(preprocessor.set.project_as_args("include_dirs")),
             src,
         )
 

--- a/prelude/decls/cxx_rules.bzl
+++ b/prelude/decls/cxx_rules.bzl
@@ -771,6 +771,11 @@ windows_resource = prelude_rule(
     further = None,
     attrs = (
         cxx_common.srcs_arg() |
+        cxx_common.headers_arg() |
+        cxx_common.platform_headers_arg() |
+        cxx_common.header_namespace_arg() |
+        cxx_common.raw_headers_arg() |
+        cxx_common.include_directories_arg() |
         {
             "labels": attrs.list(attrs.string(), default = []),
         }


### PR DESCRIPTION
Like other cxx rules it supports specifying "headers" or "include_directories" and "raw_headers".

As a test, I added a header dependency to the test I provided in the previous PR: #581.

The final result being the following files:
BUCK:
```
# A rule that includes a single .rc file and compiles it into an object file.
windows_resource(
    name = "resources",
    srcs = [
        "resources.rc",
    ],
    header_namespace = "",
    headers = ["message.h"],
)

# A rule that links against the above windows_resource rule.
# A rule that includes a single .rc file and compiles it into an object file.
windows_resource(
    name = "resources",
    srcs = [
        "resources.rc",
    ],
    header_namespace = "",
    headers = ["message.h"],
)

# A rule that links against the above windows_resource rule.
cxx_binary(
    name = "app",
    srcs = [
        "main.cpp",
    ],
    deps = [
        ":resources"
    ],
    linker_flags = [
        "User32.lib",
    ],
)
```
main.cpp:
```
#include <iostream>
#include <Windows.h>

int main(int argc, const char* argv[])
{
	std::string message;
	message.resize(50);
	int returnValue = LoadStringA(NULL, 4, message.data(), message.size());
	if (returnValue == 0)
	{
		std::cout << "Failed to read resource";
		return 1;
	}

	message.resize(returnValue);
	std::cout << message;
	return 0;
}
```
message.h:
```
#define MESSAGE_TO_PRINT "Hello from header"
```
resources.rc:
```
#include <winresrc.h>

#include "message.h"

STRINGTABLE
BEGIN
4 MESSAGE_TO_PRINT
END
```

