### PR TITLE
buck2/github: use faster Windows runners

### DIFF
--- a/.github/actions/build_debug/action.yml
+++ b/.github/actions/build_debug/action.yml
@@ -6,5 +6,5 @@ runs:
   - name: Build buck2 binary (debug)
     run: |-
       mkdir $RUNNER_TEMP/artifacts
-      cargo build --bin=buck2 -Z unstable-options --out-dir=$RUNNER_TEMP/artifacts
+      cargo build --bin=buck2 -Z unstable-options --artifact-dir=$RUNNER_TEMP/artifacts
     shell: bash

--- a/.github/actions/build_release/action.yml
+++ b/.github/actions/build_release/action.yml
@@ -6,5 +6,5 @@ runs:
   - name: Build buck2 binary (release)
     run: |-
       mkdir $RUNNER_TEMP/artifacts
-      cargo build --bin=buck2 --release -Z unstable-options --out-dir=$RUNNER_TEMP/artifacts
+      cargo build --bin=buck2 --release -Z unstable-options --artifact-dir=$RUNNER_TEMP/artifacts
     shell: bash

--- a/.github/actions/setup_linux_env/action.yml
+++ b/.github/actions/setup_linux_env/action.yml
@@ -25,7 +25,6 @@ runs:
   - name: Install conan
     run: sudo pip3 install conan==1.*
     shell: bash
-  - uses: actions/checkout@v4
   - uses: actions/setup-go@v5
     with:
       cache: false

--- a/.github/actions/setup_linux_env/action.yml
+++ b/.github/actions/setup_linux_env/action.yml
@@ -3,7 +3,7 @@ description: Setup Linux environment
 runs:
   using: composite
   steps:
-  - uses: SebRollen/toml-action@v1.0.2
+  - uses: SebRollen/toml-action@v1.2.0
     id: read_rust_toolchain
     with:
       file: rust-toolchain

--- a/.github/actions/setup_linux_env/action.yml
+++ b/.github/actions/setup_linux_env/action.yml
@@ -28,4 +28,5 @@ runs:
   - uses: actions/checkout@v4
   - uses: actions/setup-go@v5
     with:
+      cache: false
       go-version: '~1.22.0'

--- a/.github/actions/setup_macos_env/action.yml
+++ b/.github/actions/setup_macos_env/action.yml
@@ -16,6 +16,7 @@ runs:
   - uses: actions/checkout@v4
   - uses: actions/setup-go@v5
     with:
+      cache: false
       go-version: '~1.22.0'
   - uses: haskell-actions/setup@v2
     with:

--- a/.github/actions/setup_macos_env/action.yml
+++ b/.github/actions/setup_macos_env/action.yml
@@ -3,9 +3,15 @@ description: Setup macOS environment
 runs:
   using: composite
   steps:
-  - name: Install Rustup
-    run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=none
-    shell: bash
+  - uses: SebRollen/toml-action@v1.2.0
+    id: read_rust_toolchain
+    with:
+      file: rust-toolchain
+      field: toolchain.channel
+  - uses: dtolnay/rust-toolchain@v1
+    with:
+      toolchain: ${{ steps.read_rust_toolchain.outputs.value }}
+      components: clippy
   - name: Brew install
     run: brew install cmake python3 coreutils opam llvm protobuf zstd
     shell: bash
@@ -13,7 +19,6 @@ runs:
     run: sudo pip3 install --break-system-packages conan==1.*
     shell: bash
   - uses: "./.github/actions/print_versions"
-  - uses: actions/checkout@v4
   - uses: actions/setup-go@v5
     with:
       cache: false

--- a/.github/actions/setup_windows_env/action.yml
+++ b/.github/actions/setup_windows_env/action.yml
@@ -28,4 +28,5 @@ runs:
   - uses: actions/checkout@v4
   - uses: actions/setup-go@v5
     with:
+      cache: false
       go-version: '~1.22.0'

--- a/.github/actions/setup_windows_env/action.yml
+++ b/.github/actions/setup_windows_env/action.yml
@@ -3,29 +3,24 @@ description: Setup Windows environment for building and testing
 runs:
   using: composite
   steps:
-  - name: Install Rustup
+  - name: Write Visual Studio path
     run: |-
-      choco install -y rustup.install
-      write-output "[net]`ngit-fetch-with-cli = true" | out-file -append -encoding utf8 $Env:USERPROFILE/.cargo/config.toml
-      type $Env:USERPROFILE/.cargo/config.toml
+      $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
+      Join-Path $vsPath "VC\Tools\Llvm\x64\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
     shell: pwsh
   - name: Create python3 symlink
-    run: New-Item -ItemType SymbolicLink -Path C:\ProgramData\chocolatey\bin\python3.exe -Target $(Get-Command python).Source
+    run: |
+      New-Item -ItemType SymbolicLink -Path C:\ProgramData\chocolatey\bin\python3.exe -Target $(Get-Command python).Source
     shell: pwsh
-  - name: Write Powershell profile
-    run: |-
-      $psProfileContent = @'
-      $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath
-      $llvmPath = Join-Path $vsPath "VC\Tools\Llvm\x64\bin"
-      $env:PATH = "$env:USERPROFILE\.cargo\bin;$llvmPath;" + $env:PATH
-      $env:TEMP = "$env:USERPROFILE\temp"
-      $env:TMP = $env:TEMP
-      '@
-      Add-Content "$PsHome\profile.ps1" $psProfileContent
-      New-Item -ItemType Directory -Path "$env:USERPROFILE\temp"
-    shell: pwsh
-  - uses: "./.github/actions/print_versions"
-  - uses: actions/checkout@v4
+  - uses: SebRollen/toml-action@v1.2.0
+    id: read_rust_toolchain
+    with:
+      file: rust-toolchain
+      field: toolchain.channel
+  - uses: dtolnay/rust-toolchain@v1
+    with:
+      toolchain: ${{ steps.read_rust_toolchain.outputs.value }}
+      components: clippy
   - uses: actions/setup-go@v5
     with:
       cache: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: ./.github/actions/build_debug
     - uses: ./.github/actions/run_test_py
   windows-build-and-test:
-    runs-on: windows-latest
+    runs-on: windows-8-core
     steps:
     - uses: actions/checkout@v4.1.0
     - uses: ./.github/actions/setup_windows_env
@@ -72,7 +72,7 @@ jobs:
     - uses: ./.github/actions/setup_reindeer
     - uses: ./.github/actions/build_bootstrap
   windows-build-examples:
-    runs-on: windows-latest
+    runs-on: windows-8-core
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: ./.github/actions/setup_windows_env

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,11 +83,5 @@ jobs:
           & $Env:RUNNER_TEMP/artifacts/buck2 build //... -v 2
           & $Env:RUNNER_TEMP/artifacts/buck2 test //... -v 2
       - uses: ./.github/actions/build_example_no_prelude
-      - name: Configure CARGO_HOME
-        run: |-
-          echo CARGO_HOME=$GITHUB_WORKSPACE/.cargo >> $GITHUB_ENV
-          echo $GITHUB_WORKSPACE/.cargo/bin >> $GITHUB_PATH
-        shell:
-          bash
       - uses: ./.github/actions/setup_reindeer
       - uses: ./.github/actions/build_bootstrap

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ${{ matrix.target.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: SebRollen/toml-action@v1.0.2
@@ -135,7 +135,7 @@ jobs:
       - get_prelude_hash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       # Publish a new tag and upload all aritfacts from `build` and `get_prelude_hash`
@@ -196,7 +196,7 @@ jobs:
     # Only perform this action if check_for_bi_monthly_release set a tag output
     if: ${{ needs.check_for_bi_monthly_release.outputs.tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       # Publish a new tag and upload all aritfacts from `build` and `get_prelude_hash`
@@ -218,7 +218,7 @@ jobs:
       - build
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Download Buck2
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Summary:
For some reason Cargo builds are at least twice slower on Windows than on Linux or MacOS on Github. I checked this is true for other popular Rust projects as well.

We can use faster 8-core runners instead of 2-core to reduce this difference.

Differential Revision: D66011530


