### PR TITLE
github/rust: bump libc to v0.2.166

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,8 +200,7 @@ itertools = "0.13.0"
 jemallocator = { version = "0.5.0", features = ["profiling"] }
 lalrpop = { version = "0.19.7", artifact = "bin" }
 lalrpop-util = "0.19.7"
-# FIXME: libc v0.2.165 breaks sysinfo crate. This is fixed in sysinfo v0.32.1.
-libc = ">=0.2.147,<0.2.165"
+libc = "0.2.158"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
 linkme = { version = "0.3.17", features = ["used_linker"] }
 log = "0.4"

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -120,8 +120,7 @@ itertools = "0.13.0"
 jemallocator = { version = "0.5.0", features = ["profiling"] }
 lalrpop = { version = "0.19.7", artifact = "bin", features = ["pico-args"] }
 lalrpop-util = "0.19.7"
-# FIXME: libc v0.2.165 breaks sysinfo crate. This is fixed in sysinfo v0.32.1.
-libc = ">=0.2.132,<0.2.165"
+libc = "0.2.158"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }
 linkme = { version = "0.3.17", features = ["used_linker"] }
 log = "0.4"


### PR DESCRIPTION
Summary: `libc` v0.2.165 was yanked and v0.2.166 was released with the fix.

Differential Revision: D66546801


