### PR TITLE
Fix test for remote persistent workers

### DIFF
--- a/examples/persistent_worker/platforms/buildbuddy.bzl
+++ b/examples/persistent_worker/platforms/buildbuddy.bzl
@@ -21,7 +21,7 @@ def _platforms(ctx):
             allow_cache_uploads = True,
             use_limited_hybrid = True,
             use_persistent_workers = ctx.attrs.use_persistent_workers,
-            supports_bazel_remote_persistent_worker_protocol = ctx.attrs.use_persistent_workers,
+            use_bazel_protocol_remote_persistent_workers = ctx.attrs.use_persistent_workers,
             remote_execution_properties = {
                 "OSFamily": "Linux",
                 "nonroot-workspace": True,

--- a/examples/persistent_worker/platforms/local.bzl
+++ b/examples/persistent_worker/platforms/local.bzl
@@ -20,7 +20,7 @@ def _platforms(ctx):
             remote_cache_enabled = False,
             allow_cache_uploads = False,
             use_persistent_workers = ctx.attrs.use_persistent_workers,
-            supports_bazel_remote_persistent_worker_protocol = False,
+            use_bazel_protocol_remote_persistent_workers = False,
         ),
     )
 


### PR DESCRIPTION
Summary: While renaming for D68157749, these were incorrectly renamed.

Differential Revision: D68443908


