### PR TITLE
oss: Remove prelude checkout in upload job

### DIFF
--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -111,10 +111,6 @@ jobs:
         run: |
           BUCK2="$(pwd)/${{ steps.set_variables.outputs.cargo_out }}"
           cd examples/with_prelude
-          "$BUCK2" init --git
-          cd prelude
-          git checkout ${{ needs.get_prelude_hash.outputs.prelude_hash }}
-          cd ../
           "$BUCK2" build //rust/... //cpp/... //python/... -v=2
       - name: Move binary to artifacts/
         shell: bash


### PR DESCRIPTION
Summary: This is building `examples/with_prelude`, but none of that needs `buck2 init` & friends anymore

Reviewed By: iguridi

Differential Revision: D59194662
