### PR TITLE
rust-project: name the binary `buck2-rust-project`

### DIFF
--- a/integrations/rust-project/Cargo.toml
+++ b/integrations/rust-project/Cargo.toml
@@ -7,6 +7,10 @@ readme = "README.md"
 repository = { workspace = true }
 version = "0.0.0"
 
+[[bin]]
+name = "buck2-rust-project"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }


### PR DESCRIPTION
The name `rust-project` is glamorous but far too generic to be meaningful when talking about it, and it's not immediately clear what it's even referring to (imagine searching for it on Google). I think `buck2-rust-project` is *much* better and also gives a template for follow up tools like e.g. `buck2-cxx- project`