### PR TITLE
buck2/github: enable caches for all platforms

### DIFF
--- a/.github/actions/build_debug/action.yml
+++ b/.github/actions/build_debug/action.yml
@@ -3,6 +3,9 @@ description: Build buck2 binary (debug)
 runs:
   using: composite
   steps:
+  - uses: Swatinem/rust-cache@v2
+    with:
+      prefix-key: buck2-debug
   - name: Build buck2 binary (debug)
     run: |-
       mkdir $RUNNER_TEMP/artifacts

--- a/.github/actions/build_release/action.yml
+++ b/.github/actions/build_release/action.yml
@@ -3,6 +3,9 @@ description: Build buck2 binary (release)
 runs:
   using: composite
   steps:
+  - uses: Swatinem/rust-cache@v2
+    with:
+      prefix-key: buck2-release
   - name: Build buck2 binary (release)
     run: |-
       mkdir $RUNNER_TEMP/artifacts

--- a/.github/actions/setup_linux_env/action.yml
+++ b/.github/actions/setup_linux_env/action.yml
@@ -12,9 +12,6 @@ runs:
     with:
       toolchain: ${{ steps.read_rust_toolchain.outputs.value }}
       components: clippy
-  - uses: Swatinem/rust-cache@v2
-    with:
-      prefix-key: buck2-upload
   - run: sudo apt-get update
     shell: bash
   - run: sudo apt-get install opam libzstd-dev python3-pip


### PR DESCRIPTION
Summary: Enable caches for Mac and Windows to speed up build and test jobs.

Differential Revision: D66054868


