### PR TITLE
Add windows-specific call for OS version

### DIFF
--- a/app/buck2_events/BUCK
+++ b/app/buck2_events/BUCK
@@ -8,6 +8,20 @@ rust_library(
     srcs = glob(
         ["src/**/*.rs"],
     ),
+    os_deps = [
+        (
+            "windows",
+            ["fbsource//third-party/rust:winver"],
+        ),
+        (
+            "linux",
+            ["fbsource//third-party/rust:sys-info"],
+        ),
+        (
+            "macos",
+            ["fbsource//third-party/rust:sys-info"],
+        ),
+    ],
     test_deps = ["fbsource//third-party/rust:tokio"],
     deps = [
         "fbsource//third-party/rust:anyhow",
@@ -22,7 +36,6 @@ rust_library(
         "fbsource//third-party/rust:serde",
         # @oss-disable: "fbsource//third-party/rust:serde_json", 
         "fbsource//third-party/rust:smallvec",
-        "fbsource//third-party/rust:sys-info",
         "fbsource//third-party/rust:tokio",
         "fbsource//third-party/rust:uuid",
         "//buck2/allocative/allocative:allocative",

--- a/app/buck2_events/Cargo.toml
+++ b/app/buck2_events/Cargo.toml
@@ -32,3 +32,6 @@ buck2_data = { workspace = true }
 buck2_error = { workspace = true }
 buck2_util = { workspace = true }
 buck2_wrapper_common = { workspace = true }
+
+[target."cfg(windows)".dependencies]
+winver = "1"


### PR DESCRIPTION
Summary:
Right now, we rely on the sys_info library to get the OS version.

However, that functionality is broken for Windows: https://github.com/FillZpp/sys-info-rs/issues/86
Specifically, it produces `6.2.9200` for all versions across Windows: https://fburl.com/scuba/buck2_builds/iq6hsudp

This diff swaps the check to use the winver library, which has much better
support for fetching the Windows version.

Reviewed By: JakobDegen

Differential Revision: D56546196
