### PR TITLE
BuckEvent: provide a Buck Event Publisher proto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "app/buck2_event_observer",
     "app/buck2_events",
     "app/buck2_event_log",
+    "app/buck2_event_publisher_proto",
     "app/buck2_execute",
     "app/buck2_execute_impl",
     "app/buck2_external_cells",

--- a/app/buck2_event_publisher_proto/BUCK
+++ b/app/buck2_event_publisher_proto/BUCK
@@ -1,0 +1,18 @@
+load("@fbcode//buck2:proto_defs.bzl", "rust_protobuf_library")
+load("@fbsource//tools/build_defs:glob_defs.bzl", "glob")
+
+oncall("build_infra")
+
+rust_protobuf_library(
+    name = "buck2_event_publisher_proto",
+    srcs = glob(["src/**/*.rs"]),
+    build_script = "build.rs",
+    build_env = {
+        "BUCK_HACK_DATA_PROTOC_INCLUDE": "$(location //buck2/app/buck2_data:data_proto)",
+    },
+    protos = ["event_publisher.proto"],
+    deps = [
+        "fbsource//third-party/rust:tonic",
+        "//buck2/app/buck2_data:buck2_data",
+    ],
+)

--- a/app/buck2_event_publisher_proto/Cargo.toml
+++ b/app/buck2_event_publisher_proto/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "buck2_event_publisher_proto"
+
+edition = "2021"
+license = { workspace = true }
+repository = { workspace = true }
+version = "0.1.0"
+
+[dependencies]
+prost = { workspace = true }
+tonic = { workspace = true }
+
+buck2_data = { workspace = true }
+
+[build-dependencies]
+buck2_protoc_dev = { workspace = true }

--- a/app/buck2_event_publisher_proto/build.rs
+++ b/app/buck2_event_publisher_proto/build.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+use std::env;
+use std::io;
+use std::path::PathBuf;
+
+fn main() -> io::Result<()> {
+    let proto_files = &["event_publisher.proto"];
+
+    let data_include = if let Ok(value) = env::var("BUCK_HACK_DATA_PROTOC_INCLUDE") {
+        let path = PathBuf::from(value);
+        path.parent().unwrap().to_str().unwrap().to_owned()
+    } else {
+        "../buck2_data".to_owned()
+    };
+
+    buck2_protoc_dev::configure()
+        .setup_protoc()
+        .extern_path(".buck.data", "::buck2_data")
+        .compile(proto_files, &[".", &data_include])
+}

--- a/app/buck2_event_publisher_proto/event_publisher.proto
+++ b/app/buck2_event_publisher_proto/event_publisher.proto
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+syntax = "proto3";
+
+import "data.proto";
+
+package event_publisher;
+
+message BuckEventRequest {
+  // A trace-unique 64-bit identifying the stream.
+  uint64 stream_id = 1;
+
+  buck.data.BuckEvent event = 2;
+};
+
+message BuckEventResponse {
+  // A trace-unique 64-bit identifying the stream.
+  uint64 stream_id = 1;
+
+  // The trace ID of the event that has been committed.
+  uint64 trace_id = 2;
+};
+
+service BuckEventPublisher {
+  rpc StreamBuckEvent(stream BuckEventRequest) returns (stream BuckEventResponse);
+};

--- a/app/buck2_event_publisher_proto/src/lib.rs
+++ b/app/buck2_event_publisher_proto/src/lib.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+#![feature(error_generic_member_access)]
+
+tonic::include_proto!("event_publisher");


### PR DESCRIPTION
Provide a BuckEvent Publisher service which emits BuckEvents to an
external server implementation.

Closes https://github.com/facebook/buck2/issues/226
