### PR TITLE
Don't use white as a foreground color

### DIFF
--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -622,7 +622,6 @@ impl StatefulSuperConsoleImpl {
             let display_platform = self.state.config.display_platform;
             let action_id = StyledContent::new(
                 ContentStyle {
-                    foreground_color: Some(Color::White),
                     attributes: Attribute::Bold.into(),
                     ..Default::default()
                 },
@@ -664,7 +663,6 @@ impl StatefulSuperConsoleImpl {
         lines.push(Line::from_iter([Span::new_styled_lossy(
             StyledContent::new(
                 ContentStyle {
-                    foreground_color: Some(Color::White),
                     attributes: Attribute::Bold.into(),
                     ..Default::default()
                 },


### PR DESCRIPTION
Buck2 prints white text on error, which is almost unreadable when using a light colorscheme. 

<img width="762" alt="Screenshot 2024-12-01 at 4 51 14 PM" src="https://github.com/user-attachments/assets/a00fdbdd-5a36-41cf-8084-ab246d973a16">

This change removes explicitly white text, instead using the foreground color.

<img width="762" alt="Screenshot 2024-12-01 at 4 50 24 PM" src="https://github.com/user-attachments/assets/141b7302-52b3-429e-82ac-cbe0c82c98f1">

It also looks good for dark themes.

<img width="762" alt="Screenshot 2024-12-01 at 4 50 32 PM" src="https://github.com/user-attachments/assets/2f4d646e-65ec-4000-b1b9-e9c885f47e7a">
