### PR TITLE
Improve Remote Execution failure diagnostics

### DIFF
--- a/app/buck2_build_api/src/actions/calculation.rs
+++ b/app/buck2_build_api/src/actions/calculation.rs
@@ -559,5 +559,6 @@ pub async fn command_details(
         command_kind,
         signed_exit_code,
         metadata: Some(command.timing.to_proto()),
+        additional_message: command.additional_message.clone(),
     }
 }

--- a/app/buck2_build_api_tests/src/actions/calculation.rs
+++ b/app/buck2_build_api_tests/src/actions/calculation.rs
@@ -531,6 +531,7 @@ async fn test_command_details_omission() {
             stderr: "stderr".to_owned().into_bytes(),
         },
         exit_code: Some(1),
+        additional_message: None,
     };
 
     let proto = command_details(&report, false).await;

--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -797,15 +797,21 @@ fn lines_for_command_details(
                 )]));
             }
             Some(Command::RemoteCommand(remote_command)) => {
-                if !buck2_core::is_open_source() {
-                    lines.push(Line::from_iter([Span::new_styled_lossy(
-                        format!(
-                            "Reproduce locally: `frecli cas download-action {}`",
-                            remote_command.action_digest
-                        )
-                        .with(Color::DarkRed),
-                    )]));
-                }
+                let help_message = if buck2_core::is_open_source() {
+                    format!(
+                        "Remote action digest: '{}'",
+                        remote_command.action_digest
+                    )
+                } else {
+                    format!(
+                        "Reproduce locally: `frecli cas download-action {}`",
+                        remote_command.action_digest
+                    )
+                };
+
+                lines.push(Line::from_iter([Span::new_styled_lossy(
+                    help_message.with(Color::DarkRed),
+                )]));
             }
             Some(Command::OmittedLocalCommand(..)) | None => {
                 // Nothing to show in this case.

--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -871,6 +871,16 @@ fn lines_for_command_details(
             .attribute(Attribute::Bold),
     )]));
     lines.extend(Lines::from_colored_multiline_string(&command_failed.stderr));
+
+    if let Some(ref additional_message) = command_failed.additional_message {
+        lines.push(Line::from_iter([Span::new_styled_lossy(
+            "info:"
+                .to_owned()
+                .with(Color::DarkRed)
+                .attribute(Attribute::Bold),
+        )]));
+        lines.extend(Lines::from_colored_multiline_string(&additional_message));
+    }
 }
 
 // Truncates a string to a reasonable number characters, or returns None if it doesn't need truncating.

--- a/app/buck2_data/data.proto
+++ b/app/buck2_data/data.proto
@@ -1025,6 +1025,7 @@ message CommandExecutionDetails {
 
   CommandExecutionKind command_kind = 5;
   CommandExecutionMetadata metadata = 13;
+  optional string additional_message = 14;
 }
 
 message CommandExecutionKind {

--- a/app/buck2_event_observer/src/display.rs
+++ b/app/buck2_event_observer/src/display.rs
@@ -662,6 +662,10 @@ impl<'a> ActionErrorDisplay<'a> {
         append_stream("Stdout", &command_failed.stdout);
         append_stream("Stderr", &command_failed.stderr);
 
+        if let Some(ref additional_info) = command_failed.additional_message {
+            append_stream("Info", additional_info);
+        }
+
         if let Some(error_diagnostics) = self.error_diagnostics {
             match error_diagnostics.data.as_ref().unwrap() {
                 buck2_data::action_error_diagnostics::Data::SubErrors(sub_errors) => {

--- a/app/buck2_event_observer/src/display.rs
+++ b/app/buck2_event_observer/src/display.rs
@@ -626,7 +626,12 @@ impl<'a> ActionErrorDisplay<'a> {
                     );
                 }
                 Some(Command::RemoteCommand(remote_command)) => {
-                    if !buck2_core::is_open_source() {
+                    if buck2_core::is_open_source() {
+                        append!(
+                            "Remote action digest: '{}'",
+                            remote_command.action_digest
+                        );
+                    } else {
                         append!(
                             "Remote action{}, reproduce with: `frecli cas download-action {}`",
                             if remote_command.cache_hit {

--- a/app/buck2_execute/src/execute/manager.rs
+++ b/app/buck2_execute/src/execute/manager.rs
@@ -34,6 +34,7 @@ trait CommandExecutionManagerLike: Sized {
         std_streams: CommandStdStreams,
         exit_code: Option<i32>,
         timing: CommandExecutionMetadata,
+        additional_message: Option<String>,
     ) -> CommandExecutionResult;
 
     fn execution_kind(&self) -> Option<CommandExecutionKind>;
@@ -86,6 +87,7 @@ impl CommandExecutionManager {
             Default::default(),
             None,
             CommandExecutionMetadata::default(),
+            None,
         )
     }
 
@@ -111,6 +113,7 @@ impl CommandExecutionManagerLike for CommandExecutionManager {
         std_streams: CommandStdStreams,
         exit_code: Option<i32>,
         timing: CommandExecutionMetadata,
+        additional_message: Option<String>,
     ) -> CommandExecutionResult {
         CommandExecutionResult {
             outputs,
@@ -120,6 +123,7 @@ impl CommandExecutionManagerLike for CommandExecutionManager {
                 timing,
                 std_streams,
                 exit_code,
+                additional_message,
             },
             rejected_execution: None,
             did_cache_upload: false,
@@ -160,6 +164,7 @@ impl CommandExecutionManagerWithClaim {
             std_streams,
             Some(0),
             timing,
+            None,
         )
     }
 
@@ -170,6 +175,7 @@ impl CommandExecutionManagerWithClaim {
             Default::default(),
             None,
             CommandExecutionMetadata::default(),
+            None,
         )
     }
 
@@ -187,6 +193,7 @@ impl CommandExecutionManagerLike for CommandExecutionManagerWithClaim {
         std_streams: CommandStdStreams,
         exit_code: Option<i32>,
         timing: CommandExecutionMetadata,
+        additional_message: Option<String>,
     ) -> CommandExecutionResult {
         CommandExecutionResult {
             outputs,
@@ -196,6 +203,7 @@ impl CommandExecutionManagerLike for CommandExecutionManagerWithClaim {
                 timing,
                 std_streams,
                 exit_code,
+                additional_message,
             },
             rejected_execution: None,
             did_cache_upload: false,
@@ -220,6 +228,7 @@ pub trait CommandExecutionManagerExt: Sized {
         std_streams: CommandStdStreams,
         exit_code: Option<i32>,
         timing: CommandExecutionMetadata,
+        additional_message: Option<String>,
     ) -> CommandExecutionResult;
 
     fn timeout(
@@ -228,6 +237,7 @@ pub trait CommandExecutionManagerExt: Sized {
         duration: Duration,
         std_streams: CommandStdStreams,
         timing: CommandExecutionMetadata,
+        additional_message: Option<String>,
     ) -> CommandExecutionResult;
 
     fn error(self, stage: &'static str, error: impl Into<anyhow::Error>) -> CommandExecutionResult;
@@ -244,6 +254,7 @@ where
         std_streams: CommandStdStreams,
         exit_code: Option<i32>,
         timing: CommandExecutionMetadata,
+        additional_message: Option<String>,
     ) -> CommandExecutionResult {
         self.result(
             CommandExecutionStatus::Failure { execution_kind },
@@ -251,6 +262,7 @@ where
             std_streams,
             exit_code,
             timing,
+            additional_message,
         )
     }
 
@@ -260,6 +272,7 @@ where
         duration: Duration,
         std_streams: CommandStdStreams,
         timing: CommandExecutionMetadata,
+        additional_message: Option<String>,
     ) -> CommandExecutionResult {
         self.result(
             CommandExecutionStatus::TimedOut {
@@ -270,6 +283,7 @@ where
             std_streams,
             None,
             timing,
+            additional_message,
         )
     }
 
@@ -285,6 +299,7 @@ where
             Default::default(),
             None,
             CommandExecutionMetadata::default(),
+            None,
         )
     }
 }

--- a/app/buck2_execute/src/execute/result.rs
+++ b/app/buck2_execute/src/execute/result.rs
@@ -257,6 +257,9 @@ pub struct CommandExecutionReport {
     /// No exit_code means the command did not finish executing. Signals get mapped into this as
     /// 128 + SIGNUM, which is the convention shells follow.
     pub exit_code: Option<i32>,
+    /// Any additional message that a command's executor wants to be user visible in case of a 
+    /// failure.
+    pub additional_message: Option<String>
 }
 
 impl CommandExecutionReport {
@@ -336,6 +339,7 @@ impl CommandExecutionReport {
             command_kind,
             signed_exit_code,
             metadata: Some(self.timing.to_proto()),
+            additional_message: self.additional_message.clone(),
         }
     }
 }

--- a/app/buck2_execute/src/execute/result.rs
+++ b/app/buck2_execute/src/execute/result.rs
@@ -409,6 +409,7 @@ mod tests {
             timing,
             std_streams,
             exit_code: Some(456),
+            additional_message: None,
         }
     }
 
@@ -477,6 +478,7 @@ mod tests {
             stderr: "DEF".to_owned(),
             command_kind: Some(command_execution_kind),
             metadata: Some(command_execution_metadata),
+            additional_message: None,
         };
 
         buck2_data::CommandExecution {

--- a/app/buck2_execute/src/execute/testing_dry_run.rs
+++ b/app/buck2_execute/src/execute/testing_dry_run.rs
@@ -103,6 +103,7 @@ impl PreparedCommandExecutor for DryRunExecutor {
                 Default::default(),
                 Some(1),
                 CommandExecutionMetadata::default(),
+                None,
             ),
         }
     }

--- a/app/buck2_execute_impl/src/executors/action_cache.rs
+++ b/app/buck2_execute_impl/src/executors/action_cache.rs
@@ -197,6 +197,7 @@ async fn query_action_cache_and_download_result(
         action_exit_code,
         artifact_fs,
         false,
+        None,
     )
     .await;
 

--- a/app/buck2_execute_impl/src/executors/local.rs
+++ b/app/buck2_execute_impl/src/executors/local.rs
@@ -504,6 +504,7 @@ impl LocalExecutor {
                         std_streams,
                         Some(exit_code),
                         timing,
+                        None,
                     )
                 }
             }
@@ -529,10 +530,11 @@ impl LocalExecutor {
                     },
                     None,
                     timing,
+                    None,
                 )
             }
             GatherOutputStatus::TimedOut(duration) => {
-                manager.timeout(execution_kind, duration, std_streams, timing)
+                manager.timeout(execution_kind, duration, std_streams, timing, None)
             }
             GatherOutputStatus::Cancelled => manager.cancel_claim(),
         }

--- a/app/buck2_execute_impl/src/executors/re.rs
+++ b/app/buck2_execute_impl/src/executors/re.rs
@@ -172,6 +172,12 @@ impl ReExecutor {
 
         let execution_kind = response.execution_kind(remote_details);
         let manager = manager.with_execution_kind(execution_kind.clone());
+        let additional_message = if response.error.message.is_empty() {
+            None
+        } else {
+            Some(response.error.message.clone())
+        };
+
         if response.error.code != TCode::OK {
             let res = if let Some(out) = as_missing_outputs_error(&response.error) {
                 // TODO: Add a dedicated report variant for this.
@@ -187,6 +193,7 @@ impl ReExecutor {
                     // We also don't get this output so don't put trash in here.
                     None,
                     Default::default(),
+                    additional_message,
                 )
             } else if is_timeout_error(&response.error) && request.timeout().is_some() {
                 manager.timeout(
@@ -200,6 +207,7 @@ impl ReExecutor {
                         digest_config,
                     )),
                     response.timing(),
+                    additional_message,
                 )
             } else {
                 manager.error(
@@ -306,6 +314,12 @@ impl PreparedCommandExecutor for ReExecutor {
             .await?;
 
         let exit_code = response.action_result.exit_code;
+        let additional_message = if response.error.message.is_empty() {
+            None
+        } else {
+            Some(response.error.message.clone())
+        };
+
         let res = download_action_results(
             request,
             &*self.materializer,
@@ -327,6 +341,7 @@ impl PreparedCommandExecutor for ReExecutor {
             exit_code,
             &self.artifact_fs,
             self.materialize_failed_inputs,
+            additional_message,
         )
         .boxed()
         .await;

--- a/app/buck2_execute_impl/src/executors/worker.rs
+++ b/app/buck2_execute_impl/src/executors/worker.rs
@@ -92,6 +92,7 @@ impl WorkerInitError {
                     std_streams,
                     *exit_code,
                     CommandExecutionMetadata::default(),
+                    None,
                 )
             }
             // TODO(ctolliday) as above, use a new failure type (worker_init_failure) that indicates this is a worker initialization error.
@@ -105,6 +106,7 @@ impl WorkerInitError {
                     },
                     None,
                     CommandExecutionMetadata::default(),
+                    None,
                 ),
             WorkerInitError::InternalError(error) => {
                 manager.error("get_worker_failed", error.clone())

--- a/app/buck2_execute_impl/src/re/download.rs
+++ b/app/buck2_execute_impl/src/re/download.rs
@@ -77,6 +77,7 @@ pub async fn download_action_results<'a>(
     action_exit_code: i32,
     artifact_fs: &ArtifactFs,
     materialize_failed_re_action_inputs: bool,
+    additional_message: Option<String>,
 ) -> DownloadResult {
     let std_streams = response.std_streams(re_client, re_use_case, digest_config);
     let std_streams = async {
@@ -101,6 +102,7 @@ pub async fn download_action_results<'a>(
             CommandStdStreams::Remote(std_streams),
             Some(action_exit_code),
             response.timing(),
+            additional_message,
         ));
     }
     let downloader = CasDownloader {
@@ -165,6 +167,7 @@ pub async fn download_action_results<'a>(
                 CommandStdStreams::Remote(std_streams),
                 Some(e),
                 response.timing(),
+                additional_message,
             )
         }
     };

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -589,6 +589,7 @@ impl REClient {
                             action_result_ttl: 0,
                             error: REError {
                                 code: TCode::OK,
+                                message: execute_response_grpc.message,
                                 ..Default::default()
                             },
                             cached_result: execute_response_grpc.cached_result,


### PR DESCRIPTION
- when RE is the OSS variant always log the action digest 
- on any kind of failure, both user failures as well as RE failures, propagate the message from the execution as it can contain useful informations for debugging (like links to some UI)