### PR TITLE
Fix third-party/rust/Cargo.toml

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -223,3 +223,7 @@ zstd = "0.13.0"
 # For https://github.com/jimblandy/perf-event/pull/29
 perf-event = { git = "https://github.com/krallin/perf-event.git", rev = "86224a9bc025d5d19f719542f27c8c629a08b167", version = "0.4" }
 perf-event-open-sys = { git = "https://github.com/krallin/perf-event.git", rev = "86224a9bc025d5d19f719542f27c8c629a08b167", version = "4.0" }
+
+# Windows-specific dependencies
+[target."cfg(windows)".dependencies]
+winver = "1"


### PR DESCRIPTION
Summary:
It looks like D56546196 was incomplete. D56546196 added a new
dependency, but didn't account for the case where the outside world
tries to build buck2.

This diff fixes that.

Differential Revision: D56766826
