### PR TITLE
: oss examples: upgrade to ocaml-5.3.0

### DIFF
--- a/.github/actions/init_opam/action.yml
+++ b/.github/actions/init_opam/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
   - name: Initialize OPAM
     run: |
-      opam init --compiler=5.1.1 --disable-sandboxing -y
+      opam init --compiler=5.3.0 --disable-sandboxing -y
       opam env | sed -e "s/ export .*//g" -e "s/'//g" -e "s/\;//g" >> $GITHUB_ENV
     shell: bash
   - name: Install OPAM packages

--- a/examples/with_prelude/ocaml/ppx/BUCK
+++ b/examples/with_prelude/ocaml/ppx/BUCK
@@ -17,6 +17,7 @@ ocaml_binary(
     srcs = ["ppx_driver.ml"],
     compiler_flags = [
         "-linkall",
+        "-cclib", "-lcomprmarsh",
     ],
     deps = [
         ":ppx-record-selectors",


### PR DESCRIPTION
Summary: upgrade buck2 oss examples to 5.3.0. required adding `-lcomprmarsh` to the link line of `//ocaml/ppx:ppx`.

Differential Revision: D68130972


