### PR TITLE
Add remote persistent worker support

### DIFF
--- a/app/buck2_action_impl/src/actions/impls/run.rs
+++ b/app/buck2_action_impl/src/actions/impls/run.rs
@@ -255,6 +255,7 @@ struct UnpackedWorkerValues<'v> {
     exe: &'v dyn CommandLineArgLike,
     id: WorkerId,
     concurrency: Option<usize>,
+    remote: bool,
 }
 
 struct UnpackedRunActionValues<'v> {
@@ -308,6 +309,7 @@ impl RunAction {
             exe: worker.exe_command_line(),
             id: WorkerId(worker.id),
             concurrency: worker.concurrency(),
+            remote: worker.remote(),
         });
 
         Ok(UnpackedRunActionValues {
@@ -323,6 +325,7 @@ impl RunAction {
         &self,
         fs: &ExecutorFs,
         artifact_visitor: &mut impl CommandLineArtifactVisitor,
+        actx: &dyn ActionExecutionCtx,
     ) -> anyhow::Result<(ExpandedCommandLine, Option<WorkerSpec>)> {
         let mut ctx = DefaultCommandLineContext::new(fs);
         let values = Self::unpack(&self.starlark_values)?;
@@ -339,10 +342,27 @@ impl RunAction {
                 .exe
                 .add_to_command_line(&mut worker_rendered, &mut ctx)?;
             worker.exe.visit_artifacts(artifact_visitor)?;
+            let worker_key = if worker.remote {
+                let mut worker_visitor = SimpleCommandLineArtifactVisitor::new();
+                worker.exe.visit_artifacts(&mut worker_visitor)?;
+                if !worker_visitor.outputs.is_empty() {
+                    // TODO[AH] create appropriate error enum value.
+                    return Err(anyhow::anyhow!("remote persistent worker command should not produce an output"));
+                }
+                let worker_inputs: Vec<&ArtifactGroupValues> = worker_visitor
+                    .inputs()
+                    .map(|group| actx.artifact_values(group))
+                    .collect();
+                let (_, worker_digest) = metadata_content(fs.fs(), &worker_inputs, actx.digest_config())?;
+                Some(worker_digest)
+            } else {
+                None
+            };
             Some(WorkerSpec {
                 exe: worker_rendered,
                 id: worker.id,
                 concurrency: worker.concurrency,
+                remote_key: worker_key,
             })
         } else {
             None
@@ -413,7 +433,7 @@ impl RunAction {
         let fs = executor_fs.fs();
 
         let (expanded, worker) =
-            self.expand_command_line_and_worker(&ctx.executor_fs(), visitor)?;
+            self.expand_command_line_and_worker(&ctx.executor_fs(), visitor, ctx)?;
 
         // TODO (@torozco): At this point, might as well just receive the list already. Finding
         // those things in a HashMap is just not very useful.

--- a/app/buck2_build_api/src/interpreter/rule_defs/command_executor_config.rs
+++ b/app/buck2_build_api/src/interpreter/rule_defs/command_executor_config.rs
@@ -81,6 +81,7 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
     /// * `allow_hybrid_fallbacks_on_failure`: Whether to allow fallbacks when the result is failure (i.e. the command failed on the primary, but the infra worked)
     /// * `use_windows_path_separators`: Whether to use Windows path separators in command line arguments
     /// * `use_persistent workers`: Whether to use persistent workers for local execution if they are available
+    /// * `use_remote_persistent_workers`: Whether to use persistent workers for remote execution if they are available
     /// * `allow_cache_uploads`: Whether to upload local actions to the RE cache
     /// * `max_cache_upload_mebibytes`: Maximum size to upload in cache uploads
     /// * `experimental_low_pass_filter`: Whether to use the experimental low pass filter
@@ -105,6 +106,7 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
         #[starlark(default = false, require = named)] allow_hybrid_fallbacks_on_failure: bool,
         #[starlark(default = false, require = named)] use_windows_path_separators: bool,
         #[starlark(default = false, require = named)] use_persistent_workers: bool,
+        #[starlark(default = false, require = named)] use_remote_persistent_workers: bool,
         #[starlark(default = false, require = named)] allow_cache_uploads: bool,
         #[starlark(default = NoneOr::None, require = named)] max_cache_upload_mebibytes: NoneOr<
             i32,
@@ -306,6 +308,7 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
                         PathSeparatorKind::Unix
                     },
                     output_paths_behavior,
+                    use_remote_persistent_workers,
                 },
             }
         };

--- a/app/buck2_build_api/src/interpreter/rule_defs/provider/builtin/worker_info.rs
+++ b/app/buck2_build_api/src/interpreter/rule_defs/provider/builtin/worker_info.rs
@@ -45,6 +45,8 @@ pub struct WorkerInfoGen<V: ValueLifetimeless> {
     pub exe: ValueOfUncheckedGeneric<V, FrozenStarlarkCmdArgs>,
     // Maximum number of concurrent commands to execute on a worker instance without queuing
     pub concurrency: ValueOfUncheckedGeneric<V, NoneOr<usize>>,
+    // Remote execution capable worker
+    pub remote: ValueOfUncheckedGeneric<V, bool>,
 
     pub id: u64,
 }
@@ -62,6 +64,7 @@ fn worker_info_creator(globals: &mut GlobalsBuilder) {
         #[starlark(require = named, default = NoneOr::None)] concurrency: NoneOr<
             ValueOf<'v, usize>,
         >,
+        #[starlark(require = named, default = false)] remote: bool,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<WorkerInfo<'v>> {
         let heap = eval.heap();
@@ -72,6 +75,7 @@ fn worker_info_creator(globals: &mut GlobalsBuilder) {
             exe,
             id,
             concurrency: heap.alloc_typed_unchecked(concurrency).cast(),
+            remote: heap.alloc_typed_unchecked(remote).cast(),
         })
     }
 }
@@ -89,6 +93,13 @@ impl<'v, V: ValueLike<'v>> WorkerInfoGen<V> {
             .unpack()
             .expect("validated at construction")
             .into_option()
+    }
+
+    pub fn remote(&self) -> bool {
+        self.remote
+            .to_value()
+            .unpack()
+            .expect("validated at construction")
     }
 }
 

--- a/app/buck2_core/src/execution_types/executor_config.rs
+++ b/app/buck2_core/src/execution_types/executor_config.rs
@@ -262,6 +262,7 @@ impl Default for CacheUploadBehavior {
 pub struct CommandGenerationOptions {
     pub path_separator: PathSeparatorKind,
     pub output_paths_behavior: OutputPathsBehavior,
+    pub use_remote_persistent_workers: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Hash, Allocative)]
@@ -293,6 +294,7 @@ impl CommandExecutorConfig {
             options: CommandGenerationOptions {
                 path_separator: PathSeparatorKind::system_default(),
                 output_paths_behavior: Default::default(),
+                use_remote_persistent_workers: false,
             },
         })
     }

--- a/app/buck2_execute/src/execute/command_executor.rs
+++ b/app/buck2_execute/src/execute/command_executor.rs
@@ -183,6 +183,13 @@ impl CommandExecutor {
                 }
                 CommandExecutionInput::ScratchPath(_) => None,
             });
+            let mut platform = self.0.re_platform.clone();
+            if self.0.options.use_remote_persistent_workers && let Some(worker) = request.worker() && let Some(key) = worker.remote_key.as_ref() {
+                platform.properties.push(RE::Property {
+                    name: "persistentWorkerKey".to_owned(),
+                    value: key.to_string(),
+                });
+            }
             let action = re_create_action(
                 request.all_args_vec(),
                 request.paths().output_paths(),
@@ -191,7 +198,7 @@ impl CommandExecutor {
                 input_digest,
                 action_metadata_blobs,
                 request.timeout(),
-                self.0.re_platform.clone(),
+                platform,
                 false,
                 digest_config,
                 self.0.options.output_paths_behavior,

--- a/app/buck2_execute/src/execute/request.rs
+++ b/app/buck2_execute/src/execute/request.rs
@@ -274,11 +274,12 @@ impl CommandExecutionPaths {
 #[derive(Copy, Clone, Dupe, Debug, Display, Allocative, Hash, PartialEq, Eq)]
 pub struct WorkerId(pub u64);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WorkerSpec {
     pub id: WorkerId,
     pub exe: Vec<String>,
     pub concurrency: Option<usize>,
+    pub remote_key: Option<TrackedFileDigest>,
 }
 
 /// The data contains the information about the command to be executed.

--- a/app/buck2_execute/src/lib.rs
+++ b/app/buck2_execute/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(try_blocks)]
 #![feature(try_trait_v2)]
 #![feature(used_with_arg)]
+#![feature(let_chains)]
 
 pub mod artifact;
 pub mod artifact_utils;

--- a/app/buck2_server/src/daemon/common.rs
+++ b/app/buck2_server/src/daemon/common.rs
@@ -470,6 +470,7 @@ pub fn get_default_executor_config(host_platform: HostPlatformOverride) -> Comma
         options: CommandGenerationOptions {
             path_separator: get_default_path_separator(host_platform),
             output_paths_behavior: Default::default(),
+            use_remote_persistent_workers: false,
         },
     }
 }

--- a/app/buck2_test/src/orchestrator.rs
+++ b/app/buck2_test/src/orchestrator.rs
@@ -848,6 +848,7 @@ impl<'b> BuckTestOrchestrator<'b> {
             options: CommandGenerationOptions {
                 path_separator: PathSeparatorKind::system_default(),
                 output_paths_behavior: Default::default(),
+                use_remote_persistent_workers: false,
             },
         };
         let CommandExecutorResponse {
@@ -1352,6 +1353,7 @@ impl<'a> Execute2RequestExpander<'a> {
                     exe: worker_rendered,
                     id: WorkerId(worker.id),
                     concurrency: worker.concurrency(),
+                    remote_key: None,
                 })
             }
             _ => None,

--- a/examples/persistent_worker/.buckconfig
+++ b/examples/persistent_worker/.buckconfig
@@ -1,0 +1,17 @@
+[cells]
+root = .
+prelude = prelude
+toolchains = toolchains
+none = none
+
+[cell_aliases]
+config = prelude
+fbcode = none
+fbsource = none
+buck = none
+
+[external_cells]
+  prelude = bundled
+
+[parser]
+target_platform_detector_spec = target:root//...->prelude//platforms:default

--- a/examples/persistent_worker/.buckconfig.buildbuddy
+++ b/examples/persistent_worker/.buckconfig.buildbuddy
@@ -1,0 +1,15 @@
+[buck2]
+digest_algorithms = SHA256
+
+[buck2_re_client]
+engine_address       = grpc://remote.buildbuddy.io
+action_cache_address = grpc://remote.buildbuddy.io
+cas_address          = grpc://remote.buildbuddy.io
+tls                  = true
+http_headers         = \
+  x-buildbuddy-api-key:$BUILDBUDDY_API_KEY, \
+  x-buildbuddy-platform.container-registry-username:$BUILDBUDDY_CONTAINER_USER, \
+  x-buildbuddy-platform.container-registry-password:$BUILDBUDDY_CONTAINER_PASSWORD
+
+[build]
+execution_platforms = root//platforms:buildbuddy

--- a/examples/persistent_worker/.buckconfig.buildbuddy-persistent-workers
+++ b/examples/persistent_worker/.buckconfig.buildbuddy-persistent-workers
@@ -1,0 +1,15 @@
+[buck2]
+digest_algorithms = SHA256
+
+[buck2_re_client]
+engine_address       = grpc://remote.buildbuddy.io
+action_cache_address = grpc://remote.buildbuddy.io
+cas_address          = grpc://remote.buildbuddy.io
+tls                  = true
+http_headers         = \
+  x-buildbuddy-api-key:$BUILDBUDDY_API_KEY, \
+  x-buildbuddy-platform.container-registry-username:$BUILDBUDDY_CONTAINER_USER, \
+  x-buildbuddy-platform.container-registry-password:$BUILDBUDDY_CONTAINER_PASSWORD
+
+[build]
+execution_platforms = root//platforms:buildbuddy-persistent-workers

--- a/examples/persistent_worker/.buckconfig.local-persistent-workers
+++ b/examples/persistent_worker/.buckconfig.local-persistent-workers
@@ -1,0 +1,2 @@
+[build]
+execution_platforms = root//platforms:local-persistent-workers

--- a/examples/persistent_worker/.buckconfig.no-workers
+++ b/examples/persistent_worker/.buckconfig.no-workers
@@ -1,0 +1,2 @@
+[build]
+execution_platforms = root//platforms:local

--- a/examples/persistent_worker/.gitignore
+++ b/examples/persistent_worker/.gitignore
@@ -1,0 +1,6 @@
+.buckconfig.local
+.direnv
+.envrc.private
+image.digest
+prelude
+toolchains/.buckconfig.nix

--- a/examples/persistent_worker/BUCK
+++ b/examples/persistent_worker/BUCK
@@ -1,0 +1,21 @@
+load("defs.bzl", "demo", "worker")
+
+python_binary(
+    name = "worker_py",
+    main = "persistent_worker.py",
+    deps = [
+        "//proto/bazel:worker_protocol_pb2",
+        "//proto/buck2:worker_pb2",
+    ],
+)
+
+worker(
+    name = "worker",
+    worker = ":worker_py",
+    visibility = ["PUBLIC"],
+)
+
+[
+    demo(name = "demo-" + str(i))
+    for i in range(10)
+]

--- a/examples/persistent_worker/README.md
+++ b/examples/persistent_worker/README.md
@@ -1,0 +1,101 @@
+# Persistent Worker Demo
+
+At the time of writing (2024-09-25) Buck2 supports persistent workers
+for local builds through a dedicated Buck2 persistent worker gRPC
+protocol. However, Buck2 does not support persistent workers for builds
+that use remote execution. This demo is part of a patch-set that adds
+support for remote persistent workers to Buck2, see [#776].
+
+[#776]: https://github.com/facebook/buck2/issues/776
+
+## Requirements
+
+The demo uses Nix to provide required system dependencies, such as
+Python and grpc-io. As well as direnv to set up the environment.
+
+- [Nix](https://nixos.org/)
+- [direnv](https://direnv.net/)
+
+Credentials for [BuildBuddy](https://www.buildbuddy.io/) and
+[GHCR](https://ghcr.io) stored in `.envrc.private`:
+```
+export BUILDBUDDY_API_KEY=...
+export BUILDBUDDY_CONTAINER_USER=...  # GitHub user name
+export BUILDBUDDY_CONTAINER_PASSWORD=...  # GitHub access token
+export GITHUB_USER=... # GitHub user name
+```
+
+Upload the Nix Docker image for remote execution as described in
+`platforms/buildbuddy.bzl`.
+
+## Local Build
+
+Configure a local build without persistent workers:
+```
+$ cd examples/persistent_worker
+$ echo '<file:.buckconfig.no-workers>' > .buckconfig.local
+```
+
+Run a clean build:
+```
+$ buck2 clean; buck2 build : -vstderr
+...
+stderr for root//:demo-7 (demo):
+...
+ONE-SHOT START
+...
+```
+
+## Local Persistent Worker
+
+Configure a local build with persistent workers:
+```
+$ cd examples/persistent_worker
+$ echo '<file:.buckconfig.local-persistent-workers>' > .buckconfig.local
+```
+
+Run a clean build:
+```
+$ buck2 clean; buck2 build : -vstderr
+...
+stderr for root//:demo-7 (demo):
+...
+Buck2 persistent worker ...
+...
+```
+
+## Remote Execution
+
+Configure a remote build without persistent workers:
+```
+$ cd examples/persistent_worker
+$ echo '<file:.buckconfig.buildbuddy>' > .buckconfig.local
+```
+
+Run a clean build:
+```
+$ buck2 clean; buck2 build : -vstderr
+...
+stderr for root//:demo-7 (demo):
+...
+ONE-SHOT START
+...
+```
+
+## Remote Persistent Worker
+
+Configure a remote build with persistent workers:
+```
+$ cd examples/persistent_worker
+$ echo '<file:.buckconfig.buildbuddy>' > .buckconfig.local
+```
+
+Run a clean build:
+```
+$ buck2 clean; buck2 build : -vstderr
+...
+stderr for root//:demo-7 (demo):
+...
+Bazel persistent worker ...
+...
+```

--- a/examples/persistent_worker/defs.bzl
+++ b/examples/persistent_worker/defs.bzl
@@ -1,0 +1,43 @@
+load("@prelude//utils:argfile.bzl", "at_argfile")
+
+def _worker_impl(ctx: AnalysisContext) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        WorkerInfo(
+            exe = ctx.attrs.worker[RunInfo].args,
+            concurrency = None,
+            remote = True,
+        ),
+    ]
+
+worker = rule(
+    impl = _worker_impl,
+    attrs = {
+        "worker": attrs.dep(providers = [RunInfo]),
+    },
+)
+
+def _demo_impl(ctx: AnalysisContext) -> list[Provider]:
+    output = ctx.actions.declare_output(ctx.label.name)
+    worker_exe = ctx.attrs._worker[WorkerInfo].exe
+    argfile = at_argfile(
+        actions = ctx.actions,
+        name = "demo." + ctx.label.name + ".args",
+        args = cmd_args(output.as_output()),
+    )
+    ctx.actions.run(
+        cmd_args(worker_exe, argfile),
+        category = "demo",
+        exe = WorkerRunInfo(worker = ctx.attrs._worker[WorkerInfo]),
+    )
+    return [DefaultInfo(default_output = output)]
+
+demo = rule(
+    impl = _demo_impl,
+    attrs = {
+        "_worker": attrs.exec_dep(
+            default = "//:worker",
+            providers = [WorkerInfo],
+        ),
+    },
+)

--- a/examples/persistent_worker/flake.lock
+++ b/examples/persistent_worker/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727140925,
+        "narHash": "sha256-ZHSasdLwEEjSOD/WTW1o7dr3/EjuYsdwYB4NSgICZ2I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "189e5f171b163feb7791a9118afa778d9a1db81f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/persistent_worker/flake.nix
+++ b/examples/persistent_worker/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Buck2 Remote Persistent Worker Example";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+  flake-utils.lib.eachDefaultSystem (system: let
+    pkgs = import nixpkgs {
+      inherit system;
+      overlays = [];
+      config = {};
+    };
+    python = (pkgs.python3.override {
+      packageOverrides = self: super: {
+        protobuf = self.protobuf5;
+      };
+    }).withPackages (ps: with ps; [
+      ipython
+      grpcio
+      grpcio-tools
+    ]);
+  in
+  {
+    devShells = {
+      default = pkgs.mkShellNoCC {
+        packages = [ python ];
+        NIX_PYTHON = "${python}/bin/python";
+        shellHook = ''
+          cat >toolchains/.buckconfig.nix <<EOF
+          [nix]
+          python = ${python}/bin/python
+          EOF
+        '';
+      };
+    };
+
+    apps = {
+      dockerBuild = {
+        type = "app";
+        program = "${self.packages.${system}.dockerImage}";
+      };
+    };
+
+    packages = {
+      dockerImage = pkgs.dockerTools.streamNixShellImage {
+        name = "nix-build";
+        drv = pkgs.mkShell.override { stdenv = pkgs.stdenvNoCC; }
+          {
+            PATH = pkgs.lib.makeBinPath [ pkgs.bash pkgs.coreutils ];
+            nativeBuildInputs = [ python ];
+          };
+        tag = "latest";
+      };
+    };
+  });
+}

--- a/examples/persistent_worker/persistent_worker.py
+++ b/examples/persistent_worker/persistent_worker.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Buck2 local and remote persistent worker and action runner.
+
+This script can:
+- Execute build requests in one-shot mode for builds without persistent workers enabled.
+- Execute build requests as a Buck2 local persistent worker.
+- Execute build requests as a remote persistent worker through Bazel protocol.
+"""
+
+import argparse
+from concurrent import futures
+from dataclasses import dataclass
+import google.protobuf.proto as proto
+import grpc
+import os
+import sys
+import time
+import proto.bazel.worker_protocol_pb2 as bazel_pb2
+import proto.buck2.worker_pb2 as buck2_pb2
+import proto.buck2.worker_pb2_grpc as buck2_pb2_grpc
+import shlex
+import socket
+
+
+@dataclass
+class Request:
+    """Universal worker request, independent of Buck2 or Bazel protocol."""
+    argv: list[str]
+
+
+@dataclass
+class Response:
+    """Universal worker response, independent of Buck2 or Bazel protocol."""
+    exit_code: int
+    stderr: str
+
+
+class ArgumentParserError(Exception):
+    pass
+
+
+class RecoverableArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        raise ArgumentParserError(f"{self.prog}: error: {message}\n")
+
+
+class Implementation:
+    """Universal worker implementation, independent of Buck2 or Bazel protocol."""
+    def __init__(self):
+        self.parser = RecoverableArgumentParser(
+            fromfile_prefix_chars='@',
+            prog="worker_py_handler",
+            description="Persistent Worker Request Handler")
+        self.parser.add_argument(
+            "outfile",
+            type=argparse.FileType("w"),
+            help="Output file.")
+
+    def execute(self, request: Request) -> Response:
+        try:
+            print("WORKER", socket.gethostname(), os.getpid(), os.getcwd(), file=sys.stderr)
+            print("REQUEST", request.argv, file=sys.stderr)
+            args = self.parser.parse_args(request.argv)
+            print("ARGS", args, file=sys.stderr)
+            output = args.outfile
+            name = os.path.basename(output.name)
+            print("WRITE", name, file=sys.stderr)
+            output.write(name + "\n")
+            print("SLEEP", name, file=sys.stderr)
+            time.sleep(1)
+            print("COMPLETED", name, file=sys.stderr)
+            output.close()
+            return Response(
+                exit_code = 0,
+                stderr = f"wrote to {output.name}")
+        except ArgumentParserError as e:
+            return Response(exit_code = 2, stderr = str(e))
+
+
+class Buck2Servicer(buck2_pb2_grpc.WorkerServicer):
+    """Buck2 remote persistent worker implementation."""
+    def __init__(self):
+        self.impl = Implementation()
+
+    def Execute(self, request, context):
+        _ = context
+        print("BUCK2", request, file=sys.stderr)
+        # Decode arguments as UTF-8 strings.
+        # Drop the first argument, which is the worker binary.
+        # The first argument is needed for Bazel remote execution persistent workers.
+        argv = [arg.decode("utf-8") for arg in request.argv[1:]]
+        response = self.impl.execute(Request(argv = argv))
+        host = socket.gethostname()
+        pid = os.getpid()
+        cwd = os.getcwd()
+        return buck2_pb2.ExecuteResponse(
+            exit_code = response.exit_code,
+            stderr = f"Buck2 persistent worker {host} {pid} {cwd}\n" + response.stderr)
+
+
+class BazelServicer:
+    def __init__(self):
+        self.impl = Implementation()
+
+    def Execute(self, request: bazel_pb2.WorkRequest) -> bazel_pb2.WorkResponse:
+        print("BAZEL", request, file=sys.stderr)
+        response = self.impl.execute(Request(argv = request.arguments))
+        host = socket.gethostname()
+        pid = os.getpid()
+        cwd = os.getcwd()
+        return bazel_pb2.WorkResponse(
+            exit_code = response.exit_code,
+            output = f"Bazel persistent worker {host} {pid} {cwd} {request.request_id}\n" + response.stderr,
+            request_id = request.request_id)
+
+
+def main():
+    print("MAIN", socket.gethostname(), os.getpid(), os.getcwd(), file=sys.stderr)
+    parser = argparse.ArgumentParser(
+        fromfile_prefix_chars='@',
+        prog="worker",
+        description="Buck2/Bazel Local/Remote Persistent Worker")
+    parser.add_argument(
+        "--persistent_worker",
+        action="store_true",
+        help="Enable persistent worker (Bazel protocol).")
+
+    (args, rest) = parser.parse_known_args()
+
+    if socket_path := os.getenv("WORKER_SOCKET"):
+        # Buck2 persistent worker mode
+        print("BUCK2 WORKER START", file=sys.stderr)
+        if rest:
+            rest_joined = " ".join(map(shlex.quote, rest))
+            print(f"Unexpected arguments: {rest_joined}\n", file=sys.stderr)
+            parser.print_usage()
+            sys.exit(2)
+
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=os.cpu_count() or 1))
+        buck2_pb2_grpc.add_WorkerServicer_to_server(Buck2Servicer(), server)
+        server.add_insecure_port(f"unix://{socket_path}")
+        server.start()
+        server.wait_for_termination()
+    elif args.persistent_worker:
+        # Bazel persistent worker mode
+        print("BAZEL WORKER START", file=sys.stderr)
+        if rest:
+            rest_joined = " ".join(map(shlex.quote, rest))
+            print(f"Unexpected arguments: {rest_joined}\n", file=sys.stderr)
+            parser.print_usage()
+            sys.exit(2)
+
+        servicer = BazelServicer()
+        # uses length prefixed serialization features added in proto version 5.28.0.
+        # https://github.com/protocolbuffers/protobuf/pull/16965
+        while request := proto.parse_length_prefixed(bazel_pb2.WorkRequest, sys.stdin.buffer):
+            response = servicer.Execute(request)
+            proto.serialize_length_prefixed(response, sys.stdout.buffer)
+            sys.stdout.flush()
+    else:
+        # One-shot execution mode
+        print("ONE-SHOT START", file=sys.stderr)
+        servicer = Implementation()
+        request = Request(argv = rest)
+        response = servicer.execute(request)
+        print(response.stderr, file=sys.stderr)
+        sys.exit(response.exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/persistent_worker/platforms/BUCK
+++ b/examples/persistent_worker/platforms/BUCK
@@ -1,0 +1,33 @@
+load(":buildbuddy.bzl", "buildbuddy")
+load(":local.bzl", "local")
+
+host_cpu = "prelude//cpu:" + ("arm64" if host_info().arch.is_aarch64 else "x86_64")
+host_os = "prelude//os:" + ("macos" if host_info().os.is_macos else "linux")
+
+buildbuddy(
+    name = "buildbuddy",
+    cpu_configuration = host_cpu,
+    os_configuration = host_os,
+    use_persistent_workers = False,
+)
+
+buildbuddy(
+    name = "buildbuddy-persistent-workers",
+    cpu_configuration = host_cpu,
+    os_configuration = host_os,
+    use_persistent_workers = True,
+)
+
+local(
+    name = "local",
+    cpu_configuration = host_cpu,
+    os_configuration = host_os,
+    use_persistent_workers = False,
+)
+
+local(
+    name = "local-persistent-workers",
+    cpu_configuration = host_cpu,
+    os_configuration = host_os,
+    use_persistent_workers = True,
+)

--- a/examples/persistent_worker/platforms/buildbuddy.bzl
+++ b/examples/persistent_worker/platforms/buildbuddy.bzl
@@ -1,0 +1,52 @@
+# Update the Docker image for remote execution whenever you make a change to the Nix package set.
+#
+#   nix run path:.#dockerBuild \
+#     | gzip --fast --no-name \
+#     | nix run nixpkgs#skopeo -- copy \
+#         --insecure-policy \
+#         --digestfile image.digest \
+#         --preserve-digests docker-archive:/dev/stdin \
+#         docker://ghcr.io/$GITHUB_USER/buck2-remote-persistent-worker:latest
+#
+# NOTE, Change to a container registry that you have access to.
+image = "docker://ghcr.io/aherrmann/buck2-remote-persistent-worker@sha256:23832b49492ef77601111218661b8fcc6eafbcc49cb9abffd08d79988dda540e"
+
+def _platforms(ctx):
+    constraints = dict()
+    constraints.update(ctx.attrs.cpu_configuration[ConfigurationInfo].constraints)
+    constraints.update(ctx.attrs.os_configuration[ConfigurationInfo].constraints)
+    configuration = ConfigurationInfo(constraints = constraints, values = {})
+
+    platform = ExecutionPlatformInfo(
+        label = ctx.label.raw_target(),
+        configuration = configuration,
+        executor_config = CommandExecutorConfig(
+            local_enabled = True,
+            remote_enabled = True,
+            remote_cache_enabled = True,
+            allow_cache_uploads = True,
+            use_limited_hybrid = True,
+            use_persistent_workers = ctx.attrs.use_persistent_workers,
+            use_remote_persistent_workers = ctx.attrs.use_persistent_workers,
+            remote_execution_properties = {
+                "OSFamily": "Linux",
+                "container-image": image,
+                "workload-isolation-type": "podman",
+                "recycle-runner": True,  # required for remote persistent workers
+                "nonroot-workspace": True,
+            },
+            remote_execution_use_case = "buck2-default",
+            remote_output_paths = "output_paths",
+        ),
+    )
+
+    return [DefaultInfo(), ExecutionPlatformRegistrationInfo(platforms = [platform])]
+
+buildbuddy = rule(
+    attrs = {
+        "cpu_configuration": attrs.dep(providers = [ConfigurationInfo]),
+        "os_configuration": attrs.dep(providers = [ConfigurationInfo]),
+        "use_persistent_workers": attrs.bool(default = False),
+    },
+    impl = _platforms
+)

--- a/examples/persistent_worker/platforms/local.bzl
+++ b/examples/persistent_worker/platforms/local.bzl
@@ -1,0 +1,29 @@
+def _platforms(ctx):
+    constraints = dict()
+    constraints.update(ctx.attrs.cpu_configuration[ConfigurationInfo].constraints)
+    constraints.update(ctx.attrs.os_configuration[ConfigurationInfo].constraints)
+    configuration = ConfigurationInfo(constraints = constraints, values = {})
+
+    platform = ExecutionPlatformInfo(
+        label = ctx.label.raw_target(),
+        configuration = configuration,
+        executor_config = CommandExecutorConfig(
+            local_enabled = True,
+            remote_enabled = False,
+            remote_cache_enabled = False,
+            allow_cache_uploads = False,
+            use_persistent_workers = ctx.attrs.use_persistent_workers,
+            use_remote_persistent_workers = False,
+        ),
+    )
+
+    return [DefaultInfo(), ExecutionPlatformRegistrationInfo(platforms = [platform])]
+
+local = rule(
+    attrs = {
+        "cpu_configuration": attrs.dep(providers = [ConfigurationInfo]),
+        "os_configuration": attrs.dep(providers = [ConfigurationInfo]),
+        "use_persistent_workers": attrs.bool(default = False),
+    },
+    impl = _platforms
+)

--- a/examples/persistent_worker/proto/BUCK
+++ b/examples/persistent_worker/proto/BUCK
@@ -1,0 +1,5 @@
+python_binary(
+    name = "protoc",
+    main_module = "grpc_tools.protoc",
+    visibility = ["PUBLIC"],
+)

--- a/examples/persistent_worker/proto/bazel/BUCK
+++ b/examples/persistent_worker/proto/bazel/BUCK
@@ -1,0 +1,24 @@
+genrule(
+    name = "build-pb2",
+    cmd = r"""
+        $(exe //proto:protoc) \
+            -Iproto/bazel=${SRCDIR} \
+            --python_out=${OUT} \
+            --pyi_out=${OUT} \
+            --grpc_python_out=${OUT} \
+            ${SRCS}
+        mv ${OUT}/proto/bazel/* ${OUT}/
+    """,
+    srcs = ["worker_protocol.proto"],
+    outs = {"pb2": [
+        "worker_protocol_pb2.py",
+        "worker_protocol_pb2.pyi",
+        "worker_protocol_pb2_grpc.py",
+    ]},
+)
+
+python_library(
+    name = "worker_protocol_pb2",
+    srcs = [":build-pb2[pb2]"],
+    visibility = ["PUBLIC"],
+)

--- a/examples/persistent_worker/proto/bazel/worker_protocol.proto
+++ b/examples/persistent_worker/proto/bazel/worker_protocol.proto
@@ -1,0 +1,98 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package blaze.worker;
+
+option java_package = "com.google.devtools.build.lib.worker";
+
+// An input file.
+message Input {
+  // The path in the file system where to read this input artifact from. This is
+  // either a path relative to the execution root (the worker process is
+  // launched with the working directory set to the execution root), or an
+  // absolute path.
+  string path = 1;
+
+  // A hash-value of the contents. The format of the contents is unspecified and
+  // the digest should be treated as an opaque token. This can be empty in some
+  // cases.
+  bytes digest = 2;
+}
+
+// This represents a single work unit that Blaze sends to the worker.
+message WorkRequest {
+  repeated string arguments = 1;
+
+  // The inputs that the worker is allowed to read during execution of this
+  // request.
+  repeated Input inputs = 2;
+
+  // Each WorkRequest must have either a unique
+  // request_id or request_id = 0. If request_id is 0, this WorkRequest must be
+  // processed alone (singleplex), otherwise the worker may process multiple
+  // WorkRequests in parallel (multiplexing). As an exception to the above, if
+  // the cancel field is true, the request_id must be the same as a previously
+  // sent WorkRequest. The request_id must be attached unchanged to the
+  // corresponding WorkResponse. Only one singleplex request may be sent to a
+  // worker at a time.
+  int32 request_id = 3;
+
+  // EXPERIMENTAL: When true, this is a cancel request, indicating that a
+  // previously sent WorkRequest with the same request_id should be cancelled.
+  // The arguments and inputs fields must be empty and should be ignored.
+  bool cancel = 4;
+
+  // Values greater than 0 indicate that the worker may output extra debug
+  // information to stderr (which will go into the worker log). Setting the
+  // --worker_verbose flag for Bazel makes this flag default to 10.
+  int32 verbosity = 5;
+
+  // The relative directory inside the workers working directory where the
+  // inputs and outputs are placed, for sandboxing purposes. For singleplex
+  // workers, this is unset, as they can use their working directory as sandbox.
+  // For multiplex workers, this will be set when the
+  // --experimental_worker_multiplex_sandbox flag is set _and_ the execution
+  // requirements for the worker includes 'supports-multiplex-sandbox'.
+  // The paths in `inputs` will not contain this prefix, but the actual files
+  // will be placed/must be written relative to this directory. The worker
+  // implementation is responsible for resolving the file paths.
+  string sandbox_dir = 6;
+}
+
+// The worker sends this message to Blaze when it finished its work on the
+// WorkRequest message.
+message WorkResponse {
+  int32 exit_code = 1;
+
+  // This is printed to the user after the WorkResponse has been received and is
+  // supposed to contain compiler warnings / errors etc. - thus we'll use a
+  // string type here, which gives us UTF-8 encoding.
+  string output = 2;
+
+  // This field must be set to the same request_id as the WorkRequest it is a
+  // response to. Since worker processes which support multiplex worker will
+  // handle multiple WorkRequests in parallel, this ID will be used to
+  // determined which WorkerProxy does this WorkResponse belong to.
+  int32 request_id = 3;
+
+  // EXPERIMENTAL When true, indicates that this response was sent due to
+  // receiving a cancel request. The exit_code and output fields should be empty
+  // and will be ignored. Exactly one WorkResponse must be sent for each
+  // non-cancelling WorkRequest received by the worker, but if the worker
+  // received a cancel request, it doesn't matter if it replies with a regular
+  // WorkResponse or with one where was_cancelled = true.
+  bool was_cancelled = 4;
+}

--- a/examples/persistent_worker/proto/buck2/BUCK
+++ b/examples/persistent_worker/proto/buck2/BUCK
@@ -1,0 +1,24 @@
+genrule(
+    name = "build-pb2",
+    cmd = r"""
+        $(exe //proto:protoc) \
+            -Iproto/buck2=${SRCDIR} \
+            --python_out=${OUT} \
+            --pyi_out=${OUT} \
+            --grpc_python_out=${OUT} \
+            ${SRCS}
+        mv ${OUT}/proto/buck2/* ${OUT}/
+    """,
+    srcs = ["worker.proto"],
+    outs = {"pb2": [
+        "worker_pb2.py",
+        "worker_pb2.pyi",
+        "worker_pb2_grpc.py",
+    ]},
+)
+
+python_library(
+    name = "worker_pb2",
+    srcs = [":build-pb2[pb2]"],
+    visibility = ["PUBLIC"],
+)

--- a/examples/persistent_worker/proto/buck2/worker.proto
+++ b/examples/persistent_worker/proto/buck2/worker.proto
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.facebook.buck.worker.model";
+option java_outer_classname = "WorkerProto";
+
+package worker;
+
+message ExecuteCommand {
+  message EnvironmentEntry {
+    bytes key = 1;
+    bytes value = 2;
+  }
+
+  repeated bytes argv = 1;
+  repeated EnvironmentEntry env = 2;
+}
+
+message ExecuteResponse {
+  int32 exit_code = 1;
+  string stderr = 2;
+}
+
+message ExecuteCancel {}
+
+message ExecuteEvent {
+  oneof data {
+    ExecuteCommand command = 1;
+    ExecuteCancel cancel = 2;
+  }
+}
+
+service Worker {
+  // TODO(ctolliday) delete once workers switch to Exec
+  rpc Execute(ExecuteCommand) returns (ExecuteResponse) {};
+
+  rpc Exec(stream ExecuteEvent) returns (ExecuteResponse) {};
+}

--- a/examples/persistent_worker/toolchains/.buckconfig
+++ b/examples/persistent_worker/toolchains/.buckconfig
@@ -1,0 +1,1 @@
+<file:.buckconfig.nix>

--- a/examples/persistent_worker/toolchains/BUCK
+++ b/examples/persistent_worker/toolchains/BUCK
@@ -1,0 +1,25 @@
+load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
+load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
+
+system_cxx_toolchain(
+    name = "cxx",
+    visibility = ["PUBLIC"],
+)
+
+system_genrule_toolchain(
+    name = "genrule",
+    visibility = ["PUBLIC"],
+)
+
+system_python_bootstrap_toolchain(
+    name = "python_bootstrap",
+    interpreter = read_config("nix", "python"),
+    visibility = ["PUBLIC"],
+)
+
+system_python_toolchain(
+    name = "python",
+    interpreter = read_config("nix", "python"),
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
Closes #776.

Implements support for persistent workers in remote builds using the Bazel remote execution protocol and the approach documented in the Bazel remote persistent workers proposal:
https://github.com/bazelbuild/proposals/blob/main/designs/2021-03-06-remote-persistent-workers.md

Includes an example setup that works with
- local builds without persistent worker
- local builds with persistent worker (Buck2 protocol)
- remote builds without persistent worker
- remote builds with persistent worker (Bazel protocol)

The Bazel remote persistent worker protocol includes an automatic fallback in cases where the remote execution system does not yet support persistent workers. To that end actions take the shape
```
WORKER WORKER_ARGS... @REQUEST_ARGS_FILE
```
The remote execution system separates worker arguments on the command-line from request arguments in the response file and adds the `--persistent_worker` flag. 

The demo worker included in the example in this PR distinguishes between Buck2 worker, Bazel remote worker, and one-shot modes depending on whether Buck2's `WORKER_SOCKET`, Bazel's `--persistent_worker` flag, or neither is set.

The example includes a README with detailed instructions how to test this feature.

- **Add example for remote persistent workers**
- **Implement support for remote persistent workers**
