### PR TITLE
third-party/rust: add fixup for linkme-impl

### DIFF
--- a/shim/third-party/rust/fixups/linkme-impl/fixups.toml
+++ b/shim/third-party/rust/fixups/linkme-impl/fixups.toml
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+[[buildscript]]
+[buildscript.rustc_flags]


### PR DESCRIPTION
Summary:
Build script is here: https://github.com/dtolnay/linkme/blob/master/impl/build.rs

It adds `no_unsafe_attributes` and `no_unsafe_extern_blocks` if `rustc<1.82`.

We currently use 1.81 nightly.

Without these buck2 build fails with: {P1678493456}
https://github.com/facebook/buck2/actions/runs/11814773718/job/32914516948

Differential Revision: D65880700


