### PR TITLE
Fix isdigit / upgrade derive_more 1.0.0 in Cargo.toml

### DIFF
--- a/app/buck2_action_impl/BUCK
+++ b/app/buck2_action_impl/BUCK
@@ -11,7 +11,7 @@ rust_library(
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:chrono",
         "fbsource//third-party/rust:dashmap",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:hex",

--- a/app/buck2_analysis/BUCK
+++ b/app/buck2_analysis/BUCK
@@ -9,7 +9,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:smallvec",

--- a/app/buck2_anon_target/BUCK
+++ b/app/buck2_anon_target/BUCK
@@ -9,7 +9,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:serde",

--- a/app/buck2_artifact/BUCK
+++ b/app/buck2_artifact/BUCK
@@ -13,7 +13,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:serde",
         "fbsource//third-party/rust:take_mut",

--- a/app/buck2_audit_server/BUCK
+++ b/app/buck2_audit_server/BUCK
@@ -9,7 +9,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:indent_write",
         "fbsource//third-party/rust:indexmap",

--- a/app/buck2_build_api/BUCK
+++ b/app/buck2_build_api/BUCK
@@ -16,7 +16,7 @@ rust_library(
         "fbsource//third-party/rust:blake3",
         "fbsource//third-party/rust:dashmap",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:indexmap",

--- a/app/buck2_build_signals/BUCK
+++ b/app/buck2_build_signals/BUCK
@@ -11,7 +11,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "//buck2/allocative/allocative:allocative",
         "//buck2/app/buck2_core:buck2_core",

--- a/app/buck2_build_signals_impl/BUCK
+++ b/app/buck2_build_signals_impl/BUCK
@@ -11,7 +11,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:itertools",
         "fbsource//third-party/rust:smallvec",
         "fbsource//third-party/rust:static_assertions",

--- a/app/buck2_bxl/BUCK
+++ b/app/buck2_bxl/BUCK
@@ -17,7 +17,7 @@ rust_library(
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:clap",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:indexmap",

--- a/app/buck2_cfg_constructor/BUCK
+++ b/app/buck2_cfg_constructor/BUCK
@@ -11,7 +11,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "//buck2/allocative/allocative:allocative",
         "//buck2/app/buck2_build_api:buck2_build_api",

--- a/app/buck2_client/BUCK
+++ b/app/buck2_client/BUCK
@@ -24,7 +24,7 @@ rust_library(
         "fbsource//third-party/rust:clap",
         "fbsource//third-party/rust:clap_complete",
         "fbsource//third-party/rust:csv",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:humantime",
         "fbsource//third-party/rust:indexmap",

--- a/app/buck2_client_ctx/BUCK
+++ b/app/buck2_client_ctx/BUCK
@@ -44,7 +44,7 @@ rust_library(
         "fbsource//third-party/rust:clap",
         "fbsource//third-party/rust:crossterm",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:fs4",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:hex",

--- a/app/buck2_common/BUCK
+++ b/app/buck2_common/BUCK
@@ -44,7 +44,7 @@ rust_library(
         "fbsource//third-party/rust:compact_str",
         "fbsource//third-party/rust:dashmap",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:digest",
         "fbsource//third-party/rust:dirs",
         "fbsource//third-party/rust:futures",

--- a/app/buck2_configured/BUCK
+++ b/app/buck2_configured/BUCK
@@ -11,7 +11,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "//buck2/allocative/allocative:allocative",
         "//buck2/app/buck2_build_api:buck2_build_api",

--- a/app/buck2_core/BUCK
+++ b/app/buck2_core/BUCK
@@ -52,7 +52,7 @@ rust_library(
         "fbsource//third-party/rust:blake3",
         "fbsource//third-party/rust:compact_str",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:dunce",
         "fbsource//third-party/rust:equivalent",
         "fbsource//third-party/rust:futures",

--- a/app/buck2_critical_path/BUCK
+++ b/app/buck2_critical_path/BUCK
@@ -14,7 +14,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:crossbeam",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "//buck2/app/buck2_error:buck2_error",
         "//buck2/starlark-rust/starlark_map:starlark_map",
     ],

--- a/app/buck2_data/BUCK
+++ b/app/buck2_data/BUCK
@@ -14,7 +14,7 @@ rust_protobuf_library(
         "error.proto",
     ],
     deps = [
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:hex",
         "fbsource//third-party/rust:prost-types",
         "fbsource//third-party/rust:serde",

--- a/app/buck2_directory/BUCK
+++ b/app/buck2_directory/BUCK
@@ -15,7 +15,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:dashmap",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "//buck2/allocative/allocative:allocative",
         "//buck2/app/buck2_core:buck2_core",

--- a/app/buck2_error/BUCK
+++ b/app/buck2_error/BUCK
@@ -10,7 +10,7 @@ rust_library(
     ),
     deps = [
         "fbsource//third-party/rust:anyhow",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:ref-cast",
         "fbsource//third-party/rust:smallvec",

--- a/app/buck2_event_observer/BUCK
+++ b/app/buck2_event_observer/BUCK
@@ -13,7 +13,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:clap",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:linked-hash-map",
         "fbsource//third-party/rust:regex",
         "fbsource//third-party/rust:shlex",

--- a/app/buck2_events/BUCK
+++ b/app/buck2_events/BUCK
@@ -26,7 +26,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:crossbeam-channel",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:hostname",
         "fbsource//third-party/rust:is_proc_translated",

--- a/app/buck2_execute/BUCK
+++ b/app/buck2_execute/BUCK
@@ -20,7 +20,7 @@ rust_library(
         "fbsource//third-party/rust:chrono",
         "fbsource//third-party/rust:crossbeam-channel",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:digest",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:faccess",

--- a/app/buck2_execute_impl/BUCK
+++ b/app/buck2_execute_impl/BUCK
@@ -34,7 +34,7 @@ rust_library(
         "fbsource//third-party/rust:chrono",
         "fbsource//third-party/rust:dashmap",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:hostname",
         "fbsource//third-party/rust:indexmap",

--- a/app/buck2_external_cells/BUCK
+++ b/app/buck2_external_cells/BUCK
@@ -12,7 +12,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:tokio",
         "//buck2/allocative/allocative:allocative",
         "//buck2/app/buck2_build_api:buck2_build_api",

--- a/app/buck2_forkserver_proto/BUCK
+++ b/app/buck2_forkserver_proto/BUCK
@@ -12,7 +12,7 @@ rust_protobuf_library(
     build_script = "build.rs",
     protos = ["forkserver.proto"],
     deps = [
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:prost-types",
         "fbsource//third-party/rust:tonic",
         "//buck2/app/buck2_data:buck2_data",

--- a/app/buck2_interpreter/BUCK
+++ b/app/buck2_interpreter/BUCK
@@ -14,7 +14,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:fancy-regex",
         "fbsource//third-party/rust:plist",

--- a/app/buck2_interpreter_for_build/BUCK
+++ b/app/buck2_interpreter_for_build/BUCK
@@ -15,7 +15,7 @@ rust_library(
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:bumpalo",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:fancy-regex",
         "fbsource//third-party/rust:futures",

--- a/app/buck2_node/BUCK
+++ b/app/buck2_node/BUCK
@@ -13,7 +13,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:itertools",

--- a/app/buck2_query/BUCK
+++ b/app/buck2_query/BUCK
@@ -9,7 +9,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:enum-iterator",
         "fbsource//third-party/rust:fancy-regex",
         "fbsource//third-party/rust:futures",

--- a/app/buck2_query_impls/BUCK
+++ b/app/buck2_query_impls/BUCK
@@ -15,7 +15,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:dashmap",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:indexmap",

--- a/app/buck2_query_parser/BUCK
+++ b/app/buck2_query_parser/BUCK
@@ -8,7 +8,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     deps = [
         "fbsource//third-party/rust:anyhow",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:enum-map",
         "fbsource//third-party/rust:nom",
         "//buck2/app/buck2_error:buck2_error",

--- a/app/buck2_server_commands/BUCK
+++ b/app/buck2_server_commands/BUCK
@@ -15,7 +15,7 @@ rust_library(
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:blake3",
         "fbsource//third-party/rust:chrono",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:flate2",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:indent_write",

--- a/app/buck2_server_ctx/BUCK
+++ b/app/buck2_server_ctx/BUCK
@@ -15,7 +15,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-condvar-fair",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:itertools",
         "fbsource//third-party/rust:parking_lot",

--- a/app/buck2_server_starlark_debug/BUCK
+++ b/app/buck2_server_starlark_debug/BUCK
@@ -12,7 +12,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:debugserver-types",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:itertools",
         "fbsource//third-party/rust:num_cpus",

--- a/app/buck2_subscription_proto/BUCK
+++ b/app/buck2_subscription_proto/BUCK
@@ -11,7 +11,7 @@ rust_protobuf_library(
     build_script = "build.rs",
     protos = ["subscription.proto"],
     deps = [
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:serde",
         "fbsource//third-party/rust:tonic",
         "//buck2/allocative/allocative:allocative",

--- a/app/buck2_test/BUCK
+++ b/app/buck2_test/BUCK
@@ -28,7 +28,7 @@ rust_library(
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:chrono",
         "fbsource//third-party/rust:dashmap",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:indexmap",
         "fbsource//third-party/rust:itertools",

--- a/app/buck2_test_api/BUCK
+++ b/app/buck2_test_api/BUCK
@@ -15,7 +15,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:prost-types",
         "fbsource//third-party/rust:tokio",

--- a/app/buck2_transition/BUCK
+++ b/app/buck2_transition/BUCK
@@ -11,7 +11,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:itertools",
         "//buck2/allocative/allocative:allocative",
         "//buck2/app/buck2_build_api:buck2_build_api",

--- a/app/buck2_validation/BUCK
+++ b/app/buck2_validation/BUCK
@@ -12,7 +12,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:serde",

--- a/app/buck2_wrapper_common/BUCK
+++ b/app/buck2_wrapper_common/BUCK
@@ -32,7 +32,7 @@ rust_library(
     ],
     deps = [
         "fbsource//third-party/rust:anyhow",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:serde",
         "fbsource//third-party/rust:shlex",
         "fbsource//third-party/rust:sysinfo",

--- a/dice/dice/BUCK
+++ b/dice/dice/BUCK
@@ -22,7 +22,7 @@ rust_library(
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:dashmap",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:fxhash",
         "fbsource//third-party/rust:indexmap",

--- a/dice/dice_examples/BUCK
+++ b/dice/dice_examples/BUCK
@@ -12,7 +12,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:ref-cast",
         "//buck2/allocative/allocative:allocative",
@@ -29,7 +29,7 @@ rust_binary(
     deps = [
         "fbsource//third-party/rust:async-trait",
         "fbsource//third-party/rust:clap",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:tokio",
         "//buck2/allocative/allocative:allocative",

--- a/dice/dice_tests/BUCK
+++ b/dice/dice_tests/BUCK
@@ -12,7 +12,7 @@ rust_library(
     test_deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-trait",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:parking_lot",
         "fbsource//third-party/rust:tempfile",

--- a/dice/fuzzy_dice/BUCK
+++ b/dice/fuzzy_dice/BUCK
@@ -14,7 +14,7 @@ rust_binary(
         "fbsource//third-party/rust:clap",
         "fbsource//third-party/rust:crossbeam",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:futures",
         "fbsource//third-party/rust:itertools",
         "fbsource//third-party/rust:parking_lot",

--- a/shim/shims.bzl
+++ b/shim/shims.bzl
@@ -406,7 +406,7 @@ def _fix_dep(x: str) -> [
         xs = x.split("-")
         for i in range(len(xs)):
             s = xs[i]
-            if s == "old" or isdigit(s):
+            if s == "old" or s.isdigit():
                 xs.pop(i)
             else:
                 break
@@ -471,4 +471,4 @@ def _assert_eq(x, y):
         fail("Expected {} == {}".format(x, y))
 
 def _test():
-    _assert_eq("fbsource//third-party/rust:derive_more-1", "shim//third-party/rust:derive_more")
+    _assert_eq("fbsource//third-party/rust:derive_more", "shim//third-party/rust:derive_more")

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -65,7 +65,7 @@ ctor = "0.1.16"
 dashmap = "5.5.3"
 debugserver-types = "0.5.0"
 derivative = "2.2"
-derive_more = "0.99.3"
+derive_more = { version = "1.0.0", features = ["full"] }
 digest = "0.10"
 dirs = "3.0.1"
 dunce = "1.0.2"

--- a/starlark-rust/starlark/BUCK
+++ b/starlark-rust/starlark/BUCK
@@ -42,7 +42,7 @@ rust_library(
         "fbsource//third-party/rust:bumpalo",
         "fbsource//third-party/rust:debugserver-types",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:either",
         "fbsource//third-party/rust:erased-serde",
         "fbsource//third-party/rust:hashbrown",

--- a/starlark-rust/starlark_lsp/BUCK
+++ b/starlark-rust/starlark_lsp/BUCK
@@ -29,7 +29,7 @@ rust_library(
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:itertools",
         "fbsource//third-party/rust:lsp-server",
         "fbsource//third-party/rust:lsp-types",

--- a/starlark-rust/starlark_syntax/BUCK
+++ b/starlark-rust/starlark_syntax/BUCK
@@ -52,7 +52,7 @@ rust_library(
         "fbsource//third-party/rust:annotate-snippets",
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:derivative",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:lalrpop-util",
         "fbsource//third-party/rust:logos",
         "fbsource//third-party/rust:lsp-types",

--- a/superconsole/BUCK
+++ b/superconsole/BUCK
@@ -10,7 +10,7 @@ rust_library(
         ["src/**/*.rs"],
     ),
     crate_root = "src/lib.rs",
-    test_deps = ["fbsource//third-party/rust:derive_more-1"],
+    test_deps = ["fbsource//third-party/rust:derive_more"],
     deps = [
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:crossbeam-channel",
@@ -39,7 +39,7 @@ rust_binary(
     srcs = ["examples/finalization.rs"],
     deps = [
         "fbsource//third-party/rust:anyhow",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:tokio",
         ":superconsole",
     ],
@@ -69,7 +69,7 @@ rust_binary(
     srcs = ["examples/stylized.rs"],
     deps = [
         "fbsource//third-party/rust:anyhow",
-        "fbsource//third-party/rust:derive_more-1",
+        "fbsource//third-party/rust:derive_more",
         "fbsource//third-party/rust:tokio",
         ":superconsole",
     ],


### PR DESCRIPTION
Seems derive_more upgrade might be a WIP, if not the case here is a PR that can be applied or merged to fix it from the open source / github side. Please feel free to close if this being resolved internally.