### PR TITLE
fix external cells OSS tests on Windows

### DIFF
--- a/app/buck2_external_cells/src/bundled.rs
+++ b/app/buck2_external_cells/src/bundled.rs
@@ -323,13 +323,19 @@ mod tests {
     #[tokio::test]
     async fn test_smoke_read() {
         let ops = testing_ops();
-        assert_eq!(
-            ops.read_file_if_exists(&CellRelativePath::unchecked_new("dir/src.txt"))
-                .await
-                .unwrap()
-                .unwrap(),
-            "foobar\n"
-        );
+        let content = ops
+            .read_file_if_exists(&CellRelativePath::unchecked_new("dir/src.txt"))
+            .await
+            .unwrap()
+            .unwrap();
+        let content = if cfg!(windows) {
+            // Git may check out files on Windows with \r\n as line separator.
+            // We could configure git, but it's more reliable to handle it in the test.
+            content.replace("\r\n", "\n")
+        } else {
+            content
+        };
+        assert_eq!(content, "foobar\n");
         assert!(
             ops.read_file_if_exists(&CellRelativePath::unchecked_new("dir/does_not_exist.txt"))
                 .await

--- a/app/buck2_external_cells_bundled/src/lib.rs
+++ b/app/buck2_external_cells_bundled/src/lib.rs
@@ -108,11 +108,11 @@ mod tests {
     #[test]
     fn test_sanity_check() {
         let c = super::TEST_CELL;
-        assert!(
-            c.files
-                .iter()
-                .any(|file| file.path == "dir/src.txt" && file.contents == "foobar\n".as_bytes())
-        )
+        assert!(c.files.iter().any(|file| {
+            file.path == "dir/src.txt"
+            // Git may check out files on Windows with \r\n as line separator.
+            && std::str::from_utf8(file.contents).unwrap().replace("\r\n", "\n") == "foobar\n"
+        }))
     }
 
     #[test]


### PR DESCRIPTION
Summary:
OSS windows job failing with:

```
---- bundled::tests::test_smoke_read stdout ----
thread 'bundled::tests::test_smoke_read' panicked at app\buck2_external_cells\src\bundled.rs:326:9:
assertion `left == right` failed
  left: "foobar\r\n"
 right: "foobar\n"
```

problem is probably with git changing LF to CRLF on Windows

Reviewed By: samkevich

Differential Revision: D57490261


