### PR TITLE
oss: Switch examples to bundled prelude

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,8 +41,6 @@ jobs:
       run: |-
         eval $(opam env)
         cd examples/with_prelude
-        $RUNNER_TEMP/artifacts/buck2 init
-        cp -r ../../prelude prelude
         source ./ocaml-setup.sh
         $RUNNER_TEMP/artifacts/buck2 build //... -v 2
         $RUNNER_TEMP/artifacts/buck2 test //... -v 2
@@ -60,8 +58,6 @@ jobs:
       run: |-
         eval $(opam env)
         cd examples/with_prelude
-        $RUNNER_TEMP/artifacts/buck2 init
-        cp -r ../../prelude prelude
         source ./ocaml-setup.sh
         $RUNNER_TEMP/artifacts/buck2 build //... -v 2
         $RUNNER_TEMP/artifacts/buck2 test //... -v 2
@@ -78,8 +74,6 @@ jobs:
       - name: Build example/prelude directory
         run: |-
           cd examples/with_prelude
-          & $Env:RUNNER_TEMP/artifacts/buck2 init
-          copy-item -Path $env:GITHUB_WORKSPACE\prelude -Destination prelude -Recurse
           & $Env:RUNNER_TEMP/artifacts/buck2 build //... -v 2
           & $Env:RUNNER_TEMP/artifacts/buck2 test //... -v 2
       - uses: ./.github/actions/build_example_no_prelude

--- a/examples/bootstrap/.buckconfig
+++ b/examples/bootstrap/.buckconfig
@@ -11,5 +11,8 @@ buck = none
 fbcode = none
 fbsource = none
 
+[external_cells]
+  prelude = bundled
+
 [parser]
 target_platform_detector_spec = target:root//...->bootstrap//platform:default

--- a/examples/hello_world/.buckconfig
+++ b/examples/hello_world/.buckconfig
@@ -10,5 +10,9 @@ fbcode = none
 fbsource = none
 buck = none
 
+[external_cells]
+  prelude = bundled
+
+
 [parser]
 target_platform_detector_spec = target:root//...->prelude//platforms:default

--- a/examples/toolchains/conan_toolchain/.buckconfig
+++ b/examples/toolchains/conan_toolchain/.buckconfig
@@ -11,5 +11,8 @@ fbcode = none
 fbcode_macros = none
 fbsource = none
 
+[external_cells]
+  prelude = bundled
+
 [parser]
 target_platform_detector_spec = target://...->prelude//platforms:default

--- a/examples/toolchains/cxx_zig_toolchain/.buckconfig
+++ b/examples/toolchains/cxx_zig_toolchain/.buckconfig
@@ -11,5 +11,8 @@ fbcode = none
 fbcode_macros = none
 fbsource = none
 
+[external_cells]
+  prelude = bundled
+
 [parser]
 target_platform_detector_spec = target://...->prelude//platforms:default

--- a/examples/visual_studio/.buckconfig
+++ b/examples/visual_studio/.buckconfig
@@ -10,6 +10,10 @@ fbcode = none
 fbsource = none
 buck = none
 
+[external_cells]
+  prelude = bundled
+
+
 [parser]
 target_platform_detector_spec = target:root//...->toolchains//:default
 

--- a/examples/with_prelude/.buckconfig
+++ b/examples/with_prelude/.buckconfig
@@ -10,5 +10,8 @@ fbcode = none
 fbsource = none
 buck = none
 
+[external_cells]
+  prelude = bundled
+
 [parser]
 target_platform_detector_spec = target:root//...->prelude//platforms:default


### PR DESCRIPTION
Summary: And remove the `buck2 init` invocation, which shouldn't be necessary.

Differential Revision: D57818182


