### PR TITLE
Support Clang on Windows in prelude

### DIFF
--- a/prelude/cxx/cxx_executable.bzl
+++ b/prelude/cxx/cxx_executable.bzl
@@ -227,7 +227,11 @@ def cxx_executable(ctx: AnalysisContext, impl_params: CxxRuleConstructorParams, 
         inherited_preprocessor_infos,
         is_coverage_enabled_by_any_dep(ctx, preprocessor_deps),
     )
-    compile_flavor = CxxCompileFlavor("pic") if link_strategy != LinkStrategy("static") else CxxCompileFlavor("default")
+    if link_strategy == LinkStrategy("static") or get_cxx_toolchain_info(ctx).pic_behavior != "supported":
+        compile_flavor = CxxCompileFlavor("default")
+    else:
+        compile_flavor = CxxCompileFlavor("pic")
+
     cxx_outs = compile_cxx(
         ctx = ctx,
         src_compile_cmds = compile_cmd_output.src_compile_cmds,

--- a/prelude/cxx/cxx_library.bzl
+++ b/prelude/cxx/cxx_library.bzl
@@ -1379,8 +1379,7 @@ def _strip_objects(ctx: AnalysisContext, objects: list[Artifact]) -> list[Artifa
     cxx_toolchain_info = get_cxx_toolchain_info(ctx)
 
     # Stripping is not supported on Windows
-    linker_type = cxx_toolchain_info.linker_info.type
-    if linker_type == LinkerType("windows"):
+    if host_info().os.is_windows:
         return objects
 
     # Disable stripping if no `strip` binary was provided by the toolchain.

--- a/prelude/cxx/cxx_link_utility.bzl
+++ b/prelude/cxx/cxx_link_utility.bzl
@@ -251,7 +251,7 @@ def executable_shared_lib_arguments(
     linker_type = cxx_toolchain.linker_info.type
 
     if len(shared_libs) > 0:
-        if linker_type == LinkerType("windows"):
+        if host_info().os.is_windows:
             shared_libs_symlink_tree = [ctx.actions.symlink_file(
                 shlib.lib.output.basename,
                 shlib.lib.output,

--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -96,7 +96,6 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
     additional_linker_flags = ["-fuse-ld=lld"] if os == "linux" and cxx_tools_info.linker != "g++" and cxx_tools_info.cxx_compiler != "g++" else []
 
     if os == "windows":
-        linker_type = LinkerType("windows")
         binary_extension = "exe"
         object_file_extension = "obj"
         static_library_extension = "lib"
@@ -113,10 +112,8 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
         shared_library_versioned_name_format = "{}.so.{}"
 
         if os == "macos":
-            linker_type = LinkerType("darwin")
             pic_behavior = PicBehavior("always_enabled")
         else:
-            linker_type = LinkerType("gnu")
             pic_behavior = PicBehavior("supported")
 
     if cxx_tools_info.compiler_type == "clang":
@@ -137,7 +134,7 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
                 archiver_supports_argfiles = archiver_supports_argfiles,
                 generate_linker_maps = False,
                 lto_mode = LtoMode("none"),
-                type = linker_type,
+                type = cxx_tools_info.linker_type,
                 link_binaries_locally = True,
                 link_libraries_locally = True,
                 archive_objects_locally = True,
@@ -156,7 +153,7 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
                 shared_library_versioned_name_format = shared_library_versioned_name_format,
                 static_library_extension = static_library_extension,
                 force_full_hybrid_if_capable = False,
-                is_pdb_generated = is_pdb_generated(linker_type, ctx.attrs.link_flags),
+                is_pdb_generated = is_pdb_generated(cxx_tools_info.linker_type, ctx.attrs.link_flags),
                 link_ordering = ctx.attrs.link_ordering,
             ),
             bolt_enabled = False,

--- a/prelude/toolchains/cxx/clang/tools.bzl
+++ b/prelude/toolchains/cxx/clang/tools.bzl
@@ -9,6 +9,10 @@ load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerType")
 load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 
 def _path_clang_tools_impl(_ctx) -> list[Provider]:
+    if host_info().os.is_windows:
+        archiver = "llvm-ar"
+    else:
+        archiver = "ar"
     return [
         DefaultInfo(),
         CxxToolsInfo(
@@ -19,7 +23,7 @@ def _path_clang_tools_impl(_ctx) -> list[Provider]:
             asm_compiler_type = "clang",
             rc_compiler = None,
             cvtres_compiler = None,
-            archiver = "ar",
+            archiver = archiver,
             archiver_type = "gnu",
             linker = "clang++",
             linker_type = LinkerType("gnu"),


### PR DESCRIPTION
Currently with `system_cxx_toolchain` on Windows, it hardcodes usage of MSVC. The changes in this PR enabled me to set the relevant options in system_cxx_toolchain / cxx_toolchain to successfully build my project with Clang on Windows. The changes mostly involved updating code that made the assumption Windows being the host system implied msvc was the only option, leading to faulty flags being set.

I attempted to run tests locally with `cargo test`, but experienced various errors including my computer crashing, errors about pagefile too small, and running out of disk space, so eventually gave up on that.