### PR TITLE
Add option to enable f-strings

### DIFF
--- a/app/buck2_interpreter/src/file_type.rs
+++ b/app/buck2_interpreter/src/file_type.rs
@@ -21,7 +21,7 @@ pub enum StarlarkFileType {
 
 /// What type of file are we parsing - a `.bzl` file, `.bxl` file, or a `BUCK`/`TARGETS` file.
 impl StarlarkFileType {
-    pub fn dialect(&self, disable_starlark_types: bool) -> Dialect {
+    pub fn dialect(&self, disable_starlark_types: bool, enable_f_strings: bool) -> Dialect {
         let buck_dialect: Dialect = Dialect {
             enable_def: false,
             enable_lambda: true,
@@ -30,6 +30,7 @@ impl StarlarkFileType {
             enable_types: DialectTypes::Disable,
             enable_load_reexport: false,
             enable_top_level_stmt: false,
+            enable_f_strings,
             ..Dialect::Standard
         };
         let package_dialect: Dialect = Dialect {
@@ -40,6 +41,7 @@ impl StarlarkFileType {
             enable_types: DialectTypes::Disable,
             enable_load_reexport: false,
             enable_top_level_stmt: false,
+            enable_f_strings,
             ..Dialect::Standard
         };
         let bzl_dialect: Dialect = Dialect {
@@ -54,6 +56,7 @@ impl StarlarkFileType {
             },
             enable_load_reexport: false,
             enable_top_level_stmt: true,
+            enable_f_strings,
             ..Dialect::Standard
         };
         let bxl_dialect: Dialect = Dialect {
@@ -68,6 +71,7 @@ impl StarlarkFileType {
             },
             enable_load_reexport: false,
             enable_top_level_stmt: true,
+            enable_f_strings,
             ..Dialect::Standard
         };
 

--- a/app/buck2_interpreter_for_build/src/interpreter/global_interpreter_state.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/global_interpreter_state.rs
@@ -125,7 +125,7 @@ impl HasGlobalInterpreterState for DiceComputations<'_> {
                         },
                     )
                     .await?
-                    .unwrap_or_else(|| false);
+                    .unwrap_or(true);
 
                 Ok(GisValue(Arc::new(GlobalInterpreterState::new(
                     cell_resolver,

--- a/app/buck2_interpreter_for_build/src/interpreter/interpreter_for_cell.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/interpreter_for_cell.rs
@@ -441,7 +441,9 @@ impl InterpreterForCell {
         let ast = match AstModule::parse(
             project_relative_path.as_str(),
             content,
-            &import.file_type().dialect(disable_starlark_types),
+            &import
+                .file_type()
+                .dialect(disable_starlark_types, self.global_state.enable_f_strings),
         ) {
             Ok(ast) => ast,
             Err(e) => {

--- a/app/buck2_interpreter_for_build/src/interpreter/testing.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/testing.rs
@@ -205,7 +205,7 @@ impl Tester {
                 )?,
                 false,
                 true,
-                false,
+                true,
             )?),
             Arc::new(import_paths),
         )?))

--- a/app/buck2_interpreter_for_build/src/interpreter/testing.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/testing.rs
@@ -205,6 +205,7 @@ impl Tester {
                 )?,
                 false,
                 true,
+                false,
             )?),
             Arc::new(import_paths),
         )?))

--- a/app/buck2_starlark/src/lint.rs
+++ b/app/buck2_starlark/src/lint.rs
@@ -86,7 +86,7 @@ async fn lint_file(
     io: &dyn IoProvider,
     cache: &mut Cache<'_>,
 ) -> anyhow::Result<Vec<Lint>> {
-    let dialect = path.file_type().dialect(false);
+    let dialect = path.file_type().dialect(false, true);
     let proj_path = cell_resolver.resolve_path(path.path().as_ref().as_ref())?;
     let path_str = proj_path.to_string();
     let content = io


### PR DESCRIPTION
This adds `starlark_enable_f_strings` property in `buck2` section. We want to keep it behind a flag for now because some internal tool at facebook doesn't support f-strings yet.
fix #647