### PR TITLE
Update vswhere.py

### DIFF
--- a/prelude/toolchains/msvc/vswhere.py
+++ b/prelude/toolchains/msvc/vswhere.py
@@ -309,7 +309,7 @@ def main():
         cl_exe, cvtres_exe, lib_exe, ml64_exe, link_exe = (
             find_in_path(exe) for exe in VC_EXE_NAMES
         )
-        rc_exe = find_in_path("rc.exe", optional=True)
+        rc_exe = find_in_path("rc.exe", is_optional=True)
     elif "EWDKDIR" in os.environ:
         cl_exe, cvtres_exe, lib_exe, ml64_exe, link_exe, rc_exe = find_with_ewdk(
             Path(os.environ["EWDKDIR"])


### PR DESCRIPTION
Fixes the following error that I encountered:
```
Action failed: prelude//toolchains/msvc:msvc_tools (vswhere)
Local command returned non-zero exit code 1
Reproduce locally: `env -- "BUCK_SCRATCH_PATH=buck-out\\v2\\tmp\\prelude\\5540ca4c71e1230f\\toolchains\\msvc\\__msvc_too ...<omitted>... " "--rc=buck-out\\v2\\gen\\prelude\\5540ca4c71e1230f\\toolchains\\msvc\\__msvc_tools__\\rc.exe.json" (run `buck2 log what-failed` to get the full command)`
stdout:
stderr:
Traceback (most recent call last):
  File "C:\Users\mstephan\source\buck2-test\buck-out\v2\gen\prelude\5540ca4c71e1230f\toolchains\msvc\__vswhere__\vswhere.py", line 331, in <module>
    main()
  File "C:\Users\mstephan\source\buck2-test\buck-out\v2\gen\prelude\5540ca4c71e1230f\toolchains\msvc\__vswhere__\vswhere.py", line 312, in main
    rc_exe = find_in_path("rc.exe", optional=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: find_in_path() got an unexpected keyword argument 'optional'
```