### PR TITLE
buck2/oss: use macos-13 runner

### DIFF
--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -45,10 +45,10 @@ jobs:
           - os: 'ubuntu-22.04'
             triple: 'x86_64-unknown-linux-musl'
             cross: true
-          - os: 'macos-12'
+          - os: 'macos-13'
             triple: 'aarch64-apple-darwin'
             cross: true
-          - os: 'macos-12'
+          - os: 'macos-13'
             triple: 'x86_64-apple-darwin'
           - os: 'windows-2022'
             triple: 'x86_64-pc-windows-msvc'


### PR DESCRIPTION
Summary: `macos-12` runner is deprecated and no longer available: https://github.com/actions/runner-images/issues/10721

Differential Revision: D66820826


