### PR TITLE
toolchains: Allow overriding all toolchain attrs

### DIFF
--- a/prelude/decls/toolchains_common.bzl
+++ b/prelude/decls/toolchains_common.bzl
@@ -28,14 +28,7 @@ load("@prelude//rust:rust_toolchain.bzl", "RustToolchainInfo")
 load("@prelude//tests:remote_test_execution_toolchain.bzl", "RemoteTestExecutionToolchainInfo")
 load("@prelude//zip_file:zip_file_toolchain.bzl", "ZipFileToolchainInfo")
 
-def _toolchain(lang: str, providers: list[typing.Any], default_only = True) -> Attr:
-    toolchain = attrs.toolchain_dep(default = "toolchains//:" + lang, providers = providers)
-    if default_only:
-        return attrs.default_only(toolchain)
-    else:
-        return toolchain
-
-def _toolchain_with_override(lang: str, providers: list[typing.Any]) -> Attr:
+def _toolchain(lang: str, providers: list[typing.Any]) -> Attr:
     return attrs.toolchain_dep(default = "toolchains//:" + lang, providers = providers)
 
 def _android_toolchain():
@@ -48,7 +41,7 @@ def _cxx_toolchain():
     return _toolchain("cxx", [CxxToolchainInfo, CxxPlatformInfo])
 
 def _dex_toolchain():
-    return _toolchain_with_override("dex", [DexToolchainInfo])
+    return _toolchain("dex", [DexToolchainInfo])
 
 def _go_toolchain():
     return _toolchain("go", [GoToolchainInfo])
@@ -57,7 +50,7 @@ def _haskell_toolchain():
     return _toolchain("haskell", [HaskellToolchainInfo, HaskellPlatformInfo])
 
 def _java_toolchain():
-    return _toolchain_with_override("java", [JavaToolchainInfo, JavaPlatformInfo])
+    return _toolchain("java", [JavaToolchainInfo, JavaPlatformInfo])
 
 def _java_for_android_toolchain():
     return _toolchain("java_for_android", [JavaToolchainInfo, JavaPlatformInfo])
@@ -69,11 +62,11 @@ def _java_test_toolchain():
     return _toolchain("java_test", [JavaTestToolchainInfo])
 
 def _kotlin_toolchain():
-    return _toolchain_with_override("kotlin", [KotlinToolchainInfo])
+    return _toolchain("kotlin", [KotlinToolchainInfo])
 
 def _prebuilt_jar_toolchain():
     # Override is allowed for bootstrapping prebuilt jar toolchains
-    return _toolchain_with_override("prebuilt_jar", [PrebuiltJarToolchainInfo])
+    return _toolchain("prebuilt_jar", [PrebuiltJarToolchainInfo])
 
 def _python_toolchain():
     return _toolchain("python", [PythonToolchainInfo, PythonPlatformInfo])
@@ -82,7 +75,7 @@ def _python_bootstrap_toolchain():
     return _toolchain("python_bootstrap", [PythonBootstrapToolchainInfo])
 
 def _rust_toolchain():
-    return _toolchain("rust", [RustToolchainInfo], default_only = False)
+    return _toolchain("rust", [RustToolchainInfo])
 
 def _zip_file_toolchain():
     return _toolchain("zip_file", [ZipFileToolchainInfo])


### PR DESCRIPTION
Summary:
We already allowed this for a couple languages, let's extend it to all of them.

I don't see what we get by banning this, and there are clearly use cases for allowing it. Also, an open source user just needed this for the CXX toolchain.

Differential Revision: D56048492


