### PR TITLE
Support multiple execution platforms with system_cxx_toolchain

### DIFF
--- a/examples/visual_studio/.buckconfig
+++ b/examples/visual_studio/.buckconfig
@@ -11,7 +11,14 @@ fbsource = none
 buck = none
 
 [parser]
-target_platform_detector_spec = target:root//...->toolchains//:default
+target_platform_detector_spec = target:root//...->root//buck2_utils/platforms:windows_debug
 
 [build]
-execution_platforms = prelude//platforms:default
+execution_platforms = root//buck2_utils/platforms:default
+
+[buck2_re_client]
+action_cache_address = grpc://localhost:8980
+engine_address = grpc://localhost:8980
+cas_address = grpc://localhost:8980
+tls = false
+instance_name = fuse

--- a/examples/visual_studio/buck2_utils/create_compile_commands.bxl
+++ b/examples/visual_studio/buck2_utils/create_compile_commands.bxl
@@ -85,7 +85,7 @@ def gen_compilation_database_impl(ctx):
 
         if not "write" in actions_by_category:
             continue
-        if not "cxx_compile" in actions_by_category:
+        if not "cxx_compile" in actions_by_category and not "c_compile" in actions_by_category:
             continue
 
         argsfiles = {}
@@ -111,7 +111,7 @@ def gen_compilation_database_impl(ctx):
                 argsfiles[identifier] = arguments
 
         # Now walk each compilation action and generate a compilation database entry for it.
-        for action in actions_by_category["cxx_compile"]:
+        for action in actions_by_category.get("cxx_compile", []) + actions_by_category.get("c_compile", []):
             entry = create_compilation_database_entry(ctx.cli_args.directory, buildfile_folder, argsfiles, action)
             is_pic = entry["file"].endswith(" (pic)")
             file_name = entry["file"].removesuffix(" (pic)")

--- a/examples/visual_studio/buck2_utils/install.ps1
+++ b/examples/visual_studio/buck2_utils/install.ps1
@@ -29,7 +29,8 @@ begin
 			[parameter(Mandatory=$true)] [String] $SourcePath,
 			[parameter(Mandatory=$true)] [String] $TargetPath
 		)
-		Copy-Item $SourcePath -Destination $TargetPath
+		New-Item -ItemType File -Path $TargetPath -Force | Out-Null
+		Copy-Item $SourcePath -Destination $TargetPath | Out-Null
 	}
 }
 process

--- a/examples/visual_studio/buck2_utils/platforms/BUCK
+++ b/examples/visual_studio/buck2_utils/platforms/BUCK
@@ -1,0 +1,38 @@
+load(":defs.bzl", "execution_platform")
+
+execution_platform(
+    name = "default",
+    visibility = ["PUBLIC"],
+)
+
+platform(
+    name = "windows_debug",
+    constraint_values = [
+        "config//os/constraints:windows",
+        "root//buck2_utils/configuration:debug",
+    ],
+)
+
+platform(
+    name = "windows_release",
+    constraint_values = [
+        "config//os/constraints:windows",
+        "root//buck2_utils/configuration:release",
+    ],
+)
+
+platform(
+    name = "linux_debug",
+    constraint_values = [
+        "config//os/constraints:linux",
+        "root//buck2_utils/configuration:debug",
+    ],
+)
+
+platform(
+    name = "linux_release",
+    constraint_values = [
+        "config//os/constraints:linux",
+        "root//buck2_utils/configuration:release",
+    ],
+)

--- a/examples/visual_studio/buck2_utils/platforms/BUCK
+++ b/examples/visual_studio/buck2_utils/platforms/BUCK
@@ -1,6 +1,6 @@
-load(":defs.bzl", "execution_platform")
+load(":defs.bzl", "execution_platforms")
 
-execution_platform(
+execution_platforms(
     name = "default",
     visibility = ["PUBLIC"],
 )

--- a/examples/visual_studio/buck2_utils/platforms/defs.bzl
+++ b/examples/visual_studio/buck2_utils/platforms/defs.bzl
@@ -1,0 +1,61 @@
+def is_remote_enabled() -> bool:
+    re_enabled = read_config("buck2_re_client", "enabled", "false")
+    return re_enabled == "true"
+
+def _execution_platform_impl(ctx: AnalysisContext) -> list[Provider]:
+    is_re_enabled = is_remote_enabled()
+
+    name = ctx.label.raw_target()
+
+    constraints_windows = dict()
+    constraints_windows.update(ctx.attrs.os_configuration_windows[ConfigurationInfo].constraints)
+    constraints_linux = dict()
+    constraints_linux.update(ctx.attrs.os_configuration_linux[ConfigurationInfo].constraints)
+
+    platforms_details = [
+        ("windows", host_info().os.is_windows, constraints_windows),
+        ("linux", host_info().os.is_linux, constraints_linux),
+    ]
+
+    platforms = []
+    for platform_name, is_local_enabled, constraints in platforms_details:
+        if is_re_enabled or is_local_enabled:
+            platforms.append(
+                ExecutionPlatformInfo(
+                    label = name,
+                    configuration = ConfigurationInfo(
+                        constraints = constraints,
+                        values = {},
+                    ),
+                    executor_config = CommandExecutorConfig(
+                        local_enabled = is_local_enabled,
+                        remote_enabled = is_re_enabled,
+                        use_limited_hybrid = True,
+                        remote_execution_properties = {
+                            "OSFamily": platform_name,
+                            "container-image": "docker://" + platform_name + "_build",
+                        },
+                        remote_execution_use_case = "buck2-default",
+                        use_windows_path_separators = platform_name == "windows",
+                    ),
+                )
+            )
+
+    return [
+        DefaultInfo(),
+        ExecutionPlatformRegistrationInfo(platforms = platforms),
+    ]
+
+execution_platform = rule(
+    impl = _execution_platform_impl,
+    attrs = {
+        "os_configuration_windows": attrs.dep(
+            providers = [ConfigurationInfo],
+            default = "config//os:windows",
+        ),
+        "os_configuration_linux": attrs.dep(
+            providers = [ConfigurationInfo],
+            default = "config//os:linux",
+        ),
+    },
+)

--- a/examples/visual_studio/buck2_utils/platforms/defs.bzl
+++ b/examples/visual_studio/buck2_utils/platforms/defs.bzl
@@ -2,7 +2,7 @@ def is_remote_enabled() -> bool:
     re_enabled = read_config("buck2_re_client", "enabled", "false")
     return re_enabled == "true"
 
-def _execution_platform_impl(ctx: AnalysisContext) -> list[Provider]:
+def _execution_platforms_impl(ctx: AnalysisContext) -> list[Provider]:
     is_re_enabled = is_remote_enabled()
 
     name = ctx.label.raw_target()
@@ -46,8 +46,8 @@ def _execution_platform_impl(ctx: AnalysisContext) -> list[Provider]:
         ExecutionPlatformRegistrationInfo(platforms = platforms),
     ]
 
-execution_platform = rule(
-    impl = _execution_platform_impl,
+execution_platforms = rule(
+    impl = _execution_platforms_impl,
     attrs = {
         "os_configuration_windows": attrs.dep(
             providers = [ConfigurationInfo],

--- a/examples/visual_studio/library.hpp
+++ b/examples/visual_studio/library.hpp
@@ -13,6 +13,8 @@
 #else
 #define DLL_API __declspec(dllimport)
 #endif
+#else
+#define DLL_API
 #endif
 
 #ifdef __cplusplus

--- a/examples/visual_studio/toolchains/BUCK
+++ b/examples/visual_studio/toolchains/BUCK
@@ -1,8 +1,30 @@
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains/cxx/clang:tools.bzl", "path_clang_tools")
+load("@prelude//toolchains/msvc:tools.bzl", "find_msvc_tools")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
+load("@root//buck2_utils/platforms:defs.bzl", "is_remote_enabled")
+
+find_msvc_tools(
+    name = "msvc_tools",
+    use_path_compilers = is_remote_enabled(),
+    use_path_linkers = is_remote_enabled() and not host_info().os.is_windows,
+    target_compatible_with = ["config//os:windows"],
+    visibility = ["PUBLIC"],
+)
+
+path_clang_tools(
+    name = "clang_tools",
+    os = "linux",
+    target_compatible_with = ["config//os:linux"],
+    visibility = ["PUBLIC"],
+)
 
 system_cxx_toolchain(
     name = "cxx",
+    compiler = select({
+        "config//os:windows": ":msvc_tools",
+        "config//os:linux": ":clang_tools",
+    }),
     #The flags in the below attributes' Windows config are copied from Visual Studio's project "Console App", with some changes listed in each attribute
     c_flags = select({
         "config//os:linux": [],
@@ -110,12 +132,4 @@ system_cxx_toolchain(
 system_python_bootstrap_toolchain(
     name = "python_bootstrap",
     visibility = ["PUBLIC"],
-)
-
-configuration = read_config("cxx", "configuration", "debug")
-
-platform(
-    name = "default",
-    constraint_values = ["root//buck2_utils/configuration:release"] if configuration == "release" else ["root//buck2_utils/configuration:debug"],
-    deps = ["prelude//platforms:default"],
 )

--- a/examples/visual_studio/toolchains/BUCK
+++ b/examples/visual_studio/toolchains/BUCK
@@ -1,4 +1,4 @@
-load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains:cxx.bzl", "cxx_tools_info_toolchain")
 load("@prelude//toolchains/cxx/clang:tools.bzl", "path_clang_tools")
 load("@prelude//toolchains/msvc:tools.bzl", "find_msvc_tools")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
@@ -18,7 +18,7 @@ path_clang_tools(
     visibility = ["PUBLIC"],
 )
 
-system_cxx_toolchain(
+cxx_tools_info_toolchain(
     name = "cxx",
     cxx_tools_info = select({
         "config//os:windows": ":msvc_tools",

--- a/examples/visual_studio/toolchains/BUCK
+++ b/examples/visual_studio/toolchains/BUCK
@@ -20,7 +20,7 @@ path_clang_tools(
 
 system_cxx_toolchain(
     name = "cxx",
-    toolchain_info = select({
+    cxx_tools_info = select({
         "config//os:windows": ":msvc_tools",
         "config//os:linux": ":clang_tools",
     }),

--- a/examples/visual_studio/toolchains/BUCK
+++ b/examples/visual_studio/toolchains/BUCK
@@ -14,7 +14,6 @@ find_msvc_tools(
 
 path_clang_tools(
     name = "clang_tools",
-    os = "linux",
     target_compatible_with = ["config//os:linux"],
     visibility = ["PUBLIC"],
 )

--- a/examples/visual_studio/toolchains/BUCK
+++ b/examples/visual_studio/toolchains/BUCK
@@ -20,7 +20,7 @@ path_clang_tools(
 
 system_cxx_toolchain(
     name = "cxx",
-    compiler = select({
+    toolchain_info = select({
         "config//os:windows": ":msvc_tools",
         "config//os:linux": ":clang_tools",
     }),

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -77,7 +77,7 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
     """
 
     os = ctx.attrs._target_os_type[OsLookup].platform
-    cxx_tools_info = ctx.attrs.cxx_tools_info[CxxToolsInfo]
+    cxx_tools_info = ctx.attrs._cxx_tools_info[CxxToolsInfo]
     cxx_tools_info = _legacy_equivalent_cxx_tools_info_windows(ctx, cxx_tools_info) if os == "windows" else _legacy_equivalent_cxx_tools_info_non_windows(ctx, cxx_tools_info)
     return _cxx_toolchain_from_cxx_tools_info(ctx, cxx_tools_info)
 
@@ -209,10 +209,7 @@ def _run_info(args):
 system_cxx_toolchain = rule(
     impl = _system_cxx_toolchain_impl,
     attrs = {
-        "cxx_tools_info": attrs.default_only(attrs.exec_dep(providers = [CxxToolsInfo], default = select({
-            "DEFAULT": "prelude//toolchains/cxx/clang:path_clang_tools",
-            "config//os:windows": "prelude//toolchains/msvc:msvc_tools",
-        }))),
+        "_cxx_tools_info": attrs.exec_dep(providers = [CxxToolsInfo], default = "prelude//toolchains/msvc:msvc_tools" if host_info().os.is_windows else "prelude//toolchains/cxx/clang:path_clang_tools"),
         "_target_os_type": buck.target_os_type_arg(),
         "c_flags": attrs.list(attrs.string(), default = []),
         "compiler": attrs.option(attrs.string(), default = None),

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -166,17 +166,13 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
 def _run_info(args):
     return None if args == None else RunInfo(args = [args])
 
-def _get_default_compiler() -> str:
-    os = host_info().os
-    if os.is_windows:
-        return "prelude//toolchains/msvc:msvc_tools"
-    else:
-        return "prelude//toolchains/cxx/clang:path_clang_tools"
-
 system_cxx_toolchain = rule(
     impl = _system_cxx_toolchain_impl,
     attrs = {
-        "compiler": attrs.exec_dep(providers = [SystemCxxToolchainInfo], default = _get_default_compiler()),
+        "compiler": attrs.exec_dep(providers = [SystemCxxToolchainInfo], default = select({
+            "DEFAULT": "prelude//toolchains/cxx/clang:path_clang_tools",
+            "config//os:windows": "prelude//toolchains/msvc:msvc_tools",
+        })),
         "c_flags": attrs.list(attrs.string(), default = []),
         "cpp_dep_tracking_mode": attrs.string(default = "makefile"),
         "cvtres_flags": attrs.list(attrs.string(), default = []),

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -23,7 +23,7 @@ load("@prelude//cxx:linker.bzl", "is_pdb_generated")
 load("@prelude//linking:link_info.bzl", "LinkOrdering", "LinkStyle")
 load("@prelude//linking:lto.bzl", "LtoMode")
 
-NativeCompiler = provider(
+SystemCxxToolchainInfo = provider(
     fields = {
         "compiler": provider_field(typing.Any, default = None),
         "compiler_type": provider_field(typing.Any, default = None),
@@ -45,7 +45,7 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
     A very simple toolchain that is hardcoded to the current environment.
     """
 
-    compiler = ctx.attrs.compiler[NativeCompiler]
+    compiler = ctx.attrs.compiler[SystemCxxToolchainInfo]
 
     archiver_supports_argfiles = compiler.os != "macos"
     additional_linker_flags = ["-fuse-ld=lld"] if compiler.os == "linux" and compiler.linker != "g++" and compiler.cxx_compiler != "g++" else []
@@ -176,7 +176,7 @@ def _get_default_compiler() -> str:
 system_cxx_toolchain = rule(
     impl = _system_cxx_toolchain_impl,
     attrs = {
-        "compiler": attrs.exec_dep(providers = [NativeCompiler], default = _get_default_compiler()),
+        "compiler": attrs.exec_dep(providers = [SystemCxxToolchainInfo], default = _get_default_compiler()),
         "c_flags": attrs.list(attrs.string(), default = []),
         "cpp_dep_tracking_mode": attrs.string(default = "makefile"),
         "cvtres_flags": attrs.list(attrs.string(), default = []),

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -127,6 +127,7 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
                 lto_mode = LtoMode("none"),
                 type = linker_type,
                 link_binaries_locally = True,
+                link_libraries_locally = True,
                 archive_objects_locally = True,
                 use_archiver_flags = True,
                 static_dep_runtime_ld_flags = [],

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -45,12 +45,12 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
     A very simple toolchain that is hardcoded to the current environment.
     """
 
-    compiler = ctx.attrs.compiler[SystemCxxToolchainInfo]
+    toolchain_info = ctx.attrs.toolchain_info[SystemCxxToolchainInfo]
 
-    archiver_supports_argfiles = compiler.os != "macos"
-    additional_linker_flags = ["-fuse-ld=lld"] if compiler.os == "linux" and compiler.linker != "g++" and compiler.cxx_compiler != "g++" else []
+    archiver_supports_argfiles = toolchain_info.os != "macos"
+    additional_linker_flags = ["-fuse-ld=lld"] if toolchain_info.os == "linux" and toolchain_info.linker != "g++" and toolchain_info.cxx_compiler != "g++" else []
 
-    if compiler.os == "windows":
+    if toolchain_info.os == "windows":
         linker_type = "windows"
         binary_extension = "exe"
         object_file_extension = "obj"
@@ -67,14 +67,14 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
         shared_library_name_format = "{}.so"
         shared_library_versioned_name_format = "{}.so.{}"
 
-        if compiler.os == "macos":
+        if toolchain_info.os == "macos":
             linker_type = "darwin"
             pic_behavior = PicBehavior("always_enabled")
         else:
             linker_type = "gnu"
             pic_behavior = PicBehavior("supported")
 
-    if compiler.compiler_type == "clang":
+    if toolchain_info.compiler_type == "clang":
         llvm_link = RunInfo(args = ["llvm-link"])
     else:
         llvm_link = None
@@ -84,11 +84,11 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
         CxxToolchainInfo(
             mk_comp_db = ctx.attrs.make_comp_db,
             linker_info = LinkerInfo(
-                linker = _run_info(compiler.linker),
+                linker = _run_info(toolchain_info.linker),
                 linker_flags = additional_linker_flags + ctx.attrs.link_flags,
                 post_linker_flags = ctx.attrs.post_link_flags,
-                archiver = _run_info(compiler.archiver),
-                archiver_type = compiler.archiver_type,
+                archiver = _run_info(toolchain_info.archiver),
+                archiver_type = toolchain_info.archiver_type,
                 archiver_supports_argfiles = archiver_supports_argfiles,
                 generate_linker_maps = False,
                 lto_mode = LtoMode("none"),
@@ -124,36 +124,36 @@ def _system_cxx_toolchain_impl(ctx: AnalysisContext):
                 bolt_msdk = None,
             ),
             cxx_compiler_info = CxxCompilerInfo(
-                compiler = _run_info(compiler.cxx_compiler),
+                compiler = _run_info(toolchain_info.cxx_compiler),
                 preprocessor_flags = [],
                 compiler_flags = ctx.attrs.cxx_flags,
-                compiler_type = compiler.compiler_type,
+                compiler_type = toolchain_info.compiler_type,
             ),
             c_compiler_info = CCompilerInfo(
-                compiler = _run_info(compiler.compiler),
+                compiler = _run_info(toolchain_info.compiler),
                 preprocessor_flags = [],
                 compiler_flags = ctx.attrs.c_flags,
-                compiler_type = compiler.compiler_type,
+                compiler_type = toolchain_info.compiler_type,
             ),
             as_compiler_info = CCompilerInfo(
-                compiler = _run_info(compiler.compiler),
-                compiler_type = compiler.compiler_type,
+                compiler = _run_info(toolchain_info.compiler),
+                compiler_type = toolchain_info.compiler_type,
             ),
             asm_compiler_info = CCompilerInfo(
-                compiler = _run_info(compiler.asm_compiler),
-                compiler_type = compiler.asm_compiler_type,
+                compiler = _run_info(toolchain_info.asm_compiler),
+                compiler_type = toolchain_info.asm_compiler_type,
             ),
             cvtres_compiler_info = CvtresCompilerInfo(
-                compiler = _run_info(compiler.cvtres_compiler),
+                compiler = _run_info(toolchain_info.cvtres_compiler),
                 preprocessor_flags = [],
                 compiler_flags = ctx.attrs.cvtres_flags,
-                compiler_type = compiler.compiler_type,
+                compiler_type = toolchain_info.compiler_type,
             ),
             rc_compiler_info = RcCompilerInfo(
-                compiler = _run_info(compiler.rc_compiler),
+                compiler = _run_info(toolchain_info.rc_compiler),
                 preprocessor_flags = [],
                 compiler_flags = ctx.attrs.rc_flags,
-                compiler_type = compiler.compiler_type,
+                compiler_type = toolchain_info.compiler_type,
             ),
             header_mode = HeaderMode("symlink_tree_only"),
             cpp_dep_tracking_mode = ctx.attrs.cpp_dep_tracking_mode,
@@ -169,7 +169,7 @@ def _run_info(args):
 system_cxx_toolchain = rule(
     impl = _system_cxx_toolchain_impl,
     attrs = {
-        "compiler": attrs.exec_dep(providers = [SystemCxxToolchainInfo], default = select({
+        "toolchain_info": attrs.exec_dep(providers = [SystemCxxToolchainInfo], default = select({
             "DEFAULT": "prelude//toolchains/cxx/clang:path_clang_tools",
             "config//os:windows": "prelude//toolchains/msvc:msvc_tools",
         })),

--- a/prelude/toolchains/cxx/clang/BUCK
+++ b/prelude/toolchains/cxx/clang/BUCK
@@ -1,4 +1,9 @@
 load(":tools.bzl", "path_clang_tools")
+load("@prelude//utils:source_listing.bzl", "source_listing")
+
+oncall("build_infra")
+
+source_listing()
 
 path_clang_tools(
     name = "path_clang_tools",

--- a/prelude/toolchains/cxx/clang/BUCK
+++ b/prelude/toolchains/cxx/clang/BUCK
@@ -1,0 +1,6 @@
+load(":tools.bzl", "path_clang_tools")
+
+path_clang_tools(
+    name = "path_clang_tools",
+    visibility = ["PUBLIC"],
+)

--- a/prelude/toolchains/cxx/clang/tools.bzl
+++ b/prelude/toolchains/cxx/clang/tools.bzl
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+load("@prelude//toolchains:cxx.bzl", "NativeCompiler")
+
+def _get_current_os() -> str:
+    os = host_info().os
+    if os.is_macos:
+        return "macos"
+    elif os.is_windows:
+        return "windows"
+    else:
+        return "linux"
+
+def _path_clang_tools_impl(ctx: AnalysisContext) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        NativeCompiler(
+            compiler = "clang",
+            compiler_type = "clang",
+            cxx_compiler = "clang++",
+            asm_compiler = "clang",
+            asm_compiler_type = "clang",
+            rc_compiler = None,
+            cvtres_compiler = None,
+            archiver = "ar",
+            archiver_type = "gnu",
+            linker = "clang++",
+            linker_type = "gnu",
+            os = ctx.attrs.os
+        ),
+    ]
+
+path_clang_tools = rule(
+    impl = _path_clang_tools_impl,
+    attrs = {
+        "os": attrs.string(default = _get_current_os()),
+    },
+)

--- a/prelude/toolchains/cxx/clang/tools.bzl
+++ b/prelude/toolchains/cxx/clang/tools.bzl
@@ -5,11 +5,9 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@prelude//decls/common.bzl", "buck")
-load("@prelude//os_lookup:defs.bzl", "OsLookup")
 load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 
-def _path_clang_tools_impl(ctx: AnalysisContext) -> list[Provider]:
+def _path_clang_tools_impl(_ctx) -> list[Provider]:
     return [
         DefaultInfo(),
         CxxToolsInfo(
@@ -24,13 +22,10 @@ def _path_clang_tools_impl(ctx: AnalysisContext) -> list[Provider]:
             archiver_type = "gnu",
             linker = "clang++",
             linker_type = "gnu",
-            os = ctx.attrs._target_os_type[OsLookup].platform,
         ),
     ]
 
 path_clang_tools = rule(
     impl = _path_clang_tools_impl,
-    attrs = {
-        "_target_os_type": buck.target_os_type_arg(),
-    }
+    attrs = {},
 )

--- a/prelude/toolchains/cxx/clang/tools.bzl
+++ b/prelude/toolchains/cxx/clang/tools.bzl
@@ -5,16 +5,9 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//decls/common.bzl", "buck")
+load("@prelude//os_lookup:defs.bzl", "OsLookup")
 load("@prelude//toolchains:cxx.bzl", "SystemCxxToolchainInfo")
-
-def _get_current_os() -> str:
-    os = host_info().os
-    if os.is_macos:
-        return "macos"
-    elif os.is_windows:
-        return "windows"
-    else:
-        return "linux"
 
 def _path_clang_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     return [
@@ -31,13 +24,13 @@ def _path_clang_tools_impl(ctx: AnalysisContext) -> list[Provider]:
             archiver_type = "gnu",
             linker = "clang++",
             linker_type = "gnu",
-            os = ctx.attrs.os
+            os = ctx.attrs._target_os_type[OsLookup].platform,
         ),
     ]
 
 path_clang_tools = rule(
     impl = _path_clang_tools_impl,
     attrs = {
-        "os": attrs.string(default = _get_current_os()),
-    },
+        "_target_os_type": buck.target_os_type_arg(),
+    }
 )

--- a/prelude/toolchains/cxx/clang/tools.bzl
+++ b/prelude/toolchains/cxx/clang/tools.bzl
@@ -5,7 +5,7 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@prelude//toolchains:cxx.bzl", "NativeCompiler")
+load("@prelude//toolchains:cxx.bzl", "SystemCxxToolchainInfo")
 
 def _get_current_os() -> str:
     os = host_info().os
@@ -19,7 +19,7 @@ def _get_current_os() -> str:
 def _path_clang_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     return [
         DefaultInfo(),
-        NativeCompiler(
+        SystemCxxToolchainInfo(
             compiler = "clang",
             compiler_type = "clang",
             cxx_compiler = "clang++",

--- a/prelude/toolchains/cxx/clang/tools.bzl
+++ b/prelude/toolchains/cxx/clang/tools.bzl
@@ -7,12 +7,12 @@
 
 load("@prelude//decls/common.bzl", "buck")
 load("@prelude//os_lookup:defs.bzl", "OsLookup")
-load("@prelude//toolchains:cxx.bzl", "SystemCxxToolchainInfo")
+load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 
 def _path_clang_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     return [
         DefaultInfo(),
-        SystemCxxToolchainInfo(
+        CxxToolsInfo(
             compiler = "clang",
             compiler_type = "clang",
             cxx_compiler = "clang++",

--- a/prelude/toolchains/msvc/BUCK.v2
+++ b/prelude/toolchains/msvc/BUCK.v2
@@ -8,16 +8,17 @@ source_listing()
 python_bootstrap_binary(
     name = "vswhere",
     main = "vswhere.py",
-    visibility = [],
+    visibility = ["PUBLIC"],
 )
 
 python_bootstrap_binary(
     name = "run_msvc_tool",
     main = "run_msvc_tool.py",
-    visibility = [],
+    visibility = ["PUBLIC"],
 )
 
 find_msvc_tools(
     name = "msvc_tools",
+    target_compatible_with = ["config//os:windows"],
     visibility = ["PUBLIC"],
 )

--- a/prelude/toolchains/msvc/tools.bzl
+++ b/prelude/toolchains/msvc/tools.bzl
@@ -134,7 +134,6 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
             archiver_type = "windows",
             linker = _windows_linker_wrapper(ctx, link_exe_script),
             linker_type = "windows",
-            os = "windows",
         ),
     ]
 

--- a/prelude/toolchains/msvc/tools.bzl
+++ b/prelude/toolchains/msvc/tools.bzl
@@ -6,7 +6,7 @@
 # of this source tree.
 
 load("@prelude//utils:cmd_script.bzl", "ScriptOs", "cmd_script")
-load("@prelude//toolchains:cxx.bzl", "NativeCompiler")
+load("@prelude//toolchains:cxx.bzl", "SystemCxxToolchainInfo")
 
 def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     cl_exe_json = ctx.actions.declare_output("cl.exe.json")
@@ -122,7 +122,7 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
                 }),
             ],
         }),
-        NativeCompiler(
+        SystemCxxToolchainInfo(
             compiler = cl_exe_script,
             compiler_type = "windows",
             cxx_compiler = cl_exe_script,

--- a/prelude/toolchains/msvc/tools.bzl
+++ b/prelude/toolchains/msvc/tools.bzl
@@ -6,24 +6,7 @@
 # of this source tree.
 
 load("@prelude//utils:cmd_script.bzl", "ScriptOs", "cmd_script")
-
-VisualStudio = provider(
-    # @unsorted-dict-items
-    fields = {
-        # cl.exe
-        "cl_exe": provider_field(typing.Any, default = None),
-        # cvtres.exe
-        "cvtres_exe": provider_field(typing.Any, default = None),
-        # lib.exe
-        "lib_exe": provider_field(typing.Any, default = None),
-        # ml64.exe
-        "ml64_exe": provider_field(typing.Any, default = None),
-        # link.exe
-        "link_exe": provider_field(typing.Any, default = None),
-        # rc.exe
-        "rc_exe": provider_field(typing.Any, default = None),
-    },
-)
+load("@prelude//toolchains:cxx.bzl", "NativeCompiler")
 
 def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     cl_exe_json = ctx.actions.declare_output("cl.exe.json")
@@ -50,42 +33,53 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     )
 
     run_msvc_tool = ctx.attrs.run_msvc_tool[RunInfo]
-    cl_exe_script = cmd_script(
-        ctx = ctx,
-        name = "cl",
-        cmd = cmd_args(run_msvc_tool, cl_exe_json),
-        os = ScriptOs("windows"),
-    )
-    cvtres_exe_script = cmd_script(
-        ctx = ctx,
-        name = "cvtres",
-        cmd = cmd_args(run_msvc_tool, cvtres_exe_json),
-        os = ScriptOs("windows"),
-    )
-    lib_exe_script = cmd_script(
-        ctx = ctx,
-        name = "lib",
-        cmd = cmd_args(run_msvc_tool, lib_exe_json),
-        os = ScriptOs("windows"),
-    )
-    ml64_exe_script = cmd_script(
-        ctx = ctx,
-        name = "ml64",
-        cmd = cmd_args(run_msvc_tool, ml64_exe_json),
-        os = ScriptOs("windows"),
-    )
-    link_exe_script = cmd_script(
-        ctx = ctx,
-        name = "link",
-        cmd = cmd_args(run_msvc_tool, link_exe_json),
-        os = ScriptOs("windows"),
-    )
-    rc_exe_script = cmd_script(
-        ctx = ctx,
-        name = "rc",
-        cmd = cmd_args(run_msvc_tool, rc_exe_json),
-        os = ScriptOs("windows"),
-    )
+    if ctx.attrs.use_path_compilers:
+        cl_exe_script = "cl.exe"
+        ml64_exe_script = "ml64.exe"
+        rc_exe_script = "rc.exe"
+        cvtres_exe_script = "cvtres.exe"
+    else:
+        cl_exe_script = cmd_script(
+            ctx = ctx,
+            name = "cl",
+            cmd = cmd_args(run_msvc_tool, cl_exe_json),
+            os = ScriptOs("windows"),
+        )
+        cvtres_exe_script = cmd_script(
+            ctx = ctx,
+            name = "cvtres",
+            cmd = cmd_args(run_msvc_tool, cvtres_exe_json),
+            os = ScriptOs("windows"),
+        )
+        ml64_exe_script = cmd_script(
+            ctx = ctx,
+            name = "ml64",
+            cmd = cmd_args(run_msvc_tool, ml64_exe_json),
+            os = ScriptOs("windows"),
+        )
+        rc_exe_script = cmd_script(
+            ctx = ctx,
+            name = "rc",
+            cmd = cmd_args(run_msvc_tool, rc_exe_json),
+            os = ScriptOs("windows"),
+        )
+
+    if ctx.attrs.use_path_linkers:
+        lib_exe_script = "lib.exe"
+        link_exe_script = "link.exe"
+    else:
+        lib_exe_script = cmd_script(
+            ctx = ctx,
+            name = "lib",
+            cmd = cmd_args(run_msvc_tool, lib_exe_json),
+            os = ScriptOs("windows"),
+        )
+        link_exe_script = cmd_script(
+            ctx = ctx,
+            name = "link",
+            cmd = cmd_args(run_msvc_tool, link_exe_json),
+            os = ScriptOs("windows"),
+        )
 
     return [
         # Supports `buck2 run prelude//toolchains/msvc:msvc_tools[cl.exe]`
@@ -128,20 +122,52 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
                 }),
             ],
         }),
-        VisualStudio(
-            cl_exe = cl_exe_script,
-            cvtres_exe = cvtres_exe_script,
-            lib_exe = lib_exe_script,
-            ml64_exe = ml64_exe_script,
-            link_exe = link_exe_script,
-            rc_exe = rc_exe_script,
+        NativeCompiler(
+            compiler = cl_exe_script,
+            compiler_type = "windows",
+            cxx_compiler = cl_exe_script,
+            asm_compiler = ml64_exe_script,
+            asm_compiler_type = "windows_ml64",
+            rc_compiler = rc_exe_script,
+            cvtres_compiler = cvtres_exe_script,
+            archiver = lib_exe_script,
+            archiver_type = "windows",
+            linker = _windows_linker_wrapper(ctx, link_exe_script),
+            linker_type = "windows",
+            os = "windows",
         ),
     ]
+
+def _windows_linker_wrapper(ctx: AnalysisContext, linker: [cmd_args, str]) -> cmd_args:
+    # Linkers pretty much all support @file.txt argument syntax to insert
+    # arguments from the given text file, usually formatted one argument per
+    # line.
+    #
+    # - GNU ld: https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
+    # - lld is command line compatible with GNU ld
+    # - MSVC link.exe: https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#link-command-files
+    #
+    # However, there is inconsistency in whether they support nesting of @file
+    # arguments inside of another @file.
+    #
+    # We wrap the linker to flatten @file arguments down to 1 level of nesting.
+    return cmd_script(
+        ctx = ctx,
+        name = "windows_linker",
+        cmd = cmd_args(
+            ctx.attrs.linker_wrapper[RunInfo],
+            linker,
+        ),
+        os = ScriptOs("windows"),
+    )
 
 find_msvc_tools = rule(
     impl = _find_msvc_tools_impl,
     attrs = {
         "run_msvc_tool": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//toolchains/msvc:run_msvc_tool")),
         "vswhere": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//toolchains/msvc:vswhere")),
+        "linker_wrapper": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//cxx/tools:linker_wrapper")),
+        "use_path_compilers": attrs.bool(default = False),
+        "use_path_linkers": attrs.bool(default = False),
     },
 )

--- a/prelude/toolchains/msvc/tools.bzl
+++ b/prelude/toolchains/msvc/tools.bzl
@@ -6,7 +6,7 @@
 # of this source tree.
 
 load("@prelude//utils:cmd_script.bzl", "ScriptOs", "cmd_script")
-load("@prelude//toolchains:cxx.bzl", "SystemCxxToolchainInfo")
+load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 
 def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
     cl_exe_json = ctx.actions.declare_output("cl.exe.json")
@@ -122,7 +122,7 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
                 }),
             ],
         }),
-        SystemCxxToolchainInfo(
+        CxxToolsInfo(
             compiler = cl_exe_script,
             compiler_type = "windows",
             cxx_compiler = cl_exe_script,


### PR DESCRIPTION
As mentioned in #612, I have a C++ project that can be built for either Linux or Windows, without any cross-compilation so Linux and Windows are also the two execution platforms. Since there is remote execution, I wanted to be able to build for Linux from my Windows machine using RE, and vice versa.

From the response I got in the above issue, I need to add an `exec_dep` to the toolchain, pointing a compiler target, that then has a `target_compatible_with` with the execution platform the compiler can run on.

I tried to add the `target_compatible_with` directly to the toolchain but it didn't work, probably intentional.

So I moved some parts of the current system_cxx_toolchain to a separate `NativeCompiler` provider that is then returned by some rules defining a compiler. This compiler target then has the `target_compatible_with` attribute.

Can this be merged or should I just have this toolchain in my own repository? It seems useful for everyone, the only disadvantage I can see being that it is not fully backwards compatible. Hopefully I didn't completely misunderstand how execution platforms are supposed to be used.

I improved the Visual Studio example to use this new updated toolchain to easily support remote execution.

## Manual testing

I used the Visual Studio example and setup my RE workers with Buildbarn. Unfortunately Buildbarn's Windows workers don't currently work with the linking step, I haven't investigated why. The build targeting Windows made from a Windows host works because the linking is done locally but the one done from a Linux host fails.

### Local builds
#### Windows
```
buck2 build --target-platforms //buck2_utils/platforms:windows_debug :main
```
Passes
#### Linux
```
buck2 build --target-platforms //buck2_utils/platforms:linux_debug :main
```
Passes

### Remote builds
#### From Windows
##### Target Windows
```
buck2 build --no-remote-cache -c buck2_re_client.enabled=true --target-platforms //buck2_utils/platforms:windows_debug :main
```
Passes
##### Target Linux
```
buck2 build --no-remote-cache -c buck2_re_client.enabled=true --target-platforms //buck2_utils/platforms:linux_debug :main
```
Passes

#### From Linux
##### Target Windows
```
buck2 build --no-remote-cache -c buck2_re_client.enabled=true --target-platforms //buck2_utils/platforms:windows_debug :main
```
Linking fails (The system cannot open the device or file specified.)
##### Target Linux
```
buck2 build --no-remote-cache -c buck2_re_client.enabled=true --target-platforms //buck2_utils/platforms:linux_debug :main
```
Passes