### PR TITLE
rust-project: remove hardcoded mode file in OSS build

### DIFF
--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -765,3 +765,44 @@ fn named_deps_underscores() {
         }]
     );
 }
+
+#[test]
+fn test_select_mode() {
+    // Test default behavior without the fbcode_build feature
+    assert_eq!(select_mode(None), None);
+    assert_eq!(
+        select_mode(Some("custom-mode")),
+        Some("custom-mode".to_owned())
+    );
+
+    // Test behavior with the fbcode_build feature enabled
+    #[cfg(all(feature = "fbcode_build", target_os = "macos"))]
+    {
+        assert_eq!(select_mode(None), Some("@fbcode//mode/mac".to_owned()));
+        assert_eq!(
+            select_mode(Some("custom-mode")),
+            Some("custom-mode".to_owned())
+        );
+    }
+
+    #[cfg(all(feature = "fbcode_build", target_os = "windows"))]
+    {
+        assert_eq!(select_mode(None), Some("@fbcode//mode/win".to_owned()));
+        assert_eq!(
+            select_mode(Some("custom-mode")),
+            Some("custom-mode".to_owned())
+        );
+    }
+
+    #[cfg(all(
+        feature = "fbcode_build",
+        not(any(target_os = "macos", target_os = "windows"))
+    ))]
+    {
+        assert_eq!(select_mode(None), None);
+        assert_eq!(
+            select_mode(Some("custom-mode")),
+            Some("custom-mode".to_owned())
+        );
+    }
+}

--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -682,9 +682,9 @@ pub(crate) fn truncate_line_ending(s: &mut String) {
 pub(crate) fn select_mode(mode: Option<&str>) -> Option<String> {
     if let Some(mode) = mode {
         Some(mode.to_owned())
-    } else if cfg!(target_os = "macos") {
+    } else if cfg!(all(feature = "fbcode_build", target_os = "macos")) {
         Some("@fbcode//mode/mac".to_owned())
-    } else if cfg!(target_os = "windows") {
+    } else if cfg!(all(feature = "fbcode_build", target_os = "windows")) {
         Some("@fbcode//mode/win".to_owned())
     } else {
         // fallback to the platform default mode. This is likely slower than optimal, but


### PR DESCRIPTION
With this patch I am able to run the following command in a non-fbcode buck project and get a functioning `rust-project.json` file:

```
rust-project develop --prefer-rustup-managed-toolchain //my:target
```

Fixes #519