### PR TITLE
github: disallow libc 0.2.165

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,8 @@ itertools = "0.13.0"
 jemallocator = { version = "0.5.0", features = ["profiling"] }
 lalrpop = { version = "0.19.7", artifact = "bin" }
 lalrpop-util = "0.19.7"
-libc = "0.2.147"
+# FIXME: libc v0.2.165 breaks sysinfo crate. This is fixed in sysinfo v0.32.1.
+libc = ">=0.2.147,<0.2.165"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
 linkme = { version = "0.3.17", features = ["used_linker"] }
 log = "0.4"

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -120,7 +120,8 @@ itertools = "0.13.0"
 jemallocator = { version = "0.5.0", features = ["profiling"] }
 lalrpop = { version = "0.19.7", artifact = "bin", features = ["pico-args"] }
 lalrpop-util = "0.19.7"
-libc = "0.2.132"
+# FIXME: libc v0.2.165 breaks sysinfo crate. This is fixed in sysinfo v0.32.1.
+libc = ">=0.2.132,<0.2.165"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
 linkme = { version = "0.3.17", features = ["used_linker"] }
 log = "0.4"


### PR DESCRIPTION
Summary:
`sysinfo` is fixed by https://github.com/GuillaumeGomez/sysinfo/pull/1393 which is released as v0.32.1.

But there are breaking changes compare to current sysinfo v0.30.11 we have internally and it needs to be migrated.

Differential Revision: D66499693


