### PR TITLE
Separate max file size and decoding size handling in oss re client

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -266,6 +266,8 @@ pub struct Buck2OssReConfiguration {
     pub use_fbcode_metadata: bool,
     /// The max size for a GRPC message to be decoded.
     pub max_decoding_message_size: Option<usize>,
+    /// The max cumulative blob size for `Read` and `BatchReadBlobs` methods.
+    pub max_total_file_size: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -357,6 +359,10 @@ impl Buck2OssReConfiguration {
             max_decoding_message_size: legacy_config .parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_decoding_message_size",
+            })?,
+            max_total_file_size: legacy_config .parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "max_total_file_size",
             })?,
         })
     }

--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -356,11 +356,11 @@ impl Buck2OssReConfiguration {
                     property: "use_fbcode_metadata",
                 })?
                 .unwrap_or(true),
-            max_decoding_message_size: legacy_config .parse(BuckconfigKeyRef {
+            max_decoding_message_size: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_decoding_message_size",
             })?,
-            max_total_file_size: legacy_config .parse(BuckconfigKeyRef {
+            max_total_file_size: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_total_file_size",
             })?,

--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -264,6 +264,8 @@ pub struct Buck2OssReConfiguration {
     pub instance_name: Option<String>,
     /// Use the Meta version of the request metadata
     pub use_fbcode_metadata: bool,
+    /// The max size for a GRPC message to be decoded.
+    pub max_decoding_message_size: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -352,6 +354,10 @@ impl Buck2OssReConfiguration {
                     property: "use_fbcode_metadata",
                 })?
                 .unwrap_or(true),
+            max_decoding_message_size: legacy_config .parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "max_decoding_message_size",
+            })?,
         })
     }
 }

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -280,6 +280,10 @@ impl REClientBuilder {
             interceptor.dupe(),
         );
 
+        if let Some(max_decoding_message_size) = opts.max_decoding_message_size {
+            capabilities_client = capabilities_client.max_decoding_message_size(max_decoding_message_size);
+        }
+
         let instance_name = InstanceName(opts.instance_name.clone());
 
         let capabilities = if opts.capabilities.unwrap_or(true) {
@@ -295,7 +299,8 @@ impl REClientBuilder {
             return Err(anyhow::anyhow!("Server has remote execution disabled."));
         }
 
-        let max_decoding_msg_size = std::cmp::max(DEFAULT_MAX_MSG_SIZE, capabilities.max_msg_size * 3);
+        let max_decoding_msg_size = opts.max_decoding_message_size
+            .unwrap_or(capabilities.max_msg_size * 2);
 
         let grpc_clients = GRPCClients {
             cas_client: ContentAddressableStorageClient::with_interceptor(


### PR DESCRIPTION
Before it was possible to set a total file size for all the RE's IO API that exceed tonic's default max-decoding size of 4MB. Matter of fact, because the default limit is 4MB for both this happened by default with files of comulative size close to or equal to the limit. Example:

```
genrule(
    name = "large_download",
    out = "out.txt",
    cmd = "dd if=/dev/zero of=$OUT bs=4M count=1",
)
```

PS: Please be nice, this is my first time contribution both here and in rust :)