### PR TITLE
Add the python interpreter as a hidden dep of a pex file

### DIFF
--- a/prelude/python/make_py_package.bzl
+++ b/prelude/python/make_py_package.bzl
@@ -344,7 +344,7 @@ def _make_py_package_impl(
         other_outputs_prefix = symlink_tree_path.short_path if symlink_tree_path != None else None,
         hidden_resources = hidden_resources,
         sub_targets = {},
-        run_cmd = cmd_args(run_args).hidden(runtime_files + hidden_resources),
+        run_cmd = cmd_args(run_args).hidden(runtime_files + hidden_resources, python_toolchain.interpreter),
     )
 
 def _debuginfo_subtarget(


### PR DESCRIPTION
We have a unique python setup.  We distribute it hermetically via an internal tool (similar to dotslash), then we set up our `python` toolchain to return a `PythonToolchainInfo` whose `interpreter` and `host_interpreter` fields point to a shell script called `python_shim.sh` that is created via `ctx.actions.write()`, in order to properly set up the venv and do some other things to make it hermetic.

Later, if you call `python_binary`, it generates a pex file which contains a line like this at the beginning:

```
#!/usr/bin/env buck-out/v2/gen/toolchains/48291db568f0aab5-9e2be58768776d78/__python__/python_shim.sh 
```

Presently this is broken because the `cmd_args` to execute the pex file does not have an action dependency on the interpreter, and so it complains that it cannot find `python_shim.h`.  This PR makes it work