### PR TITLE
Make C++ tools configurable

### DIFF
--- a/prelude/cxx/tools/BUCK.v2
+++ b/prelude/cxx/tools/BUCK.v2
@@ -24,11 +24,13 @@ prelude.command_alias(
     ],
     exe = ":hmap_wrapper.py",
     labels = ["buck2-only"],
+    visibility = ["PUBLIC"],
 )
 
 prelude.python_bootstrap_binary(
     name = "make_comp_db",
     main = "make_comp_db.py",
+    visibility = ["PUBLIC"],
 )
 
 prelude.python_bootstrap_binary(
@@ -59,6 +61,7 @@ prelude.python_bootstrap_binary(
 prelude.python_bootstrap_binary(
     name = "remap_cwd",
     main = "remap_cwd.py",
+    visibility = ["PUBLIC"],
 )
 
 prelude.python_bootstrap_binary(

--- a/prelude/cxx/tools/defs.bzl
+++ b/prelude/cxx/tools/defs.bzl
@@ -24,13 +24,13 @@ def _cxx_internal_tools_impl(ctx: AnalysisContext) -> list[Provider]:
 cxx_internal_tools = rule(
     impl = _cxx_internal_tools_impl,
     attrs = {
-        "concatenate_diagnostics": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:concatenate_diagnostics")),
-        "dep_file_processor": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:dep_file_processor")),
-        "dist_lto": attrs.default_only(attrs.dep(providers = [DistLtoToolsInfo], default = "prelude//cxx/dist_lto/tools:dist_lto_tools")),
-        "hmap_wrapper": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:hmap_wrapper")),
-        "make_comp_db": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:make_comp_db")),
-        "remap_cwd": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:remap_cwd")),
-        "stderr_to_file": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:stderr_to_file")),
+        "concatenate_diagnostics": attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:concatenate_diagnostics"),
+        "dep_file_processor": attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:dep_file_processor"),
+        "dist_lto": attrs.dep(providers = [DistLtoToolsInfo], default = "prelude//cxx/dist_lto/tools:dist_lto_tools"),
+        "hmap_wrapper": attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:hmap_wrapper"),
+        "make_comp_db": attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:make_comp_db"),
+        "remap_cwd": attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:remap_cwd"),
+        "stderr_to_file": attrs.dep(providers = [RunInfo], default = "prelude//cxx/tools:stderr_to_file"),
     },
 )
 


### PR DESCRIPTION
The move to `cxx_internal_tools` broke open source users that had a custom `make_comp_db` to work around https://github.com/facebook/buck2/issues/307.

This commit makes it configurable so that OSS users can again provide their own script to generate legal `compile_commands.json` files.

A few remaining tools are made `PUBLIC` so that OSS users can simply reuse them.