### PR TITLE
remote_execution: enable ActionCache support in OSS builds

### DIFF
--- a/app/buck2_execute/src/execute/output.rs
+++ b/app/buck2_execute/src/execute/output.rs
@@ -14,10 +14,12 @@ use anyhow::Context;
 use buck2_common::file_ops::FileDigest;
 use buck2_core::execution_types::executor_config::RemoteExecutorUseCase;
 use futures::future;
+use remote_execution::InlinedBlobWithDigest;
 use remote_execution::TDigest;
 
 use crate::digest::CasDigestConversionResultExt;
 use crate::digest::CasDigestFromReExt;
+use crate::digest::CasDigestToReExt;
 use crate::digest_config::DigestConfig;
 use crate::re::manager::ManagedRemoteExecutionClient;
 use crate::re::streams::RemoteCommandStdStreams;
@@ -238,12 +240,13 @@ impl CommandStdStreams {
         self,
         client: &ManagedRemoteExecutionClient,
         use_case: RemoteExecutorUseCase,
+        digest_config: DigestConfig,
     ) -> anyhow::Result<StdStreamPair<ReStdStream>> {
         match self {
             Self::Local { stdout, stderr } => {
                 let (stdout, stderr) = future::try_join(
-                    maybe_upload_to_re(client, use_case, stdout),
-                    maybe_upload_to_re(client, use_case, stderr),
+                    maybe_upload_to_re(client, use_case, stdout, digest_config),
+                    maybe_upload_to_re(client, use_case, stderr, digest_config),
                 )
                 .await?;
 
@@ -276,11 +279,17 @@ async fn maybe_upload_to_re(
     client: &ManagedRemoteExecutionClient,
     use_case: RemoteExecutorUseCase,
     bytes: Vec<u8>,
+    digest_config: DigestConfig,
 ) -> anyhow::Result<ReStdStream> {
     const MIN_STREAM_UPLOAD_SIZE: usize = 50 * 1024; // Same as RE
     if bytes.len() < MIN_STREAM_UPLOAD_SIZE {
         return Ok(ReStdStream::Raw(bytes));
     }
-    let digest = client.upload_blob(bytes, use_case).await?;
+    let inline_blob = InlinedBlobWithDigest {
+        digest: FileDigest::from_content(&bytes, digest_config.cas_digest_config()).to_re(),
+        blob: bytes,
+        ..Default::default()
+    };
+    let digest = client.upload_blob(inline_blob, use_case).await?;
     Ok(ReStdStream::Digest(digest))
 }

--- a/app/buck2_execute/src/re/client.rs
+++ b/app/buck2_execute/src/re/client.rs
@@ -318,7 +318,7 @@ impl RemoteExecutionClient {
 
     pub async fn upload_blob(
         &self,
-        blob: Vec<u8>,
+        blob: InlinedBlobWithDigest,
         use_case: RemoteExecutorUseCase,
     ) -> anyhow::Result<TDigest> {
         self.data
@@ -1131,9 +1131,10 @@ impl RemoteExecutionClientImpl {
 
     pub async fn upload_blob(
         &self,
-        blob: Vec<u8>,
+        blob: InlinedBlobWithDigest,
         use_case: RemoteExecutorUseCase,
     ) -> anyhow::Result<TDigest> {
+        let digest = blob.digest.clone();
         with_error_handler(
             "upload_blob",
             self.get_session_id(),
@@ -1141,7 +1142,8 @@ impl RemoteExecutionClientImpl {
                 .upload_blob(blob, use_case.metadata(None))
                 .await,
         )
-        .await
+        .await?;
+        Ok(digest)
     }
 
     async fn materialize_files(

--- a/app/buck2_execute/src/re/manager.rs
+++ b/app/buck2_execute/src/re/manager.rs
@@ -455,7 +455,7 @@ impl ManagedRemoteExecutionClient {
 
     pub async fn upload_blob(
         &self,
-        blob: Vec<u8>,
+        blob: InlinedBlobWithDigest,
         use_case: RemoteExecutorUseCase,
     ) -> anyhow::Result<TDigest> {
         self.lock()?.get().await?.upload_blob(blob, use_case).await

--- a/app/buck2_execute_impl/src/executors/caching.rs
+++ b/app/buck2_execute_impl/src/executors/caching.rs
@@ -416,7 +416,7 @@ impl CacheUploader {
                 .report
                 .std_streams
                 .clone()
-                .into_re(&self.re_client, self.re_use_case)
+                .into_re(&self.re_client, self.re_use_case, digest_config)
                 .await
                 .context("Error accessing std_streams")
         };

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -758,11 +758,21 @@ impl REClient {
 
     pub async fn upload_blob(
         &self,
-        _blob: Vec<u8>,
-        _metadata: RemoteExecutionMetadata,
-    ) -> anyhow::Result<TDigest> {
-        // TODO(aloiscochard)
-        Err(anyhow::anyhow!("Not implemented (RE upload_blob)"))
+        blob: InlinedBlobWithDigest,
+        metadata: RemoteExecutionMetadata,
+    ) -> anyhow::Result<()> {
+        self.upload(
+            metadata,
+            UploadRequest {
+                inlined_blobs_with_digest: Some(vec![blob]),
+                files_with_digest: None,
+                directories: None,
+                upload_only_missing: false,
+                ..Default::default()
+            },
+        )
+        .await?;
+        Ok(())
     }
 
     pub async fn download(


### PR DESCRIPTION
This is a forward port of #477 to the latest trunk. It didn't take much time to get working or testing, but it would be really nice to have this for OSS use in GitHub Actions (where you disable RE but use the cache), so we should try to get it working.

This is two patches, which are collectively all the "juice" from #477:

- The first fixes the usage of ActionCache so that locally run actions get cached.
- The second fixes a bug where `upload_blob` wasn't uploading stdout/stderr when the sizes were > 50KiB

I can submit tests too, though I'm not sure where. But, using the testing example from #477, running `./buck2 clean && BUCK_LOG=buck2_execute_impl=debug ./buck2 build -v3 //:` where `./buck2` is the dotslash build from the [`2024-09-02` tag](https://github.com/facebook/buck2/releases/tag/2024-09-02) gets me:

```
austin@GANON:~/tmp/buck2-test-477$ ./buck2 clean && BUCK_LOG=buck2_execute_impl=debug ./buck2 build -v3 //:
killing buckd server
Buck2 daemon pid 1862754 has exited
/home/austin/tmp/buck2-test-477/buck-out/v2/CACHEDIR.TAG
/home/austin/tmp/buck2-test-477/buck-out/v2/tmp
/home/austin/tmp/buck2-test-477/buck-out/v2/gen
/home/austin/tmp/buck2-test-477/buck-out/v2/log
/home/austin/tmp/buck2-test-477/buck-out/v2/forkserver
/home/austin/.buck/buckd/home/austin/tmp/buck2-test-477/v2
Starting new buck2 daemon...
Connected to new buck2 daemon.
Running action: root//:tests (<unspecified>) (stage0) (build), local executor: env -- 'TMPDIR=/home/austin/tmp/buck2-test-477/buck-out/v2/tmp/root/99fb5bba051d5fee/stage0' 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/root/99fb5bba051d5fee/stage0' 'BUCK2_DAEMON_UUID=7f7061a9-f018-441c-8dbb-b5b149c0909b' 'BUCK_BUILD_ID=531fa58e-8263-468c-b908-7415b5e87944' /usr/bin/env sh -c '/usr/bin/env yes abcdefghijklmnopqrstuvwxyz | /usr/bin/head -c 65536 && echo done > "$1"' -- buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0
Build ID: 531fa58e-8263-468c-b908-7415b5e87944
Network: (GRPC-SESSION-ID)
Jobs completed: 10. Time elapsed: 0.1s.
Cache hits: 0%. Commands: 1 (cached: 0, remote: 0, local: 1)
[2024-09-03T17:04:15.718-05:00] 2024-09-03T22:04:15.564918Z  INFO buck2_execute_impl::executors::worker: Creating new WorkerPool
[2024-09-03T17:04:15.718-05:00] 2024-09-03T22:04:15.707678Z  INFO buck2_execute_impl::executors::local: Local execution command line:
[2024-09-03T17:04:15.718-05:00] ```
[2024-09-03T17:04:15.718-05:00] $ /usr/bin/env sh -c /usr/bin/env yes abcdefghijklmnopqrstuvwxyz | /usr/bin/head -c 65536 && echo done > "$1" -- buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0
[2024-09-03T17:04:15.718-05:00] ```
[2024-09-03T17:04:15.719-05:00] 2024-09-03T22:04:15.711154Z DEBUG buck2_execute_impl::executors::caching: Uploading action result for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142`
[2024-09-03T17:04:15.719-05:00] 2024-09-03T22:04:15.714243Z  WARN buck2_execute_impl::executors::caching: Cache upload for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142` failed: Upload for permission check: Remote Execution Error on write_action_result for ReSession GRPC-SESSION-ID
[2024-09-03T17:04:15.719-05:00] Error: (Not supported)
[2024-09-03T17:04:15.719-05:00] 2024-09-03T22:04:15.714274Z  INFO buck2_execute_impl::executors::caching: Dep file cache upload for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142` not attempted
[2024-09-03T17:04:15.719-05:00] 2024-09-03T22:04:15.714558Z DEBUG materialize_artifact{event_dispatcher=EventDispatcher(TraceId = 531fa58e-8263-468c-b908-7415b5e87944) path=buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0}: buck2_execute_impl::materializers::deferred: nothing to materialize, adding to access times buffer
```

Executing with this patch (truncated output of the exact same command above):

```
Cache hits: 0%. Commands: 1 (cached: 0, remote: 0, local: 1)
[2024-09-03T17:06:01.780-05:00] 2024-09-03T22:06:01.594777Z  INFO buck2_execute_impl::executors::worker: Creating new WorkerPool
[2024-09-03T17:06:01.780-05:00] 2024-09-03T22:06:01.759943Z  INFO buck2_execute_impl::executors::local: Local execution command line:
[2024-09-03T17:06:01.780-05:00] ```
[2024-09-03T17:06:01.780-05:00] $ /usr/bin/env sh -c /usr/bin/env yes abcdefghijklmnopqrstuvwxyz | /usr/bin/head -c 65536 && echo done > "$1" -- buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0
[2024-09-03T17:06:01.780-05:00] ```
[2024-09-03T17:06:01.780-05:00] 2024-09-03T22:06:01.764632Z DEBUG buck2_execute_impl::executors::caching: Uploading action result for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142`
[2024-09-03T17:06:01.780-05:00] 2024-09-03T22:06:01.777826Z  INFO buck2_execute_impl::executors::caching: Cache upload for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142` succeeded
[2024-09-03T17:06:01.780-05:00] 2024-09-03T22:06:01.777862Z  INFO buck2_execute_impl::executors::caching: Dep file cache upload for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142` not attempted
[2024-09-03T17:06:01.780-05:00] 2024-09-03T22:06:01.778246Z DEBUG materialize_artifact{event_dispatcher=EventDispatcher(TraceId = 3c7147f3-2c6b-49e6-ba00-cfcf230b2dfc) path=buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0}: buck2_execute_impl::materializers::deferred: nothing to materialize, adding to access times buffer
```

And then running the command again, showing a cache hit:

```
Cache hits: 100%. Commands: 1 (cached: 1, remote: 0, local: 0)
[2024-09-03T17:06:04.975-05:00] 2024-09-03T22:06:04.834804Z  INFO buck2_execute_impl::executors::worker: Creating new WorkerPool
[2024-09-03T17:06:04.975-05:00] 2024-09-03T22:06:04.969252Z  INFO buck2_execute_impl::executors::action_cache: Action result is cached, skipping execution of:
[2024-09-03T17:06:04.975-05:00] ```
[2024-09-03T17:06:04.975-05:00] $ /usr/bin/env sh -c /usr/bin/env yes abcdefghijklmnopqrstuvwxyz | /usr/bin/head -c 65536 && echo done > "$1" -- buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0
[2024-09-03T17:06:04.976-05:00] ```
[2024-09-03T17:06:04.976-05:00]  for action `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142`
[2024-09-03T17:06:04.976-05:00] 2024-09-03T22:06:04.969338Z  INFO buck2_execute_impl::executors::caching: Cache upload for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142` not attempted
[2024-09-03T17:06:04.976-05:00] 2024-09-03T22:06:04.969349Z  INFO buck2_execute_impl::executors::caching: Dep file cache upload for `4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142` not attempted
[2024-09-03T17:06:04.976-05:00] 2024-09-03T22:06:04.969721Z DEBUG materialize_artifact{event_dispatcher=EventDispatcher(TraceId = 709c8472-7b45-4e22-af70-d72d789a98c0) path=buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0}: buck2_execute_impl::materializers::deferred: materialize artifact has_entry_and_method=true method=Some(CasDownload { info: CasDownloadInfo { origin: Execution(ActionExecutionOrigin { action_digest: [4d0d66e6fcec174bb91a2173d9dbf46900028215ab714b32cceb4439be742eae:142 expires at 1725401164], action_instant: 2024-09-03T22:06:04.969094718Z, ttl: TimeDelta { secs: 0, nanos: 0 } }), re_use_case: RemoteExecutorUseCase(Intern { pointer: InternedData { data: "buck2-default", hash: 13166193100074524988 } }) } }) has_deps=false version=2 cleaning=false
[2024-09-03T17:06:04.976-05:00] 2024-09-03T22:06:04.974376Z DEBUG materialization_finished{artifact_path=ProjectRelativePathBuf("buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0") timestamp=2024-09-03T22:06:04.969799792Z version=Version(2) path=buck-out/v2/gen/root/6dd044292ff31ae1/__tests__/stage0}: buck2_execute_impl::materializers::deferred: transition to Materialized has_deps=false
```