### PR TITLE
Document `link_style` and `preferred_linkage` for C++ rules

### DIFF
--- a/prelude/decls/cxx_rules.bzl
+++ b/prelude/decls/cxx_rules.bzl
@@ -12,8 +12,10 @@
 
 load("@prelude//apple:apple_common.bzl", "apple_common")
 load("@prelude//cxx:link_groups_types.bzl", "LINK_GROUP_MAP_ATTR")
+load("@prelude//linking:link_info.bzl", "LinkStyle")
 load("@prelude//linking:types.bzl", "Linkage")
-load(":common.bzl", "CxxRuntimeType", "CxxSourceType", "HeadersAsRawHeadersMode", "LinkableDepType", "buck", "prelude_rule")
+
+load(":common.bzl", "CxxRuntimeType", "CxxSourceType", "HeadersAsRawHeadersMode", "buck", "prelude_rule")
 load(":cxx_common.bzl", "cxx_common")
 load(":genrule_common.bzl", "genrule_common")
 load(":native_common.bzl", "native_common")
@@ -854,6 +856,7 @@ cxx_test = prelude_rule(
         buck.test_rule_timeout_ms() |
         native_common.link_group_deps() |
         native_common.link_group_public_deps_label() |
+        native_common.link_style() |
         {
             "additional_coverage_targets": attrs.list(attrs.source(), default = []),
             "contacts": attrs.list(attrs.string(), default = []),
@@ -879,7 +882,6 @@ cxx_test = prelude_rule(
             "link_deps_query_whole": attrs.bool(default = False),
             "link_group": attrs.option(attrs.string(), default = None),
             "link_group_map": LINK_GROUP_MAP_ATTR,
-            "link_style": attrs.option(attrs.enum(LinkableDepType), default = None),
             "linker_extra_outputs": attrs.list(attrs.string(), default = []),
             "platform_compiler_flags": attrs.list(attrs.tuple(attrs.regex(), attrs.list(attrs.arg())), default = []),
             "platform_deps": attrs.list(attrs.tuple(attrs.regex(), attrs.set(attrs.dep(), sorted = True)), default = []),
@@ -957,7 +959,13 @@ cxx_toolchain = prelude_rule(
             "labels": attrs.list(attrs.string(), default = []),
             "licenses": attrs.list(attrs.source(), default = []),
             "link_path_normalization_args_enabled": attrs.bool(default = False),
-            "link_style": attrs.string(default = "static"),
+            "link_style": attrs.enum(
+                LinkStyle.values(),
+                default = "static",
+                doc = """
+                The default value of the `link_style` attribute for rules that use this toolchain.
+                """,
+            ),
             "linker": attrs.source(),
             "linker_flags": attrs.list(attrs.arg(anon_target_compatible = True), default = []),
             "linker_type": attrs.enum(LinkerProviderType),

--- a/prelude/rules_impl.bzl
+++ b/prelude/rules_impl.bzl
@@ -437,7 +437,14 @@ inlined_extra_attributes = {
         "link_ordering": attrs.option(attrs.enum(LinkOrdering.values()), default = None),
         "precompiled_header": attrs.option(attrs.dep(providers = [CPrecompiledHeaderInfo]), default = None),
         "prefer_stripped_objects": attrs.bool(default = False),
-        "preferred_linkage": attrs.enum(Linkage.values(), default = "any"),
+        "preferred_linkage": attrs.enum(
+            Linkage.values(),
+            default = "any",
+            doc = """
+            Determines what linkage is used when the library is depended on by another target. To
+            control how the dependencies of this library are linked, use `link_style` instead.
+            """,
+        ),
         "resources": attrs.named_set(attrs.one_of(attrs.dep(), attrs.source(allow_directory = True)), sorted = True, default = []),
         "supports_header_symlink_subtarget": attrs.bool(default = False),
         "supports_python_dlopen": attrs.option(attrs.bool(), default = None),
@@ -552,7 +559,14 @@ inlined_extra_attributes = {
         "linker_flags": attrs.list(attrs.arg(anon_target_compatible = True), default = []),
         "platform_header_dirs": attrs.option(attrs.list(attrs.tuple(attrs.regex(), attrs.list(attrs.source(allow_directory = True)))), default = None),
         "post_linker_flags": attrs.list(attrs.arg(anon_target_compatible = True), default = []),
-        "preferred_linkage": attrs.enum(Linkage.values(), default = "any"),
+        "preferred_linkage": attrs.enum(
+            Linkage.values(),
+            default = "any",
+            doc = """
+            Determines what linkage is used when the library is depended on by another target. To
+            control how the dependencies of this library are linked, use `link_style` instead.
+            """,
+        ),
         "public_include_directories": attrs.set(attrs.string(), sorted = True, default = []),
         "public_system_include_directories": attrs.set(attrs.string(), sorted = True, default = []),
         "raw_headers": attrs.set(attrs.source(), sorted = True, default = []),

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -206,7 +206,13 @@ system_cxx_toolchain = rule(
         "cxx_flags": attrs.list(attrs.string(), default = []),
         "link_flags": attrs.list(attrs.string(), default = []),
         "link_ordering": attrs.option(attrs.enum(LinkOrdering.values()), default = None),
-        "link_style": attrs.string(default = "shared"),
+        "link_style": attrs.enum(
+            LinkStyle.values(),
+            default = "shared",
+            doc = """
+            The default value of the `link_style` attribute for rules that use this toolchain.
+            """,
+        ),
         "linker": attrs.string(default = "link.exe" if host_info().os.is_windows else "clang++"),
         "linker_wrapper": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//cxx/tools:linker_wrapper")),
         "make_comp_db": attrs.default_only(attrs.exec_dep(providers = [RunInfo], default = "prelude//cxx/tools:make_comp_db")),

--- a/prelude/toolchains/cxx/zig/defs.bzl
+++ b/prelude/toolchains/cxx/zig/defs.bzl
@@ -435,7 +435,13 @@ cxx_zig_toolchain = rule(
         "cxx_compiler_flags": attrs.list(attrs.arg(), default = []),
         "cxx_preprocessor_flags": attrs.list(attrs.arg(), default = []),
         "distribution": attrs.exec_dep(providers = [RunInfo, ZigDistributionInfo]),
-        "link_style": attrs.enum(LinkStyle.values(), default = "static"),
+        "link_style": attrs.enum(
+            LinkStyle.values(),
+            default = "static",
+            doc = """
+            The default value of the `link_style` attribute for rules that use this toolchain.
+            """,
+        ),
         "linker_flags": attrs.list(attrs.arg(), default = []),
         "make_comp_db": attrs.dep(providers = [RunInfo], default = DEFAULT_MAKE_COMP_DB),
         "shared_dep_runtime_ld_flags": attrs.list(attrs.arg(), default = []),


### PR DESCRIPTION
Based on https://github.com/facebook/buck2/issues/571#issuecomment-1960032466.

Also use enums instead of strings where relevant.

<hr>

This commit does not add docs for _all_ the attributes with those names (e.g. in the Apple or Python ecosystems) because I am not familiar with those.