### PR TITLE
Install conan using uv

### DIFF
--- a/.github/actions/setup_linux_env/action.yml
+++ b/.github/actions/setup_linux_env/action.yml
@@ -19,8 +19,10 @@ runs:
   - uses: haskell-actions/setup@v2
     with:
       ghc-version: '9.10.1'
+  - name: Install uv
+    uses: astral-sh/setup-uv@v5
   - name: Install conan
-    run: sudo pip3 install conan==1.*
+    run: uv tool install conan==1.*
     shell: bash
   - uses: actions/setup-go@v5
     with:

--- a/.github/actions/setup_macos_env/action.yml
+++ b/.github/actions/setup_macos_env/action.yml
@@ -15,8 +15,10 @@ runs:
   - name: Brew install
     run: brew install cmake python3 coreutils opam llvm protobuf zstd
     shell: bash
+  - name: Install uv
+    uses: astral-sh/setup-uv@v5
   - name: Install conan
-    run: sudo pip3 install --break-system-packages conan==1.*
+    run: uv tool install conan==1.*
     shell: bash
   - uses: "./.github/actions/print_versions"
   - uses: actions/setup-go@v5


### PR DESCRIPTION
Summary:
Linux CI is currently broken because pip tries to remove system package.

uv installs tools in its own virtualenv and it's much faster than pip.

Differential Revision: D68271455


