### PR TITLE
Remove arbitrary concurrency limiter for uplods and replace with a configurable limit that is disabled by default.

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -264,6 +264,8 @@ pub struct Buck2OssReConfiguration {
     pub instance_name: Option<String>,
     /// Use the Meta version of the request metadata
     pub use_fbcode_metadata: bool,
+    /// Maximum number of concurrent upload requests.
+    pub max_concurrent_uploads: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -352,6 +354,10 @@ impl Buck2OssReConfiguration {
                     property: "use_fbcode_metadata",
                 })?
                 .unwrap_or(true),
+            max_concurrent_uploads: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "max_concurrent_uploads",
+            })?,
         })
     }
 }


### PR DESCRIPTION
The existing limit doesn't really help to achieve the goals it states as it cannot help in conditions where multiple clients are using RE at the same time, which are the common exercise conditions. Since the flag can be used to limit quickly uploads in case of some issues with RBE I opten in for keeping it in some form, by making it a setting, though it likely isn't very useful, so it's disabled by default. Instead we should rely on other control mechanisms like number of connections and TCP or HTTP/2 flow control or, like in this case, explicit errors coming from the RE protocol itself (like `RESOURCE_EXHAUSTED` or others). 