### PR TITLE
Fix third-party/rust/Cargo.toml

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -215,6 +215,7 @@ walkdir = "2.3.2"
 which = "4.3.0"
 windows_x86_64_msvc = "=0.48.0"  # our fixup only works if we are on precisely 0.48.0
 winapi = { version = "0.3", features = ["everything"] }
+winver = "1"
 xattr = "0.2.2"
 zip = "0.5"
 zstd = "0.13.0"


### PR DESCRIPTION
Summary:
It looks like D56546196 was incomplete. D56546196 added a new
dependency, but didn't account for the case where the outside world
tries to build buck2.

This diff fixes that.

Differential Revision: D56765969
