### PR TITLE
Update target path for CI macros 1/N

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,5 +1,5 @@
-load("@fbcode//target_determinator/macros:ci.bzl", "ci")
 load("@fbcode_macros//build_defs:native_rules.bzl", "alias")
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load(":defs.bzl", "buck2_bundle")
 
 oncall("build_infra")

--- a/ci.bzl
+++ b/ci.bzl
@@ -5,7 +5,7 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@fbcode//target_determinator/macros:ci.bzl", "ci")
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 
 # We want to test most things on all platforms we support, but for various reasons,
 # this PACKAGE should be treated as Linux-only.

--- a/tests/buck_e2e.bzl
+++ b/tests/buck_e2e.bzl
@@ -6,10 +6,10 @@
 # of this source tree.
 
 load("@fbcode//buck2/app:modifier.bzl", "buck2_modifiers")
-load("@fbcode//target_determinator/macros:ci.bzl", "ci")
-load("@fbcode//target_determinator/macros:ci_hint.bzl", "ci_hint")
 load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup")
 load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
+load("@fbsource//tools/target_determinator/macros:ci_hint.bzl", "ci_hint")
 
 def buck_e2e_test(
         name,


### PR DESCRIPTION
Summary: We moved CI macros from /fbcode to /tools https://fb.workplace.com/groups/1243087773044302/posts/1477603662926044

Reviewed By: zertosh

Differential Revision: D67352185


