### PR TITLE
github/shim: disallow backtrace 0.3.74

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -44,7 +44,8 @@ async-recursion = "1.0"
 async-scoped = { version = "0.8", features = ["use-tokio"] }
 async-trait = "0.1.24"
 atomic = "0.5.1"
-backtrace = "0.3.51"
+# backtrace 0.3.74 is failing to build on Windows
+backtrace = ">=0.3.51,<0.3.74"
 base64 = "0.21.7"
 bincode = "1.3.3"
 bitflags = "2.4"


### PR DESCRIPTION
Summary: backtrace 0.3.74 is failing in buck2 builds: https://github.com/facebook/buck2/actions/runs/11782066104/job/32816266975

Reviewed By: stepancheg

Differential Revision: D65760231


