### PR TITLE
Fix str being returned instead of Path() in get_sdk10_dir

### DIFF
--- a/prelude/toolchains/msvc/vswhere.py
+++ b/prelude/toolchains/msvc/vswhere.py
@@ -189,7 +189,7 @@ def get_sdk10_dir():
     windows_sdk_dir = os.environ.get("WindowsSdkDir")
     windows_sdk_version = os.environ.get("WindowsSDKVersion")
     if windows_sdk_dir is not None and windows_sdk_version is not None:
-        return windows_sdk_dir, windows_sdk_version.removesuffix("\\")
+        return Path(windows_sdk_dir), windows_sdk_version.removesuffix("\\")
 
     registry = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
     key_name = "SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows\\v10.0"


### PR DESCRIPTION
When both WindowsSdkDir and WindowsSDKVersion environment variables are set, **get_sdk10_dir()**
returns the path set in WindowsSdkDir as a str instead of Path which will then cause a type error
(TypeError: unsupported operand type(s) for /: 'str' and 'str')  in **find_with_vswhere_exe()** when
the returned path is used.