### PR TITLE
Add subtarget information to a test target name

### DIFF
--- a/app/buck2_test/src/translations.rs
+++ b/app/buck2_test/src/translations.rs
@@ -32,7 +32,7 @@ pub(crate) fn build_configured_target_handle(
     let label = target.target().unconfigured();
     let cell = label.pkg().cell_name().to_string();
     let package = label.pkg().cell_relative_path().to_string();
-    let target_name = label.name().to_string();
+    let target_name = label.name().to_string() + &target.name().to_string();
     let configuration = target.cfg().to_string();
     let package_project_relative_path = cell_resolver
         .resolve_path(label.pkg().as_cell_path())


### PR DESCRIPTION
This lets users know which subtarget failed, which is crucial when testing multiple test subtargets (e.g. when there is one per configuration, generated via transitions).

Before:
```
2 TESTS FAILED
  ✗ root//:dummy_test
  ✗ root//:dummy_test
```

After:
```
2 TESTS FAILED
  ✗ root//:dummy_test[gcc13-cxx20-debug]
  ✗ root//:dummy_test[clang18-cxx20-debug]
```

When a default provider is built (no subtargets), the output is unchanged, because `ProviderName`'s `Display` implementation returns an empty string for default providers.