### PR TITLE
Add rustc env to rust toolchain

### DIFF
--- a/prelude/rust/build.bzl
+++ b/prelude/rust/build.bzl
@@ -1352,7 +1352,7 @@ def _rustc_invoke(
 
     toolchain_info = compile_ctx.toolchain_info
 
-    plain_env, path_env = process_env(compile_ctx, ctx.attrs.env, exec_is_windows)
+    plain_env, path_env = process_env(compile_ctx, toolchain_info.rustc_env |ctx.attrs.env, exec_is_windows)
 
     more_plain_env, more_path_env = process_env(compile_ctx, env, exec_is_windows)
     plain_env.update(more_plain_env)

--- a/prelude/rust/rust_toolchain.bzl
+++ b/prelude/rust/rust_toolchain.bzl
@@ -53,6 +53,8 @@ rust_toolchain_attrs = {
     # FIXME(JakobDegen): Can't use `list[str]` here, because then the default is wrong, but can't
     # use a non-empty list as the default because lists are mutable
     "rustc_coverage_flags": provider_field(typing.Any, default = ("-Cinstrument-coverage",)),
+    # Extra env variables that should be made available to the rustc executable.
+    "rustc_env": provider_field(dict[str, typing.Any], default = {}),
     # Extra env variables that should be made available to the rustdoc executable.
     "rustdoc_env": provider_field(dict[str, typing.Any], default = {}),
     # Extra flags for rustdoc invocations


### PR DESCRIPTION
- Add `rustc_env` to `RustToolchainInfo`
- This enables overriding at the toolchain level env vars such as `RUSTUP_TOOLCHAIN` and `RUSTUP_HOME` which otherwise would need to be set on each `rust_*` target - https://rust-lang.github.io/rustup/environment-variables.html
- Setting `RUSTUP_TOOLCHAIN` and `RUSTUP_HOME` allows for remote execution of `rust_*` rules where the rust toolchain is preinstalled in the remote execution environment (i.e., inside a container defined in a platform configured for remote execution). 
- Setting these env vars at the rust target level is not ideal as they are only needed when using an RE toolchain, and not generally for other use cases (i.e., when using a local execution toolchain).
- It would be ideal for the same targets to be either compiled locally or remotely based solely on the selection of the `--target-platforms` via the command line. If these are defined on the `rust_*` targets they will need select statements on each target. 
Example `rust_*` target with select statement (not ideal):
```
rust_library(
    name = "library",
    # We set these env vars to configure the RE Rust toolchain. Unfortunately the prelude does not provide a way to set these at the rust_toolchain level. We override the HOME location so rustp creates its `.rustp` directory in this location.
    env = select({
        "//platforms:engflow": {
            "RUSTUP_TOOLCHAIN":"/usr/local/rustup/toolchains/1.83.0-x86_64-unknown-linux-gnu",
            "RUSTUP_HOME": "buck-out/.rustup",
        },
        "DEFAULT": {},
    }),
    srcs = glob(
        ["src/**/*.rs"],
    ),
    exec_compatible_with = select({
        "//platforms:engflow": ["//platforms:remote_platform"],
        "DEFAULT": [],
    }),
)
```

Example rust toolchain with env vars (once `rustc_env` is added with this PR):
```
remote_rust_toolchain(
    name = "rust",
    default_edition = "2021",
    visibility = ["PUBLIC"],
    rustc_env = {
        "RUSTUP_TOOLCHAIN":"/usr/local/rustup/toolchains/1.83.0-x86_64-unknown-linux-gnu",
        "RUSTUP_HOME": "buck-out/.rustup",
    },
)
```

Full sample of rust with RE staged in https://github.com/EngFlow/example/pull/361 (currently without use of `rustc_env` attr). 