### PR TITLE
buck2_client: download traces via `buck2.log_url` config key

### DIFF
--- a/app/buck2_client_ctx/src/client_ctx.rs
+++ b/app/buck2_client_ctx/src/client_ctx.rs
@@ -14,6 +14,7 @@ use buck2_cli_proto::client_context::HostPlatformOverride as GrpcHostPlatformOve
 use buck2_cli_proto::client_context::PreemptibleWhen as GrpcPreemptibleWhen;
 use buck2_cli_proto::ClientContext;
 use buck2_common::argv::Argv;
+use buck2_common::init::LogDownloadMethod;
 use buck2_common::invocation_paths::InvocationPaths;
 use buck2_common::invocation_paths_result::InvocationPathsResult;
 use buck2_core::error::buck2_hard_error_env;
@@ -304,5 +305,13 @@ impl<'a> ClientCommandContext<'a> {
 
     pub fn async_cleanup_context(&self) -> &AsyncCleanupContext<'a> {
         &self.async_cleanup
+    }
+
+    pub fn log_download_method(&self) -> LogDownloadMethod {
+        self.immediate_config
+            .daemon_startup_config()
+            .unwrap()
+            .log_download_method
+            .clone()
     }
 }

--- a/app/buck2_common/src/init.rs
+++ b/app/buck2_common/src/init.rs
@@ -294,6 +294,13 @@ impl ResourceControlConfig {
     }
 }
 
+#[derive(Allocative, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LogDownloadMethod {
+    Manifold,
+    Curl(String),
+    None,
+}
+
 /// Configurations that are used at startup by the daemon. Those are actually read by the client,
 /// and passed on to the daemon.
 ///
@@ -313,11 +320,46 @@ pub struct DaemonStartupConfig {
     pub materializations: Option<String>,
     pub http: HttpConfig,
     pub resource_control: ResourceControlConfig,
+    pub log_download_method: LogDownloadMethod,
 }
 
 impl DaemonStartupConfig {
     pub fn new(config: &LegacyBuckConfig) -> buck2_error::Result<Self> {
         // Intepreted client side because we need the value here.
+
+        let log_download_method = {
+            // Determine the log download method to use. Only default to
+            // manifold in fbcode contexts, or when specifically asked.
+            let use_manifold_default = cfg!(fbcode_build);
+            let use_manifold = config
+                .parse(BuckconfigKeyRef {
+                    section: "buck2",
+                    property: "log_use_manifold",
+                })?
+                .unwrap_or(use_manifold_default);
+
+            if use_manifold {
+                Ok(LogDownloadMethod::Manifold)
+            } else {
+                let log_url = config.get(BuckconfigKeyRef {
+                    section: "buck2",
+                    property: "log_url",
+                });
+                if let Some(log_url) = log_url {
+                    if log_url.is_empty() {
+                        Err(buck2_error::buck2_error!(
+                            buck2_error::ErrorTag::Input,
+                            "log_url is empty, but log_use_manifold is false"
+                        ))
+                    } else {
+                        Ok(LogDownloadMethod::Curl(log_url.to_owned()))
+                    }
+                } else {
+                    Ok(LogDownloadMethod::None)
+                }
+            }
+        }?;
+
         Ok(Self {
             daemon_buster: config
                 .get(BuckconfigKeyRef {
@@ -346,6 +388,7 @@ impl DaemonStartupConfig {
                 .map(ToOwned::to_owned),
             http: HttpConfig::from_config(config)?,
             resource_control: ResourceControlConfig::from_config(config)?,
+            log_download_method,
         })
     }
 
@@ -366,6 +409,11 @@ impl DaemonStartupConfig {
             materializations: None,
             http: HttpConfig::default(),
             resource_control: ResourceControlConfig::default(),
+            log_download_method: if cfg!(fbcode_build) {
+                LogDownloadMethod::Manifold
+            } else {
+                LogDownloadMethod::None
+            },
         }
     }
 }


### PR DESCRIPTION
When doing a command like `buck2 log replay --trace-id ...` it helps to be able to download previously created logs from users, automated CI, etc. This functionality exists within Meta, as logs are available for download through the "Manifest" system, but it isn't usable in OSS, despite being useful for diagnostics and getting help.

The only missing thing to really get things working is a download mechanism for log files, and a way to know where they should come from.

With this patch, if a user configures the `buck2.log_url` key, which is expected to look something like:

    [buck2]
    log_url = https://example.com

Then, upon executing a `log` command with a `--trace-id` flag, this server will be queried with a:

    GET /v1/get/{uuid}

request, which is expected to return the raw zst-encoded protobuf file. So, buck2 will do that and download the trace, and then use it like normal.

The request is done with `curl`, though in principle it could be done within Buck itself.

This shares as much code as possible with the existing infrastructure and tries to only insert a small key set of `#[cfg(fbcode_build)]` directives. Notably, the path Meta uses for their "Manifold" client is still fully available in the OSS version; `fbcode_build` is only used to gate what the default choice is.

How the server gets access to these files and how they are uploaded is another question. But for now, this can be done several ways outside of buck2 core, so this is good enough.

GitHub Issue: https://github.com/facebook/buck2/issues/441