### PR TITLE
Bug: output paths/files/dirs and env variables in a RE Command are not sorted

### DIFF
--- a/app/buck2_execute/src/execute/command_executor.rs
+++ b/app/buck2_execute/src/execute/command_executor.rs
@@ -281,6 +281,12 @@ fn re_create_action(
         action_and_blobs.add_paths(digest, data);
     }
 
+    command.output_directories.sort();
+    command.output_files.sort();
+    command.output_paths.sort();
+    command.output_node_properties.sort();
+    command.environment_variables.sort_by(|e1, e2| e1.name.cmp(&e2.name));
+
     let mut action = RE::Action {
         input_root_digest: Some(input_digest.to_grpc()),
         command_digest: Some(action_and_blobs.add_command(&command).to_grpc()),


### PR DESCRIPTION
Ensure that the following properties in a RE `Command` are ordered as per the [spec](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto):

- [output_directories](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L634)
- [output_files](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L616)
- [output_paths](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L667)
- [output_node_properties](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L698)
- [environment_variables](https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L588) 

The idea of enforcing this constraint in RE is to ensure predictable generation of an action/command digest which helps in caching.