### PR TITLE
feat: fix apple toolchain apple framework

### DIFF
--- a/examples/hello_world/BUCK
+++ b/examples/hello_world/BUCK
@@ -1,13 +1,35 @@
+apple_binary(
+    name = "main-mm",
+    srcs = ["main.mm"],
+    link_style = "static",
+    frameworks =  ["$SDKROOT/System/Library/Foundation.framework"],
+    compatible_with = ["config//os:macos" ],
+    target_sdk_version = "14.5",
+    deps = [":print-mm"],
+)
+
+apple_library(
+    name = "print-mm",
+    srcs = ["library.cpp"],
+    compatible_with = ["config//os:macos"],
+    exported_headers = glob(["**/*.hpp"]),
+    target_sdk_version = "14.5",
+    visibility = ["PUBLIC"],
+)
+
 cxx_binary(
     name = "main",
     srcs = ["main.cpp"],
+    compatible_with = ["config//os:linux", "config//os:windows" ],
     link_style = "static",
     deps = [":print"],
 )
 
+
 cxx_library(
     name = "print",
     srcs = ["library.cpp"],
+    compatible_with = ["config//os:linux", "config//os:windows" ],
     exported_headers = glob(["**/*.hpp"]),
     visibility = ["PUBLIC"],
 )

--- a/examples/hello_world/main.mm
+++ b/examples/hello_world/main.mm
@@ -1,0 +1,14 @@
+
+#import <Foundation/Foundation.h>
+#include "library.hpp"
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        // insert code here...
+        NSLog(@"Hello, World!");
+    }
+    print_hello();
+    return 0;
+}
+
+

--- a/examples/hello_world/toolchains/BUCK
+++ b/examples/hello_world/toolchains/BUCK
@@ -1,5 +1,12 @@
 load("@prelude//toolchains:demo.bzl", "system_demo_toolchains")
+load("@prelude//toolchains/apple:tools.bzl", "system_apple_toolchain")
 
 # All the default toolchains, suitable for a quick demo or early prototyping.
 # Most real projects should copy/paste the implementation to configure them.
 system_demo_toolchains()
+
+system_apple_toolchain(
+    name = "apple",
+    visibility = ["PUBLIC"],
+)
+

--- a/prelude/apple/apple_rules_impl.bzl
+++ b/prelude/apple/apple_rules_impl.bzl
@@ -36,6 +36,7 @@ load(
     "apple_dsymutil_attrs",
     "apple_test_extra_attrs",
     "apple_xcuitest_extra_attrs",
+    "get_apple_bundle_toolchain_attr",
     "get_apple_toolchain_attr",
     "get_apple_xctoolchain_attr",
     "get_apple_xctoolchain_bundle_id_attr",
@@ -47,6 +48,7 @@ load(":apple_toolchain_types.bzl", "AppleToolsInfo")
 load(":apple_xcuitest.bzl", "apple_xcuitest_impl")
 load(":prebuilt_apple_framework.bzl", "prebuilt_apple_framework_impl")
 load(":scene_kit_assets.bzl", "scene_kit_assets_impl")
+load("@prelude//decls/toolchains_common.bzl", "toolchains_common")
 
 implemented_rules = {
     "apple_asset_catalog": apple_asset_catalog_impl,
@@ -63,8 +65,6 @@ implemented_rules = {
     "scene_kit_assets": scene_kit_assets_impl,
     "swift_toolchain": swift_toolchain_impl,
 }
-
-_APPLE_TOOLCHAIN_ATTR = get_apple_toolchain_attr()
 
 def _apple_binary_extra_attrs():
     attribs = {
@@ -83,7 +83,8 @@ def _apple_binary_extra_attrs():
         "stripped": attrs.option(attrs.bool(), default = None),
         "swift_compilation_mode": attrs.enum(SwiftCompilationMode.values(), default = "wmo"),
         "swift_package_name": attrs.option(attrs.string(), default = None),
-        "_apple_toolchain": _APPLE_TOOLCHAIN_ATTR,
+        "_apple_toolchain": toolchains_common.apple(),
+        "_cxx_toolchain": toolchains_common.cxx(),
         "_apple_tools": attrs.exec_dep(default = "prelude//apple/tools:apple-tools", providers = [AppleToolsInfo]),
         "_apple_xctoolchain": get_apple_xctoolchain_attr(),
         "_apple_xctoolchain_bundle_id": get_apple_xctoolchain_bundle_id_attr(),
@@ -116,7 +117,8 @@ def _apple_library_extra_attrs():
         "swift_compilation_mode": attrs.enum(SwiftCompilationMode.values(), default = "wmo"),
         "swift_package_name": attrs.option(attrs.string(), default = None),
         "use_archive": attrs.option(attrs.bool(), default = None),
-        "_apple_toolchain": _APPLE_TOOLCHAIN_ATTR,
+        "_apple_toolchain": toolchains_common.apple(),
+        "_cxx_toolchain": toolchains_common.cxx(),
         "_apple_tools": attrs.exec_dep(default = "prelude//apple/tools:apple-tools", providers = [AppleToolsInfo]),
         "_apple_xctoolchain": get_apple_xctoolchain_attr(),
         "_apple_xctoolchain_bundle_id": get_apple_xctoolchain_bundle_id_attr(),
@@ -150,6 +152,7 @@ extra_attributes = {
             ),
             default = [],
         ),
+        "_apple_toolchain": get_apple_bundle_toolchain_attr(),
         "_apple_tools": attrs.exec_dep(default = "prelude//apple/tools:apple-tools", providers = [AppleToolsInfo]),
         "_ipa_compression_level": attrs.enum(IpaCompressionLevel.values()),
         "_ipa_package": attrs.dep(),
@@ -218,7 +221,7 @@ extra_attributes = {
         "framework": attrs.option(attrs.source(allow_directory = True), default = None),
         "preferred_linkage": attrs.enum(Linkage.values(), default = "any"),
         "stripped": attrs.option(attrs.bool(), default = None),
-        "_apple_toolchain": _APPLE_TOOLCHAIN_ATTR,
+        "_apple_toolchain": toolchains_common.apple(),
         "_apple_tools": attrs.default_only(attrs.exec_dep(default = "prelude//apple/tools:apple-tools", providers = [AppleToolsInfo])),
         "_stripped_default": attrs.bool(default = False),
     },

--- a/prelude/apple/apple_rules_impl.bzl
+++ b/prelude/apple/apple_rules_impl.bzl
@@ -37,7 +37,6 @@ load(
     "apple_test_extra_attrs",
     "apple_xcuitest_extra_attrs",
     "get_apple_bundle_toolchain_attr",
-    "get_apple_toolchain_attr",
     "get_apple_xctoolchain_attr",
     "get_apple_xctoolchain_bundle_id_attr",
     "get_enable_library_evolution",

--- a/prelude/apple/apple_rules_impl_utility.bzl
+++ b/prelude/apple/apple_rules_impl_utility.bzl
@@ -22,39 +22,35 @@ load("@prelude//linking:types.bzl", "Linkage")
 load("@prelude//decls/common.bzl", "LinkableDepType")
 
 def get_apple_toolchain_attr():
-    # FIXME: prelude// should be standalone (not refer to fbcode//)
-    return attrs.toolchain_dep(default = "fbcode//buck2/platform/toolchain:apple-default", providers = [AppleToolchainInfo])
+    return attrs.toolchain_dep(default = "toolchains//:apple", providers = [AppleToolchainInfo])
 
 def get_apple_bundle_toolchain_attr():
-    # FIXME: prelude// should be standalone (not refer to fbcode//)
-    return attrs.toolchain_dep(default = "fbcode//buck2/platform/toolchain:apple-bundle", providers = [AppleToolchainInfo])
+    return attrs.toolchain_dep(default = "toolchains//:apple", providers = [AppleToolchainInfo])
 
 def get_apple_xctoolchain_attr():
-    # FIXME: prelude// should be standalone (not refer to fbcode//)
-    return attrs.toolchain_dep(default = "fbcode//buck2/platform/toolchain:apple-xctoolchain")
+    return attrs.toolchain_dep(default = "toolchains//:apple")
 
 def get_apple_xctoolchain_bundle_id_attr():
-    # FIXME: prelude// should be standalone (not refer to fbcode//)
-    return attrs.toolchain_dep(default = "fbcode//buck2/platform/toolchain:apple-xctoolchain-bundle-id")
+    return attrs.toolchain_dep(default = "toolchains//:apple")
 
 def get_enable_library_evolution():
     return attrs.bool(default = select({
         "DEFAULT": False,
-        "config//features/apple:swift_library_evolution_enabled": True,
+        "prelude//apple/constraints:swift_library_evolution_enabled": True,
     }))
 
 def _strict_provisioning_profile_search_default_attr():
     default_value = (read_root_config("apple", "strict_provisioning_profile_search", "true").lower() == "true")
     return attrs.bool(default = select({
         "DEFAULT": default_value,
-        "config//features/apple:strict_provisioning_profile_search_enabled": True,
+        "prelude//apple/constraints:strict_provisioning_profile_search_enabled": True,
     }))
 
 def _fast_adhoc_signing_enabled_default_attr():
     return attrs.bool(default = select({
         "DEFAULT": True,
-        "config//features/apple:fast_adhoc_signing_disabled": False,
-        "config//features/apple:fast_adhoc_signing_enabled": True,
+        "prelude//apple/constraints:fast_adhoc_signing_disabled": False,
+        "prelude//apple/constraints:fast_adhoc_signing_enabled": True,
     }))
 
 APPLE_ARCHIVE_OBJECTS_LOCALLY_OVERRIDE_ATTR_NAME = "_archive_objects_locally_override"

--- a/prelude/apple/apple_toolchain.bzl
+++ b/prelude/apple/apple_toolchain.bzl
@@ -7,7 +7,6 @@
 
 load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolchainInfo")
 load("@prelude//apple/swift:swift_toolchain_types.bzl", "SwiftToolchainInfo")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainInfo")
 
 def apple_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     sdk_path = ctx.attrs._internal_sdk_path or ctx.attrs.sdk_path

--- a/prelude/apple/apple_toolchain.bzl
+++ b/prelude/apple/apple_toolchain.bzl
@@ -23,8 +23,6 @@ def apple_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
             codesign_identities_command = ctx.attrs.codesign_identities_command[RunInfo] if ctx.attrs.codesign_identities_command else None,
             compile_resources_locally = ctx.attrs.compile_resources_locally,
             copy_scene_kit_assets = ctx.attrs.copy_scene_kit_assets[RunInfo],
-            cxx_platform_info = ctx.attrs.cxx_toolchain[CxxPlatformInfo],
-            cxx_toolchain_info = ctx.attrs.cxx_toolchain[CxxToolchainInfo],
             dsymutil = ctx.attrs.dsymutil[RunInfo],
             dwarfdump = ctx.attrs.dwarfdump[RunInfo] if ctx.attrs.dwarfdump else None,
             extra_linker_outputs = ctx.attrs.extra_linker_outputs,

--- a/prelude/apple/apple_toolchain_types.bzl
+++ b/prelude/apple/apple_toolchain_types.bzl
@@ -7,6 +7,7 @@
 
 load("@prelude//apple/swift:swift_toolchain_types.bzl", "SwiftToolchainInfo")
 load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainInfo")
+load("@prelude//platforms/apple:sdk.bzl", "AppleSdk")
 
 AppleToolchainInfo = provider(
     # @unsorted-dict-items
@@ -18,8 +19,6 @@ AppleToolchainInfo = provider(
         "codesign": provider_field(RunInfo),
         "compile_resources_locally": provider_field(bool),
         "copy_scene_kit_assets": provider_field(RunInfo),
-        "cxx_platform_info": provider_field(CxxPlatformInfo),
-        "cxx_toolchain_info": provider_field(CxxToolchainInfo),
         "dsymutil": provider_field(RunInfo),
         "dwarfdump": provider_field(RunInfo | None, default = None),
         "extra_linker_outputs": provider_field(list[str]),
@@ -49,8 +48,8 @@ AppleToolsInfo = provider(
     fields = {
         "assemble_bundle": provider_field(RunInfo),
         "split_arch_combine_dsym_bundles_tool": provider_field(RunInfo),
-        "dry_codesign_tool": provider_field(RunInfo),
-        "adhoc_codesign_tool": provider_field(RunInfo),
+        "dry_codesign_tool": provider_field(RunInfo ),
+        "adhoc_codesign_tool": provider_field(RunInfo | None),
         "selective_debugging_scrubber": provider_field(RunInfo),
         "info_plist_processor": provider_field(RunInfo),
         "ipa_package_maker": provider_field(RunInfo),

--- a/prelude/apple/apple_toolchain_types.bzl
+++ b/prelude/apple/apple_toolchain_types.bzl
@@ -6,8 +6,6 @@
 # of this source tree.
 
 load("@prelude//apple/swift:swift_toolchain_types.bzl", "SwiftToolchainInfo")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainInfo")
-load("@prelude//platforms/apple:sdk.bzl", "AppleSdk")
 
 AppleToolchainInfo = provider(
     # @unsorted-dict-items

--- a/prelude/apple/constraints/BUCK.v2
+++ b/prelude/apple/constraints/BUCK.v2
@@ -1,0 +1,45 @@
+load("@prelude//utils:source_listing.bzl", "source_listing")
+load("@prelude//apple/constraints:defs.bzl", "generate_sdk_versions")
+
+oncall("build_infra")
+
+source_listing()
+
+prelude = native  # Avoid warnings and auto-formatters
+
+generate_sdk_versions()
+
+prelude.constraint_setting(
+  name = "maybe_swift_library_evolution",
+  visibility = ["PUBLIC"]
+)
+
+prelude.constraint_value(
+    name = "swift_library_evolution_enabled",
+    constraint_setting = ":maybe_swift_library_evolution",
+    visibility = ["PUBLIC"]
+)
+
+prelude.constraint_value(
+    name = "swift_library_evolution_disabled",
+    constraint_setting = ":maybe_swift_library_evolution",
+    visibility = ["PUBLIC"]
+)
+
+prelude.constraint_setting(
+  name = "fast_adhoc_signing_maybe",
+  visibility = ["PUBLIC"]
+)
+
+prelude.constraint_value(
+    name = "fast_adhoc_signing_disabled",
+    constraint_setting = ":fast_adhoc_signing_maybe",
+    visibility = ["PUBLIC"]
+)
+
+prelude.constraint_value(
+    name = "fast_adhoc_signing_enabled",
+    constraint_setting = ":fast_adhoc_signing_maybe",
+    visibility = ["PUBLIC"]
+)
+

--- a/prelude/apple/constraints/defs.bzl
+++ b/prelude/apple/constraints/defs.bzl
@@ -1,0 +1,15 @@
+load("@prelude//apple:versions.bzl", "TARGET_SDK_VERSIONS")
+load("@prelude//:native.bzl", "native")
+
+def generate_sdk_versions():
+  native.constraint_setting(
+      name = "constraint-setting-target-sdk-version",
+      visibility = ["PUBLIC"],
+  )
+
+  for ver in TARGET_SDK_VERSIONS:
+    native.constraint_value(
+      name = "constraint-value-target-sdk-version-" + ver,
+      constraint_setting = ":constraint-setting-target-sdk-version",
+      visibility = ["PUBLIC"]
+    )

--- a/prelude/apple/tools/code_signing/BUCK.v2
+++ b/prelude/apple/tools/code_signing/BUCK.v2
@@ -8,13 +8,13 @@ source_listing()
 configured_alias(
     name = "dummy_binary_for_signing_configured",
     actual = ":dummy_binary_for_signing",
-    platform = "config//platform/macos:base",
+    platform = "prelude//platforms:default",
 )
 
 cxx_binary(
     name = "dummy_binary_for_signing",
     srcs = ["dummy_binary_for_signing.c"],
-    default_target_platform = "config//platform/macos:base",
+#        default_target_platform = "prelude//platforms:default",
 )
 
 python_library(

--- a/prelude/apple/user/apple_toolchain_override.bzl
+++ b/prelude/apple/user/apple_toolchain_override.bzl
@@ -6,7 +6,6 @@
 # of this source tree.
 
 load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolchainInfo")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
 load("@prelude//user:rule_spec.bzl", "RuleRegistrationSpec")
 
 def _impl(ctx: AnalysisContext) -> list[Provider]:

--- a/prelude/apple/user/apple_toolchain_override.bzl
+++ b/prelude/apple/user/apple_toolchain_override.bzl
@@ -11,7 +11,6 @@ load("@prelude//user:rule_spec.bzl", "RuleRegistrationSpec")
 
 def _impl(ctx: AnalysisContext) -> list[Provider]:
     base = ctx.attrs.base[AppleToolchainInfo]
-    cxx_toolchain_override = ctx.attrs.cxx_toolchain[CxxToolchainInfo]
     return [
         DefaultInfo(),
         AppleToolchainInfo(

--- a/prelude/apple/user/apple_toolchain_override.bzl
+++ b/prelude/apple/user/apple_toolchain_override.bzl
@@ -21,8 +21,6 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
             codesign_allocate = base.codesign_allocate,
             copy_scene_kit_assets = base.copy_scene_kit_assets,
             compile_resources_locally = base.compile_resources_locally,
-            cxx_platform_info = base.cxx_platform_info,
-            cxx_toolchain_info = cxx_toolchain_override if cxx_toolchain_override != None else base.cxx_toolchain_info,
             dsymutil = base.dsymutil,
             dwarfdump = base.dwarfdump,
             extra_linker_outputs = base.extra_linker_outputs,
@@ -50,7 +48,6 @@ registration_spec = RuleRegistrationSpec(
     impl = _impl,
     attrs = {
         "base": attrs.toolchain_dep(providers = [AppleToolchainInfo]),
-        "cxx_toolchain": attrs.toolchain_dep(providers = [CxxToolchainInfo]),
     },
     is_toolchain_rule = True,
 )

--- a/prelude/apple/user/apple_tools.bzl
+++ b/prelude/apple/user/apple_tools.bzl
@@ -15,7 +15,7 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
             assemble_bundle = ctx.attrs.assemble_bundle[RunInfo],
             split_arch_combine_dsym_bundles_tool = ctx.attrs.split_arch_combine_dsym_bundles_tool[RunInfo],
             dry_codesign_tool = ctx.attrs.dry_codesign_tool[RunInfo],
-            adhoc_codesign_tool = ctx.attrs.adhoc_codesign_tool[RunInfo],
+            adhoc_codesign_tool = ctx.attrs.adhoc_codesign_tool[RunInfo] if ctx.attrs.adhoc_codesign_tool else None,
             info_plist_processor = ctx.attrs.info_plist_processor[RunInfo],
             ipa_package_maker = ctx.attrs.ipa_package_maker[RunInfo],
             make_modulemap = ctx.attrs.make_modulemap[RunInfo],

--- a/prelude/apple/user/target_sdk_version_transition.bzl
+++ b/prelude/apple/user/target_sdk_version_transition.bzl
@@ -41,8 +41,8 @@ def _impl(platform: PlatformInfo, refs: struct, attrs: struct) -> PlatformInfo:
 target_sdk_version_transition = transition(
     impl = _impl,
     refs = dict(
-        [("version", "@config//version:constraint-setting-target-sdk-version")] + {
-            version: "@config//version:constraint-value-target-sdk-version-" + version
+        [("version", "@prelude//apple/constraints:constraint-setting-target-sdk-version")] + {
+            version: "@prelude//apple/constraints:constraint-value-target-sdk-version-" + version
             for version in TARGET_SDK_VERSIONS
         }.items(),
     ),

--- a/prelude/cxx/cxx_context.bzl
+++ b/prelude/cxx/cxx_context.bzl
@@ -5,7 +5,6 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolchainInfo")
 load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainInfo")
 
 # The functions below allow the Cxx rules to find toolchain providers

--- a/prelude/cxx/cxx_context.bzl
+++ b/prelude/cxx/cxx_context.bzl
@@ -24,11 +24,8 @@ load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainIn
 def get_cxx_platform_info(ctx: AnalysisContext) -> CxxPlatformInfo:
     apple_toolchain = getattr(ctx.attrs, "_apple_toolchain", None)
     if apple_toolchain:
-        return apple_toolchain[AppleToolchainInfo].cxx_platform_info
+        return apple_toolchain[CxxPlatformInfo]
     return ctx.attrs._cxx_toolchain[CxxPlatformInfo]
 
 def get_cxx_toolchain_info(ctx: AnalysisContext) -> CxxToolchainInfo:
-    apple_toolchain = getattr(ctx.attrs, "_apple_toolchain", None)
-    if apple_toolchain:
-        return apple_toolchain[AppleToolchainInfo].cxx_toolchain_info
     return ctx.attrs._cxx_toolchain[CxxToolchainInfo]

--- a/prelude/decls/ios_rules.bzl
+++ b/prelude/decls/ios_rules.bzl
@@ -11,7 +11,7 @@
 # well-formatted (and then delete this TODO)
 
 load("@prelude//apple:apple_common.bzl", "apple_common")
-load("@prelude//apple:apple_rules_impl_utility.bzl", "apple_dsymutil_attrs", "get_apple_toolchain_attr")
+load("@prelude//apple:apple_rules_impl_utility.bzl", "apple_dsymutil_attrs")
 load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolsInfo")
 load("@prelude//apple:apple_universal_executable.bzl", "apple_universal_executable_impl")
 load("@prelude//apple:resource_groups.bzl", "RESOURCE_GROUP_MAP_ATTR")

--- a/prelude/decls/ios_rules.bzl
+++ b/prelude/decls/ios_rules.bzl
@@ -16,6 +16,7 @@ load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolsInfo")
 load("@prelude//apple:apple_universal_executable.bzl", "apple_universal_executable_impl")
 load("@prelude//apple:resource_groups.bzl", "RESOURCE_GROUP_MAP_ATTR")
 load("@prelude//apple/user:cpu_split_transition.bzl", "cpu_split_transition")
+load("@prelude//decls/toolchains_common.bzl", "toolchains_common")
 load("@prelude//cxx:link_groups_types.bzl", "LINK_GROUP_MAP_ATTR")
 load("@prelude//linking:types.bzl", "Linkage")
 load(":common.bzl", "CxxRuntimeType", "CxxSourceType", "HeadersAsRawHeadersMode", "IncludeType", "buck", "prelude_rule")
@@ -1014,8 +1015,6 @@ swift_toolchain = prelude_rule(
     ),
 )
 
-_APPLE_TOOLCHAIN_ATTR = get_apple_toolchain_attr()
-
 def _apple_universal_executable_attrs():
     attribs = {
         "executable": attrs.split_transition_dep(cfg = cpu_split_transition, doc = """
@@ -1041,7 +1040,7 @@ def _apple_universal_executable_attrs():
                 of the `config//cpu/constraints:universal-enabled` constraint. Read the rule docs
                 for more information on resolution.
             """),
-        "_apple_toolchain": _APPLE_TOOLCHAIN_ATTR,
+        "_apple_toolchain": toolchains_common.apple(),
         "_apple_tools": attrs.exec_dep(default = "prelude//apple/tools:apple-tools", providers = [AppleToolsInfo]),
     }
     attribs.update(apple_dsymutil_attrs())

--- a/prelude/decls/toolchains_common.bzl
+++ b/prelude/decls/toolchains_common.bzl
@@ -27,6 +27,7 @@ load("@prelude//python_bootstrap:python_bootstrap.bzl", "PythonBootstrapToolchai
 load("@prelude//rust:rust_toolchain.bzl", "RustToolchainInfo")
 load("@prelude//tests:remote_test_execution_toolchain.bzl", "RemoteTestExecutionToolchainInfo")
 load("@prelude//zip_file:zip_file_toolchain.bzl", "ZipFileToolchainInfo")
+load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolchainInfo")
 
 def _toolchain(lang: str, providers: list[typing.Any]) -> Attr:
     return attrs.toolchain_dep(default = "toolchains//:" + lang, providers = providers)
@@ -39,6 +40,9 @@ def _csharp_toolchain():
 
 def _cxx_toolchain():
     return _toolchain("cxx", [CxxToolchainInfo, CxxPlatformInfo])
+
+def _apple_toolchain():
+    return _toolchain("apple", [AppleToolchainInfo])
 
 def _dex_toolchain():
     return _toolchain("dex", [DexToolchainInfo])
@@ -85,6 +89,7 @@ def _remote_test_execution_toolchain():
 
 toolchains_common = struct(
     android = _android_toolchain,
+    apple = _apple_toolchain,
     csharp = _csharp_toolchain,
     cxx = _cxx_toolchain,
     dex = _dex_toolchain,

--- a/prelude/toolchains/apple/tools.bzl
+++ b/prelude/toolchains/apple/tools.bzl
@@ -1,0 +1,73 @@
+load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolchainInfo", "AppleToolsInfo")
+load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainInfo")
+load("@prelude//apple/swift:swift_toolchain_types.bzl", "SwiftToolchainInfo")
+load("@prelude//platforms/apple:sdk.bzl", "AppleSdk")
+
+_APPLE_SDKS = [
+    "appletvos",
+    "appletvsimulator",
+    "iphoneos",
+    "iphonesimulator",
+    "maccatalyst",
+    "macosx",
+    "visionos",
+    "visionsimulator",
+    "watchos",
+    "watchsimulator"
+]
+
+def _system_apple_toolschain_impl(ctx: AnalysisContext) -> list[Provider]:
+  xcode_bin_path =  "{}/Contents/Developer/usr/bin".format(ctx.attrs.xcode_app)
+  sdk_path =  "{}/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk".format(ctx.attrs.xcode_app)
+
+  return [
+        DefaultInfo(),
+        AppleToolchainInfo(
+            actool = RunInfo(args = ["actool"]),
+            architecture = ctx.attrs._architecture,
+            codesign = RunInfo(args = ["codesign"]),
+            codesign_allocate = RunInfo(args = ["codesign_allocate"]),
+            codesign_identities_command = None,
+            compile_resources_locally = True,
+            copy_scene_kit_assets = RunInfo(args = ["{}/copySceneKitAssets".format(xcode_bin_path)]),
+            dsymutil = RunInfo(args = ["dsymutil"]),
+            dwarfdump = RunInfo(args = ["dwarfdump"]),
+            extra_linker_outputs = ctx.attrs.extra_linker_outputs,
+            ibtool = RunInfo(args = ["ibtool"]),
+            libtool = RunInfo(args = ["libtool"]),
+            lipo = RunInfo(args = ["lipo"]),
+            objdump = RunInfo(args = ["objdump"]),
+            installer = ctx.attrs.installer,
+            momc = RunInfo(args = ["{}/momc".format(xcode_bin_path)]),
+            platform_path = "/",
+            sdk_name = ctx.attrs.sdk_name,
+            sdk_path = sdk_path,
+            xctest = RunInfo(args = ["{}/xctest".format(xcode_bin_path)]),
+            swift_toolchain_info = SwiftToolchainInfo(
+              sdk_path = sdk_path,
+              compiler_flags = []
+            )
+        ),
+        CxxPlatformInfo(name = "{}-{}".format(ctx.attrs.sdk_name, ctx.attrs._architecture)),
+    ]
+
+_DEFAULT_ARCH = select({
+    "config//cpu:arm64": "arm64",
+    "config//cpu:x86_64": "x86_64",
+})
+
+
+system_apple_toolchain = rule(
+    impl = _system_apple_toolschain_impl,
+    attrs = {
+        "xcode_app": attrs.string(default = "/Applications/Xcode.app"),
+        "extra_linker_outputs": attrs.list(attrs.string(), default = []),
+        "sdk_name": attrs.enum(_APPLE_SDKS, default = "macosx"),
+        "installer": attrs.default_only(attrs.label(default = "buck//src/com/facebook/buck/installer/apple:apple_installer")),
+        "_architecture": attrs.string(default = _DEFAULT_ARCH),
+
+    },
+    is_toolchain_rule = True,
+)
+
+

--- a/prelude/toolchains/apple/tools.bzl
+++ b/prelude/toolchains/apple/tools.bzl
@@ -1,7 +1,6 @@
-load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolchainInfo", "AppleToolsInfo")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainInfo")
+load("@prelude//apple:apple_toolchain_types.bzl", "AppleToolchainInfo")
+load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo")
 load("@prelude//apple/swift:swift_toolchain_types.bzl", "SwiftToolchainInfo")
-load("@prelude//platforms/apple:sdk.bzl", "AppleSdk")
 
 _APPLE_SDKS = [
     "appletvos",


### PR DESCRIPTION
I've just been roughly trying to get this to work for my local setup. some of this is a bit hacked away to get this to work but I think its in the general right direction.

this is what I have in mind for resolving the apple tools 
```
find_apple_tools(
    name = "apple",
    architecture = "amr64",
    sdk_name= "macosx",
    visibility = ["PUBLIC"],
)
```

here is the working code I'm trying to test
```

apple_binary(
    name = "main-apple",
    srcs = ["main.mm"],
    link_style = "static",
    frameworks =  ["$SDKROOT/System/Library/Foundation.framework"],
    compatible_with = ["config//os:macos" ],
    target_sdk_version = "14.5",
    deps = [":print"],
)

```

here is my sample application that  I've been testing these changes with: https://github.com/OSS-Cosmic/buck2-samples/tree/main/hello_world

I need to build this locally and verify it on my own system but this is what I have so far.