### PR TITLE
Use `value` attribute of tset for HaskellLibraryInfo

### DIFF
--- a/prelude/haskell/haskell.bzl
+++ b/prelude/haskell/haskell.bzl
@@ -540,7 +540,7 @@ def _build_haskell_lib(
     linfos = [x.prof_info if enable_profiling else x.info for x in hlis]
 
     # only gather direct dependencies
-    uniq_infos = [x[link_style].reduce("root") for x in linfos]
+    uniq_infos = [x[link_style].value for x in linfos]
 
     objfiles = _srcs_to_objfiles(ctx, compiled.objects, osuf)
 

--- a/prelude/haskell/library_info.bzl
+++ b/prelude/haskell/library_info.bzl
@@ -45,14 +45,8 @@ HaskellLibraryInfo = record(
 def _project_as_package_db(lib: HaskellLibraryInfo):
     return cmd_args("-package-db", lib.db)
 
-def _direct_deps(_children: list[HaskellLibraryInfo | None], lib: HaskellLibraryInfo | None) -> HaskellLibraryInfo | None:
-    return lib
-
 HaskellLibraryInfoTSet = transitive_set(
     args_projections = {
         "package_db": _project_as_package_db,
-    },
-    reductions = {
-        "root": _direct_deps,
     },
 )


### PR DESCRIPTION
This is a follow-up to PR #617 which simplifies accessing direct dependencies for haskell libraries by using the `value` attribute of tsets and removes the `root` reduction for `HaskellLibraryInfoTSet` which was used for this purpose before.
