### PR TITLE
buck2_execute: implement OSS `upload_blob` for `local_only` cache uploads

### DIFF
--- a/app/buck2_execute/src/re/client.rs
+++ b/app/buck2_execute/src/re/client.rs
@@ -303,7 +303,7 @@ impl RemoteExecutionClient {
 
     pub async fn upload_blob(
         &self,
-        blob: Vec<u8>,
+        blob: InlinedBlobWithDigest,
         use_case: RemoteExecutorUseCase,
     ) -> buck2_error::Result<TDigest> {
         self.data
@@ -1228,17 +1228,19 @@ impl RemoteExecutionClientImpl {
 
     pub async fn upload_blob(
         &self,
-        blob: Vec<u8>,
+        blob: InlinedBlobWithDigest,
         use_case: RemoteExecutorUseCase,
     ) -> buck2_error::Result<TDigest> {
+        let digest = blob.digest.clone();
         with_error_handler(
             "upload_blob",
             self.get_session_id(),
             self.client()
-                .upload_blob(blob, use_case.metadata(None))
+                .upload_blob_with_digest(blob.blob, blob.digest, use_case.metadata(None))
                 .await,
         )
-        .await
+        .await?;
+        Ok(digest)
     }
 
     async fn materialize_files(

--- a/app/buck2_execute/src/re/manager.rs
+++ b/app/buck2_execute/src/re/manager.rs
@@ -471,7 +471,7 @@ impl ManagedRemoteExecutionClient {
 
     pub async fn upload_blob(
         &self,
-        blob: Vec<u8>,
+        blob: InlinedBlobWithDigest,
         use_case: RemoteExecutorUseCase,
     ) -> buck2_error::Result<TDigest> {
         let use_case = self.re_use_case_override.unwrap_or(use_case);

--- a/app/buck2_execute_impl/src/executors/caching.rs
+++ b/app/buck2_execute_impl/src/executors/caching.rs
@@ -417,7 +417,7 @@ impl CacheUploader {
                 .report
                 .std_streams
                 .clone()
-                .into_re(&self.re_client, self.re_use_case)
+                .into_re(&self.re_client, self.re_use_case, digest_config)
                 .await
                 .buck_error_context("Error accessing std_streams")
         };

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -760,13 +760,25 @@ impl REClient {
         .await
     }
 
-    pub async fn upload_blob(
+    pub async fn upload_blob_with_digest(
         &self,
-        _blob: Vec<u8>,
-        _metadata: RemoteExecutionMetadata,
-    ) -> anyhow::Result<TDigest> {
-        // TODO(aloiscochard)
-        Err(anyhow::anyhow!("Not implemented (RE upload_blob)"))
+        blob: Vec<u8>,
+        digest: TDigest,
+        metadata: RemoteExecutionMetadata,
+    ) -> anyhow::Result<()> {
+        let blob = InlinedBlobWithDigest{digest:digest.clone(), blob, ..Default::default()};
+        self.upload(
+            metadata,
+            UploadRequest {
+                inlined_blobs_with_digest: Some(vec![blob]),
+                files_with_digest: None,
+                directories: None,
+                upload_only_missing: false,
+                ..Default::default()
+            },
+        )
+        .await?;
+        Ok(())
     }
 
     pub async fn download(


### PR DESCRIPTION
Forward-port of patch 4 in <https://github.com/facebook/buck2/pull/477>, providing a clear piece of missing functionality: in the event that stdout or stderr were more than 50KiB of output when caching `local_only` actions, then this dead path was taken, and so stdout/stderr would not be uploaded successfully in the cache.