### PR TITLE
re_grpc_proto: add serde support

### DIFF
--- a/app/buck2_data/src/lib.rs
+++ b/app/buck2_data/src/lib.rs
@@ -14,7 +14,7 @@ use std::fmt;
 
 pub mod action_key_owner;
 
-mod serialize_timestamp {
+pub mod serialize_timestamp {
     use serde::Deserialize;
     use serde::Deserializer;
     use serde::Serialize;

--- a/remote_execution/oss/re_grpc_proto/BUCK
+++ b/remote_execution/oss/re_grpc_proto/BUCK
@@ -9,7 +9,9 @@ rust_protobuf_library(
     build_script = "build.rs",
     protos = glob(["proto/**/*.proto"]),
     deps = [
+        "fbsource//third-party/rust:serde",
         "fbsource//third-party/rust:prost-types",
         "fbsource//third-party/rust:tonic",
+        "//buck2/app/buck2_data:buck2_data",
     ],
 )

--- a/remote_execution/oss/re_grpc_proto/Cargo.toml
+++ b/remote_execution/oss/re_grpc_proto/Cargo.toml
@@ -9,7 +9,10 @@ version = "0.1.0"
 [dependencies]
 prost = { workspace = true }
 prost-types = { workspace = true }
+serde= { workspace = true, features = ["derive"] }
 tonic = { workspace = true }
+
+buck2_data = { workspace = true }
 
 [build-dependencies]
 buck2_protoc_dev = { workspace = true }

--- a/remote_execution/oss/re_grpc_proto/build.rs
+++ b/remote_execution/oss/re_grpc_proto/build.rs
@@ -24,5 +24,74 @@ fn main() -> io::Result<()> {
 
     buck2_protoc_dev::configure()
         .setup_protoc()
+        .type_attribute(".", "#[derive(::serde::Serialize, ::serde::Deserialize)]")
+        .field_attribute(
+            "build.bazel.remote.execution.v2.Action.timeout",
+            "#[serde(with = \"::buck2_data::serialize_duration_as_micros\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.virtual_execution_duration",
+            "#[serde(with = \"::buck2_data::serialize_duration_as_micros\")]",
+        )
+        .field_attribute(
+            "google.longrunning.WaitOperationRequest.timeout",
+            "#[serde(with = \"::buck2_data::serialize_duration_as_micros\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.NodeProperties.mtime",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.queued_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.worker_start_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.worker_completed_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.input_fetch_start_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.input_fetch_completed_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.execution_start_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.execution_completed_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.output_upload_start_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.output_upload_completed_timestamp",
+            "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "build.bazel.remote.execution.v2.ExecutedActionMetadata.auxiliary_metadata",
+            "#[serde(with = \"crate::serialize_vec_any\")]",
+        )
+        .field_attribute(
+            "google.longrunning.Operation.metadata",
+            "#[serde(with = \"crate::serialize_option_any\")]",
+        )
+        .field_attribute(
+            "google.longrunning.Operation.result.response",
+            "#[serde(with = \"crate::serialize_any\")]",
+        )
+        .field_attribute(
+            "google.rpc.Status.details",
+            "#[serde(with = \"crate::serialize_vec_any\")]",
+        )
         .compile(proto_files, &["./proto/"])
 }

--- a/remote_execution/oss/re_grpc_proto/src/lib.rs
+++ b/remote_execution/oss/re_grpc_proto/src/lib.rs
@@ -35,3 +35,88 @@ pub mod build {
         }
     }
 }
+
+pub mod serialize_vec_any {
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serialize;
+    use serde::Serializer;
+
+    pub fn serialize<S>(value: &[::prost_types::Any], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let d: Vec<(String, Vec<u8>)> = value
+            .iter()
+            .map(|v| (v.type_url.clone(), v.value.clone()))
+            .collect();
+        d.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<::prost_types::Any>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let d: Vec<::prost_types::Any> = Vec::deserialize(deserializer)?
+            .into_iter()
+            .map(|(type_url, value)| ::prost_types::Any { type_url, value })
+            .collect();
+        Ok(d)
+    }
+}
+
+pub mod serialize_option_any {
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serialize;
+    use serde::Serializer;
+
+    pub fn serialize<S>(
+        value: &Option<::prost_types::Any>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let d = value
+            .as_ref()
+            .map(|v| (v.type_url.clone(), v.value.clone()));
+        d.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<::prost_types::Any>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let d = Option::<(String, Vec<u8>)>::deserialize(deserializer)?
+            .map(|(type_url, value)| ::prost_types::Any { type_url, value });
+        Ok(d)
+    }
+}
+
+pub mod serialize_any {
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serialize;
+    use serde::Serializer;
+
+    pub fn serialize<S>(value: &::prost_types::Any, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let d = (value.type_url.clone(), value.value.clone());
+        d.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<::prost_types::Any, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let d = <(String, Vec<u8>)>::deserialize(deserializer)?;
+        let d = ::prost_types::Any {
+            type_url: d.0,
+            value: d.1,
+        };
+        Ok(d)
+    }
+}


### PR DESCRIPTION
Add support for serde::{Serialize, Deserialize} to remote execution
protobuf.
Short term, this enables quick debugging use cases in OSS setup as user
could print out the requests and responses using serde_json.
