### PR TITLE
github: build aarch64-linux binaries with 16k-page jemalloc

### DIFF
--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -93,6 +93,12 @@ jobs:
         env:
           RUSTFLAGS: "-C strip=debuginfo -C codegen-units=1"
         run: |
+          # aarch64-linux builds need JEMALLOC_SYS_WITH_LG_PAGE=16
+          # this is for e.g. linux running on apple silicon with native 16k pages
+          if [[ "${{ matrix.target.triple }}" == aarch64-unknown-linux* ]]; then
+            export JEMALLOC_SYS_WITH_LG_PAGE=16
+          fi
+
           if [ -n "${{ matrix.target.cross }}" ]; then
             CARGO=cross
           else

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = [ "JEMALLOC_SYS_WITH_LG_PAGE" ]


### PR DESCRIPTION
jemalloc builds in the system page size as part of its (internal) ABI at compile time, which means that if you build with a smaller page size than what your system allows, it doesn't work.

In particular, this impacts Linux on Apple Silicon, which doesn't natively support 4k pages which are the default. Set it to 16k so that the prebuilt binaries work OOTB. **EDIT**: Apparently the Raspberry Pi 5 ships with a 16k page kernel by default, as well.