### PR TITLE
rust-project: fix cquery usage in `rust-project check`

### DIFF
--- a/prelude/rust/rust-analyzer/check.bxl
+++ b/prelude/rust/rust-analyzer/check.bxl
@@ -8,8 +8,9 @@
 load("@prelude//rust:outputs.bzl", "RustcExtraOutputsInfo")
 
 def check_targets_impl(ctx: bxl.Context) -> None:
-    target_universe = ctx.uquery().owner(ctx.cli_args.file)
-    owners = ctx.cquery().owner(ctx.cli_args.file, target_universe)
+    uowners = ctx.uquery().owner(ctx.cli_args.file)
+    target_universe = ctx.target_universe(uowners)
+    owners = ctx.cquery().owner(ctx.cli_args.file, target_universe.target_set())
     nodes = ctx.cquery().kind("^(rust_binary|rust_library|rust_test)$", owners)
 
     if len(nodes) == 0:


### PR DESCRIPTION
`check` was silently broken in OSS builds because the `check.bxl` script used a deprecated mechanism for calling `cquery()` with an inferred target universe (everything should migrate to explicit universes.) Inside Meta this is only a soft error, so it's allowed and logged, but all soft errors are hard errors in the OSS version so this just nuked the feature completely, resulting in a very sub-par editor experience.