### PR TITLE
bugfix: tweak prelude path for os_lookup

### DIFF
--- a/prelude/os_lookup/targets/BUCK.v2
+++ b/prelude/os_lookup/targets/BUCK.v2
@@ -1,5 +1,5 @@
 load("@prelude//utils:source_listing.bzl", "source_listing")
-load("//os_lookup:defs.bzl", "os_lookup")
+load("@prelude//os_lookup:defs.bzl", "os_lookup")
 
 oncall("build_infra")
 


### PR DESCRIPTION
I have prelude nested in another directory. this seems to be the only line where this loads from root and not the alias @prelude. 