### PR TITLE
Do not set `GHC_PACKAGE_PATH` when it is empty

### DIFF
--- a/prelude/haskell/haskell.bzl
+++ b/prelude/haskell/haskell.bzl
@@ -481,7 +481,7 @@ def _make_package(
             hidden = hi.values() + lib.values(),
         ),
         category = "haskell_package_" + artifact_suffix.replace("-", "_"),
-        env = {"GHC_PACKAGE_PATH": ghc_package_path},
+        env = {"GHC_PACKAGE_PATH": ghc_package_path} if db_deps else {},
     )
 
     return db


### PR DESCRIPTION
This fixes a problem that we have seen after adding a .conf file to the project root.

`ghc-pkg` interprets an empty package path as the current working directory and will try to read any
`.conf` file from there which can lead to spurious errors like this:

```
Local command returned non-zero exit code 1
Reproduce locally: `env -- 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/root/904931f735703749/backend/src/__backend_infra__/haskel ...<omitted>... nfra__/db-static buck-out/v2/gen/root/904931f735703749/backend/src/__backend_infra__/pkg-static.conf (run `buck2 log what-failed` to get the full command)`
stdout:
stderr:
WARNING: cache does not exist: ./package.cache
ghc will fail to read this package db. Use 'ghc-pkg recache' to fix.
ghc-pkg-9.8.2: "the input" (line 14, column 1):
unexpected operator "#"
expecting field or section name
```
