### PR TITLE
`rust-project check TARGET`

### DIFF
--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -221,6 +221,36 @@ pub(crate) fn to_json_project(
                 cwd: project_root.to_owned(),
                 kind: RunnableKind::TestOne,
             },
+            Runnable {
+                kind: RunnableKind::Run,
+                program: "buck2".to_string(),
+                args: vec!["run".to_owned(), "{label}".to_string()],
+                cwd: project_root.clone(),
+            },
+            Runnable {
+                kind: RunnableKind::TestOne,
+                program: "buck2".to_string(),
+                args: vec![
+                    "test".to_owned(),
+                    "{label}".to_owned(),
+                    "--".to_owned(),
+                    // R-A substitutes $$TEST_NAME$$ with e.g. `mycrate::tests::one`
+                    // --test-arg tells `buck2 test` to pass that string through to
+                    // the test program, which we will assume to be the rust test
+                    // harness.
+                    // Same overall effect as `cargo test -- mycrate::tests::one`,
+                    //
+                    // But this is a bit less than ideal, because buck will build
+                    // all of the related test binaries, including integration tests.
+                    // We don't know your naming conventions for library tests.
+                    // You might have a rust_test target named `mycrate-test`. So
+                    // we might need a way (probably buck metadata in the library
+                    // target) to tell rust-project about these.
+                    "--test-arg".to_owned(),
+                    "{test_id}".to_owned(),
+                ],
+                cwd: project_root.clone(),
+            },
         ],
         // needed to ignore the generated `rust-project.json` in diffs, but including the actual
         // string will mark this file as generated

--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -50,6 +50,7 @@ pub(crate) fn to_json_project(
     aliases: FxHashMap<Target, AliasedTargetInfo>,
     relative_paths: bool,
     check_cycles: bool,
+    use_clippy: bool,
 ) -> Result<JsonProject, anyhow::Error> {
     let mode = select_mode(None);
     let buck = Buck::new(mode);
@@ -220,6 +221,19 @@ pub(crate) fn to_json_project(
                 ],
                 cwd: project_root.to_owned(),
                 kind: RunnableKind::TestOne,
+            },
+            Runnable {
+                kind: RunnableKind::Flycheck,
+                program: "rust-project".to_owned(),
+                args: {
+                    let mut args = vec!["check".to_owned(), "{label}".to_owned()];
+                    if !use_clippy {
+                        args.push("--use-clippy".to_owned());
+                        args.push("false".to_owned());
+                    }
+                    args
+                },
+                cwd: project_root.clone(),
             },
             Runnable {
                 kind: RunnableKind::Run,

--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -577,13 +577,10 @@ impl Buck {
         if let Some(parent_dir) = saved_file.parent() {
             command.current_dir(parent_dir);
         }
+        
+        tracing::debug!(?command, "running bxl");
 
         let output = command.output();
-        if let Ok(output) = &output {
-            if output.stdout.is_empty() {
-                return Ok(vec![]);
-            }
-        }
 
         let files = deserialize_output(output, &command)?;
         Ok(files)
@@ -611,6 +608,9 @@ impl Buck {
             "--targets",
         ]);
         command.args(targets);
+
+        tracing::debug!(?command, "running bxl");
+
         deserialize_output(command.output(), &command)
     }
 

--- a/integrations/rust-project/src/cli/develop.rs
+++ b/integrations/rust-project/src/cli/develop.rs
@@ -40,6 +40,7 @@ pub(crate) struct Develop {
     pub(crate) buck: buck::Buck,
     pub(crate) check_cycles: bool,
     pub(crate) invoked_by_ra: bool,
+    pub(crate) use_clippy: bool,
 }
 
 pub(crate) struct OutputCfg {
@@ -67,6 +68,7 @@ impl Develop {
             mode,
             check_cycles,
             log_scuba_to_stdout: _,
+            use_clippy,
         } = command
         {
             let out = if stdout {
@@ -92,6 +94,7 @@ impl Develop {
                 buck,
                 check_cycles,
                 invoked_by_ra: false,
+                use_clippy,
             };
             let out = OutputCfg { out, pretty };
 
@@ -109,6 +112,7 @@ impl Develop {
             sysroot_mode,
             args,
             log_scuba_to_stdout: _,
+            use_clippy,
         } = command
         {
             let out = Output::Stdout;
@@ -135,6 +139,7 @@ impl Develop {
                 buck,
                 check_cycles: false,
                 invoked_by_ra: true,
+                use_clippy,
             };
             let out = OutputCfg { out, pretty: false };
 
@@ -233,6 +238,7 @@ impl Develop {
             relative_paths,
             buck,
             check_cycles,
+            use_clippy,
             ..
         } = self;
 
@@ -272,6 +278,7 @@ impl Develop {
             aliased_libraries,
             *relative_paths,
             *check_cycles,
+            *use_clippy,
         )?;
 
         let duration = start.elapsed();

--- a/integrations/rust-project/src/cli/develop.rs
+++ b/integrations/rust-project/src/cli/develop.rs
@@ -261,10 +261,7 @@ impl Develop {
                     sysroot_path = relative_to(&sysroot_path, &project_root);
                 }
 
-                Sysroot {
-                    sysroot: sysroot_path,
-                    sysroot_src: None,
-                }
+                Sysroot::with_default_sysroot_src(sysroot_path)
             }
             SysrootConfig::BuckConfig => {
                 resolve_buckconfig_sysroot(&project_root, *relative_paths)?

--- a/integrations/rust-project/src/json_project.rs
+++ b/integrations/rust-project/src/json_project.rs
@@ -15,6 +15,7 @@
 //!
 //! [documentation]: https://rust-analyzer.github.io/manual.html#non-cargo-based-projects
 
+use std::path::Path;
 use std::path::PathBuf;
 
 use rustc_hash::FxHashMap;
@@ -247,19 +248,14 @@ pub(crate) struct Sysroot {
     /// if you do not provide a value. So we will always provide one.
     pub(crate) sysroot_src: PathBuf,
 }
-
 impl Sysroot {
-    pub(crate) fn with_default_sysroot_src(sysroot: PathBuf) -> Self {
-        let mut sysroot_src = sysroot.clone();
+    pub(crate) fn sysroot_src_for_sysroot(sysroot: &Path) -> PathBuf {
+        let mut sysroot_src = sysroot.to_owned();
         sysroot_src.push("lib");
         sysroot_src.push("rustlib");
         sysroot_src.push("src");
         sysroot_src.push("rust");
         sysroot_src.push("library");
-
-        Self {
-            sysroot_src,
-            sysroot,
-        }
+        sysroot_src
     }
 }

--- a/integrations/rust-project/src/main.rs
+++ b/integrations/rust-project/src/main.rs
@@ -139,8 +139,7 @@ enum Command {
         mode: Option<String>,
         #[clap(short = 'c', long, default_value = "true", action = ArgAction::Set)]
         use_clippy: bool,
-        /// The file saved by the user. `rust-project` will infer the owning target(s) of the saved file and build them.
-        saved_file: PathBuf,
+        target: String,
         /// Write Scuba sample to stdout.
         #[clap(long, hide = true)]
         log_scuba_to_stdout: bool,
@@ -285,14 +284,14 @@ fn main() -> Result<(), anyhow::Error> {
         Command::Check {
             mode,
             use_clippy,
-            saved_file,
+            target,
             log_scuba_to_stdout,
         } => {
             let subscriber = tracing_subscriber::registry()
                 .with(fmt.with_filter(filter))
                 .with(scuba::ScubaLayer::new(log_scuba_to_stdout));
             tracing::subscriber::set_global_default(subscriber)?;
-            cli::Check::new(mode, use_clippy, saved_file).run()
+            cli::Check::new(mode, use_clippy, target).run()
         }
     }
 }

--- a/integrations/rust-project/src/main.rs
+++ b/integrations/rust-project/src/main.rs
@@ -84,6 +84,8 @@ enum Command {
         ///
         /// This option requires the presence of `rustc` in the `$PATH`, as rust-project
         /// will run `rustc --print sysroot` and ignore any other `sysroot` configuration.
+        ///
+        /// The sysroot_src is set to `${sysroot}/lib/rustlib/src/rust/library`
         #[clap(long, conflicts_with = "sysroot")]
         prefer_rustup_managed_toolchain: bool,
 
@@ -91,6 +93,11 @@ enum Command {
         /// Default value is determined based on platform.
         #[clap(short = 's', long)]
         sysroot: Option<PathBuf>,
+
+        /// Default is `${sysroot}/lib/rustlib/src/rust/library`. Not used when using
+        /// `.buckconfig`-managed sysroot.
+        #[clap(long)]
+        sysroot_src: Option<PathBuf>,
 
         /// Pretty-print generated `rust-project.json` file.
         #[clap(short, long)]

--- a/integrations/rust-project/src/main.rs
+++ b/integrations/rust-project/src/main.rs
@@ -108,6 +108,11 @@ enum Command {
         #[clap(short = 'm', long)]
         mode: Option<String>,
 
+        /// Enables clippy in the flycheck commands in `rust-project.json`
+        /// Default is true, pass `--use-clippy false` to disable
+        #[clap(short = 'c', long, default_value = "true", action = ArgAction::Set)]
+        use_clippy: bool,
+
         /// Write Scuba sample to stdout.
         #[clap(long, hide = true)]
         log_scuba_to_stdout: bool,
@@ -130,6 +135,11 @@ enum Command {
         #[clap(long, default_value = "rustc")]
         sysroot_mode: SysrootMode,
 
+        /// Enables clippy in the flycheck commands in `rust-project.json`
+        /// Default is true, pass `--use-clippy false` to disable
+        #[clap(short = 'c', long, default_value = "true", action = ArgAction::Set)]
+        use_clippy: bool,
+
         args: JsonArguments,
     },
     /// Build the saved file's owning target. This is meant to be used by IDEs to provide diagnostics on save.
@@ -137,6 +147,8 @@ enum Command {
         /// Optional argument specifying build mode.
         #[clap(short = 'm', long)]
         mode: Option<String>,
+        /// Enables clippy in the flycheck commands in `rust-project.json`
+        /// Default is true, pass `--use-clippy false` to disable
         #[clap(short = 'c', long, default_value = "true", action = ArgAction::Set)]
         use_clippy: bool,
         target: String,

--- a/integrations/rust-project/src/sysroot.rs
+++ b/integrations/rust-project/src/sysroot.rs
@@ -61,7 +61,7 @@ pub(crate) fn resolve_buckconfig_sysroot(
         // buck2 run fbcode//third-party-buck/platform010/build/rust:bin/rustc -- --print sysroot
         let sysroot = Sysroot {
             sysroot: base.join("fbcode/third-party-buck/platform010/build/rust/llvm-fb-15"),
-            sysroot_src: Some(sysroot_src),
+            sysroot_src,
         };
 
         return Ok(sysroot);
@@ -95,7 +95,7 @@ pub(crate) fn resolve_buckconfig_sysroot(
 
     let sysroot = Sysroot {
         sysroot,
-        sysroot_src: Some(sysroot_src),
+        sysroot_src,
     };
 
     Ok(sysroot)
@@ -111,17 +111,7 @@ pub(crate) fn resolve_rustup_sysroot() -> Result<Sysroot, anyhow::Error> {
 
     let mut output = utf8_output(cmd.output(), &cmd)?;
     truncate_line_ending(&mut output);
-    let sysroot = PathBuf::from(output);
-    let sysroot_src = sysroot
-        .join("lib")
-        .join("rustlib")
-        .join("src")
-        .join("rust")
-        .join("library");
-
-    let sysroot = Sysroot {
-        sysroot,
-        sysroot_src: Some(sysroot_src),
-    };
+    let sysroot_path = PathBuf::from(output);
+    let sysroot = Sysroot::with_default_sysroot_src(sysroot_path);
     Ok(sysroot)
 }

--- a/prelude/rust/rust-analyzer/check.bxl
+++ b/prelude/rust/rust-analyzer/check.bxl
@@ -8,10 +8,15 @@
 load("@prelude//rust:outputs.bzl", "RustcExtraOutputsInfo")
 
 def check_targets_impl(ctx: bxl.Context) -> None:
-    uquery_owners = ctx.uquery().owner(ctx.cli_args.file)
-    target_universe = ctx.target_universe(uquery_owners)
-    owners = ctx.cquery().owner(ctx.cli_args.file, target_universe.target_set())
-    nodes = ctx.cquery().kind("^(rust_binary|rust_library|rust_test)$", owners)
+    if ctx.cli_args.target != None:
+        uquery_targets = ctx.uquery().kind("^(rust_binary|rust_library|rust_test)$", ctx.cli_args.target)
+        target_universe = ctx.target_universe(uquery_targets)
+        nodes = ctx.cquery().kind("^(rust_binary|rust_library|rust_test)$", target_universe.target_set())
+    elif ctx.cli_args.file != None:
+        uquery_owners = ctx.uquery().owner(ctx.cli_args.file)
+        target_universe = ctx.target_universe(uquery_owners)
+        owners = ctx.cquery().owner(ctx.cli_args.file, target_universe.target_set())
+        nodes = ctx.cquery().kind("^(rust_binary|rust_library|rust_test)$", owners)
 
     if len(nodes) == 0:
         ctx.output.print_json([])
@@ -39,7 +44,8 @@ def check_targets_impl(ctx: bxl.Context) -> None:
 check = bxl_main(
     impl = check_targets_impl,
     cli_args = {
-        "file": cli_args.string(),
+        "file": cli_args.option(cli_args.string()),
+        "target": cli_args.option(cli_args.target_label()),
         "use-clippy": cli_args.bool(),
     },
 )

--- a/prelude/rust/rust-analyzer/check.bxl
+++ b/prelude/rust/rust-analyzer/check.bxl
@@ -14,6 +14,7 @@ def check_targets_impl(ctx: bxl.Context) -> None:
     nodes = ctx.cquery().kind("^(rust_binary|rust_library|rust_test)$", owners)
 
     if len(nodes) == 0:
+        ctx.output.print_json([])
         return
 
     analysis = ctx.analysis(nodes).values()

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -11,4 +11,4 @@
 
 # @rustc_version: rustc 1.80.0-nightly (804421dff 2024-06-07)
 channel = "nightly-2024-06-08"
-components = ["llvm-tools-preview","rustc-dev","rust-src"]
+components = ["llvm-tools-preview","rustc-dev","rust-src", "rust-analyzer"]


### PR DESCRIPTION
Context: relies on the as-yet unmerged https://github.com/rust-lang/rust-analyzer/pull/18043 adds `{label}` interpolation in rust-analyzer flycheck commands and allows `rust-project develop-json` to supply the flycheck commands.

Previously rust-project worked with the `$saved_file` interpolation in rust-analyzer. This PR makes it work with a target label instead. So it's not really backwards compatible, but we can make it so. Submitting this now to get feedback.

We also now emit flycheck runnables that configure rust-analyzer to do flychecks using `rust-project check`.

Also:

- `rust-project develop-json --use-clippy false`
- Don't just exit silently if check.bxl fails, show us what went wrong
- Errors out if your rustc sysroot does not have the `rust-src` component. This was an undocumented requirement and rust-analyzer just doesn't work without it, so we should fail as early as possible.
- Clobbers the existing `buck2 test` runnables to make them work with the rustc_test harness and OSS buck2. Don't know what to do there.

Attn @davidbarsky