### PR TITLE
Force UTF8 output regardless of the system code page

### DIFF
--- a/prelude/toolchains/msvc/vswhere.py
+++ b/prelude/toolchains/msvc/vswhere.py
@@ -75,6 +75,7 @@ def find_with_vswhere_exe():
             "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
             "-format",
             "json",
+            "-utf8",
             "-nologo",
         ],
         encoding="utf-8",


### PR DESCRIPTION
vswhere will print localized text to the console in localized Windows which cannot be encoded by Python in utf8 and the script fails, we can work around this by passing -utf8 to vswhere 2.5 or newer (https://github.com/microsoft/vswhere/wiki/Encoding)