### PR TITLE
Move to TSets

### DIFF
--- a/prelude/haskell/compile.bzl
+++ b/prelude/haskell/compile.bzl
@@ -12,11 +12,7 @@ load(
 )
 load(
     "@prelude//haskell:library_info.bzl",
-    "HaskellLibraryInfo",
-)
-load(
-    "@prelude//haskell:link_info.bzl",
-    "merge_haskell_link_infos",
+    "HaskellLibraryInfoTSet",
 )
 load(
     "@prelude//haskell:toolchain.bzl",
@@ -54,7 +50,7 @@ CompileArgsInfo = record(
 PackagesInfo = record(
     exposed_package_args = cmd_args,
     packagedb_args = cmd_args,
-    transitive_deps = field(list[HaskellLibraryInfo]),
+    transitive_deps = field(HaskellLibraryInfoTSet),
 )
 
 def _package_flag(toolchain: HaskellToolchainInfo) -> str:
@@ -71,24 +67,25 @@ def get_packages_info(
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 
     # Collect library dependencies. Note that these don't need to be in a
-    # particular order and we really want to remove duplicates (there
-    # are a *lot* of duplicates).
-    libs = {}
+    # particular order.
     direct_deps_link_info = attr_deps_haskell_link_infos(ctx)
-    merged_hs_link_info = merge_haskell_link_infos(direct_deps_link_info)
-
-    hs_link_info = merged_hs_link_info.prof_info if enable_profiling else merged_hs_link_info.info
-
-    for lib in hs_link_info[link_style]:
-        libs[lib.db] = lib  # lib.db is a good enough unique key
+    libs = ctx.actions.tset(
+        HaskellLibraryInfoTSet,
+        children = [
+            lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
+            for lib in direct_deps_link_info
+        ],
+    )
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
     exposed_package_args = cmd_args([package_flag, "base"])
 
     packagedb_args = cmd_args()
+    packagedb_set = {}
 
-    for lib in libs.values():
+    for lib in libs.traverse():
+        packagedb_set[lib.db] = None
         exposed_package_args.hidden(lib.import_dirs.values())
         exposed_package_args.hidden(lib.stub_dirs)
 
@@ -100,10 +97,9 @@ def get_packages_info(
         packagedb_args.hidden(lib.stub_dirs)
         packagedb_args.hidden(lib.libs)
 
-    for lib in libs.values():
-        # These we need to add for all the packages/dependencies, i.e.
-        # direct and transitive (e.g. `fbcode-common-hs-util-hs-array`)
-        packagedb_args.add("-package-db", lib.db)
+    # These we need to add for all the packages/dependencies, i.e.
+    # direct and transitive (e.g. `fbcode-common-hs-util-hs-array`)
+    packagedb_args.add([cmd_args("-package-db", x) for x in packagedb_set])
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,
@@ -122,7 +118,7 @@ def get_packages_info(
     return PackagesInfo(
         exposed_package_args = exposed_package_args,
         packagedb_args = packagedb_args,
-        transitive_deps = libs.values(),
+        transitive_deps = libs,
     )
 
 def compile_args(

--- a/prelude/haskell/haskell.bzl
+++ b/prelude/haskell/haskell.bzl
@@ -61,6 +61,7 @@ load(
 load(
     "@prelude//haskell:library_info.bzl",
     "HaskellLibraryInfo",
+    "HaskellLibraryInfoTSet",
     "HaskellLibraryProvider",
 )
 load(
@@ -69,7 +70,6 @@ load(
     "HaskellProfLinkInfo",
     "attr_link_style",
     "cxx_toolchain_link_style",
-    "merge_haskell_link_infos",
 )
 load(
     "@prelude//haskell:toolchain.bzl",
@@ -269,9 +269,17 @@ def haskell_prebuilt_library_impl(ctx: AnalysisContext) -> list[Provider]:
         ]
 
         hlibinfos[link_style] = hlibinfo
-        hlinkinfos[link_style] = [hlibinfo]
+        hlinkinfos[link_style] = ctx.actions.tset(
+            HaskellLibraryInfoTSet,
+            value = hlibinfo,
+            children = [lib.info[link_style] for lib in haskell_infos],
+        )
         prof_hlibinfos[link_style] = prof_hlibinfo
-        prof_hlinkinfos[link_style] = [prof_hlibinfo]
+        prof_hlinkinfos[link_style] = ctx.actions.tset(
+            HaskellLibraryInfoTSet,
+            value = prof_hlibinfo,
+            children = [lib.prof_info[link_style] for lib in haskell_infos],
+        )
         link_infos[link_style] = LinkInfos(
             default = LinkInfo(
                 pre_flags = ctx.attrs.exported_linker_flags,
@@ -352,7 +360,7 @@ def haskell_prebuilt_library_impl(ctx: AnalysisContext) -> list[Provider]:
             shared_library_infos,
         ),
         merge_link_group_lib_info(deps = ctx.attrs.deps),
-        merge_haskell_link_infos(haskell_infos + [haskell_link_infos]),
+        haskell_link_infos,
         merged_link_info,
         HaskellProfLinkInfo(
             prof_infos = prof_merged_link_info,
@@ -412,10 +420,6 @@ def _make_package(
     # Don't expose boot sources, as they're only meant to be used for compiling.
     modules = [src_to_module_name(x) for x, _ in srcs_to_pairs(ctx.attrs.srcs) if is_haskell_src(x)]
 
-    uniq_hlis = {}
-    for x in hlis:
-        uniq_hlis[x.id] = x
-
     if enable_profiling:
         # Add the `-p` suffix otherwise ghc will look for objects
         # following this logic (https://fburl.com/code/3gmobm5x) and will fail.
@@ -444,20 +448,20 @@ def _make_package(
         "import-dirs:" + ", ".join(import_dirs),
         "library-dirs:" + ", ".join(library_dirs),
         "extra-libraries: " + libname,
-        "depends: " + ", ".join(uniq_hlis),
+        "depends: " + ", ".join([lib.id for lib in hlis]),
     ]
     pkg_conf = ctx.actions.write("pkg-" + artifact_suffix + ".conf", conf)
 
     db = ctx.actions.declare_output("db-" + artifact_suffix)
 
-    db_deps = {}
-    for x in uniq_hlis.values():
-        db_deps[repr(x.db)] = x.db
+    # While the list of hlis is unique, there may be multiple packages in the same db.
+    # Cutting down the GHC_PACKAGE_PATH significantly speeds up GHC.
+    db_deps = {x.db: None for x in hlis}.keys()
 
     # So that ghc-pkg can find the DBs for the dependencies. We might
     # be able to use flags for this instead, but this works.
     ghc_package_path = cmd_args(
-        db_deps.values(),
+        db_deps,
         delimiter = ":",
     )
 
@@ -536,7 +540,9 @@ def _build_haskell_lib(
     lib_short_path = paths.join("lib-{}".format(artifact_suffix), libfile)
 
     linfos = [x.prof_info if enable_profiling else x.info for x in hlis]
-    uniq_infos = dedupe(flatten([x[link_style] for x in linfos]))
+
+    # only gather direct dependencies
+    uniq_infos = [x[link_style].value for x in linfos]
 
     objfiles = _srcs_to_objfiles(ctx, compiled.objects, osuf)
 
@@ -702,11 +708,19 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
 
             if enable_profiling:
                 prof_hlib_infos[link_style] = hlib
-                prof_hlink_infos[link_style] = [hlib]
+                prof_hlink_infos[link_style] = ctx.actions.tset(
+                    HaskellLibraryInfoTSet,
+                    value = hlib,
+                    children = [li.prof_info[link_style] for li in hlis],
+                )
                 prof_link_infos[link_style] = hlib_build_out.link_infos
             else:
                 hlib_infos[link_style] = hlib
-                hlink_infos[link_style] = [hlib]
+                hlink_infos[link_style] = ctx.actions.tset(
+                    HaskellLibraryInfoTSet,
+                    value = hlib,
+                    children = [li.info[link_style] for li in hlis],
+                )
                 link_infos[link_style] = hlib_build_out.link_infos
 
             # Build the indices and create subtargets only once, with profiling
@@ -809,10 +823,10 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
             lib = hlib_infos,
             prof_lib = prof_hlib_infos,
         ),
-        merge_haskell_link_infos(hlis + [HaskellLinkInfo(
+        HaskellLinkInfo(
             info = hlink_infos,
             prof_info = prof_hlink_infos,
-        )]),
+        ),
         merged_link_info,
         HaskellProfLinkInfo(
             prof_infos = prof_merged_link_info,

--- a/prelude/haskell/haskell_ghci.bzl
+++ b/prelude/haskell/haskell_ghci.bzl
@@ -635,11 +635,11 @@ def haskell_ghci_impl(ctx: AnalysisContext) -> list[Provider]:
     package_symlinks_root = ctx.label.name + ".packages"
 
     packagedb_args = cmd_args(delimiter = " ")
-    prebuilt_packagedb_args_set = {}
+    prebuilt_packagedb_args = cmd_args(delimiter = " ")
 
-    for lib in packages_info.transitive_deps:
+    for lib in packages_info.transitive_deps.traverse():
         if lib.is_prebuilt:
-            prebuilt_packagedb_args_set[lib.db] = lib.db
+            prebuilt_packagedb_args.add(lib.db)
         else:
             lib_symlinks_root = paths.join(
                 package_symlinks_root,
@@ -669,7 +669,6 @@ def haskell_ghci_impl(ctx: AnalysisContext) -> list[Provider]:
                     "packagedb",
                 ),
             )
-    prebuilt_packagedb_args = cmd_args(prebuilt_packagedb_args_set.values(), delimiter = " ")
 
     script_templates = []
     for script_template in ctx.attrs.extra_script_templates:

--- a/prelude/haskell/ide/ide.bxl
+++ b/prelude/haskell/ide/ide.bxl
@@ -259,7 +259,7 @@ def _assembleSolution(ctx, linkStyle, result):
     for provider in result["haskell_deps"].values():
         info = provider.info.get(linkStyle)
         if info != None:
-            for item in info:
+            for item in info.traverse():
                 if result["exclude_packages"].get(item.name) == None:
                     hlis[item.name] = item
     for hli in hlis.values():

--- a/prelude/haskell/library_info.bzl
+++ b/prelude/haskell/library_info.bzl
@@ -41,3 +41,5 @@ HaskellLibraryInfo = record(
     is_prebuilt = bool,
     profiling_enabled = bool,
 )
+
+HaskellLibraryInfoTSet = transitive_set()

--- a/prelude/haskell/link_info.bzl
+++ b/prelude/haskell/link_info.bzl
@@ -10,6 +10,10 @@ load(
     "CxxToolchainInfo",
 )
 load(
+    "@prelude//haskell:library_info.bzl",
+    "HaskellLibraryInfoTSet",
+)
+load(
     "@prelude//linking:link_info.bzl",
     "LinkStyle",
 )
@@ -18,8 +22,8 @@ load(
 HaskellLinkInfo = provider(
     # Contains a list of HaskellLibraryInfo records.
     fields = {
-        "info": provider_field(typing.Any, default = None),  # dict[LinkStyle, list[HaskellLibraryInfo]] # TODO use a tset
-        "prof_info": provider_field(typing.Any, default = None),  # dict[LinkStyle, list[HaskellLibraryInfo]] # TODO use a tset
+        "info": provider_field(dict[LinkStyle, HaskellLibraryInfoTSet]),
+        "prof_info": provider_field(dict[LinkStyle, HaskellLibraryInfoTSet]),
     },
 )
 
@@ -31,24 +35,6 @@ HaskellProfLinkInfo = provider(
         "prof_infos": provider_field(typing.Any, default = None),  # MergedLinkInfo
     },
 )
-
-def merge_haskell_link_infos(deps: list[HaskellLinkInfo]) -> HaskellLinkInfo:
-    merged = {}
-    prof_merged = {}
-    for link_style in LinkStyle:
-        children = []
-        prof_children = []
-        for dep in deps:
-            if link_style in dep.info:
-                children.extend(dep.info[link_style])
-
-            if link_style in dep.prof_info:
-                prof_children.extend(dep.prof_info[link_style])
-
-        merged[link_style] = dedupe(children)
-        prof_merged[link_style] = dedupe(prof_children)
-
-    return HaskellLinkInfo(info = merged, prof_info = prof_merged)
 
 def cxx_toolchain_link_style(ctx: AnalysisContext) -> LinkStyle:
     return ctx.attrs._cxx_toolchain[CxxToolchainInfo].linker_info.link_style


### PR DESCRIPTION
Summary:
Apply D56345659 and D56241179 (which were reverted in D56364484) along with performance optimisations on the fact that multiple packages might exist within the same package_db. Before, since we deduplicated everything by value, you might have 100 packages and 20 package_dbs. If you give GHC 100 package dbs (even if there are only 20 unique ones) the performance crashes dramatically. That's especially true if you have a package_db representing all of stackage, which both occurs a lot and is slow to load. The two places are:

* When we construct GHC_PACKAGE_PATH env var. These are fairly trivially deduped with a dict construction
* When we do packagedb_args.add. We traverse the TSet in the loop above, so dedupe to a dict then too.

Differential Revision: D56378115


