### PR TITLE
Properly support single file compilation in vsgo

### DIFF
--- a/prelude/ide_integrations/visual_studio/gen_filters.bxl
+++ b/prelude/ide_integrations/visual_studio/gen_filters.bxl
@@ -29,7 +29,7 @@ def _get_common_directory(paths) -> str:
 
 def _get_file_filter_map(vs_settings: dict) -> dict:
     filters = {}
-    files = vs_settings["Headers"] + vs_settings["Sources"]
+    files = vs_settings["Headers"] + vs_settings["Sources"].keys()
 
     # Handle paths that start with "buck-out"(exported files) separately since these file
     # don't have any common dir with the others and would make the hierarchy really nested

--- a/prelude/ide_integrations/visual_studio/gen_vcxproj.bxl
+++ b/prelude/ide_integrations/visual_studio/gen_vcxproj.bxl
@@ -49,12 +49,13 @@ def _gen_headers(headers):
     ], indent_level = 1)
 
 def _gen_sources(sources):
-    return h("ItemGroup", [
-        h("ClCompile", None, {
+    source_entries = [
+        h("ClCompile", [h("BuckObjSubTarget", object, indent_level=3)], {
             "Include": cmd_args("$(RepoRoot)\\", source, delimiter = ""),
         }, indent_level = 2)
-        for source in sources
-    ], indent_level = 1)
+        for source, object in sources.items()
+    ]
+    return h("ItemGroup", source_entries, indent_level = 1)
 
 def _gen_import_mode_configs(vs_settings: dict, target):
     imports = []
@@ -117,6 +118,26 @@ def gen_vcxproj(target: bxl.ConfiguredTargetNode, vs_settings: dict, cli_args, b
         "",
         sources,
         "",
+        h(
+            "Target",
+            [
+                h(
+                    "Exec",
+                    None,
+                    {
+                        "WorkingDirectory": "$(RepoRoot)",
+                        "Command": "$(vs_buck_build_command)[objects][%(ClCompile.BuckObjSubTarget)] $(ExtraBuckOptions)"
+                    },
+                    indent_level = 2
+                )
+            ],
+            {
+                "Name": "ClCompile",
+                "Condition": "\'@(ClCompile)\' != \'\'",
+                "DependsOnTargets": "SelectClCompile"
+            },
+            indent_level = 1,
+        ),
         """
     <ImportGroup Label="ExtensionTargets" />
 </Project>""",

--- a/prelude/ide_integrations/visual_studio/get_attrs.bxl
+++ b/prelude/ide_integrations/visual_studio/get_attrs.bxl
@@ -135,22 +135,25 @@ def _get_exported_preprocessor_flags(attrs) -> list:
 
 ############## others ##############
 
-def _get_srcs(attrs) -> list:
+def _get_srcs(attrs) -> dict:
     """Returns list of source associated with its src property"""
 
     # take_values as genrule target src properties can be a map of target location to source
     # location, and this function is defined to always return the source location.
     raw_srcs = get_unified_value(attrs, "srcs", "platform_srcs", take_values = True)
 
-    srcs = []
+    srcs = {}
 
     for src in raw_srcs:
+        obj = None
+        if isinstance(src, Artifact):
+            obj = src.short_path + ".obj"
         # Flatten the list to remove any per-file compile flags, these won't
         # get carried thru to the vcxproj file.
         if isinstance(src, tuple):
-            srcs.append(src[0])  # add just the source file
-        else:
-            srcs.append(src)
+            src = src[0]
+
+        srcs[src] = obj
 
     return srcs
 

--- a/prelude/ide_integrations/visual_studio/get_vs_settings.bxl
+++ b/prelude/ide_integrations/visual_studio/get_vs_settings.bxl
@@ -36,15 +36,14 @@ def _get_all_header_files(attrs: dict):
 # e.g., fbsource//xplat/QNNPACK:operators
 def _get_headers_and_sources(attrs):
     headers_dict = {h: True for h in _get_all_header_files(attrs)}
-    sources_dict = {s: True for s in attrs["srcs"]}
+    sources_dict = attrs["srcs"]
 
     def is_header(filename):
         return suffix(filename) in ["h", "hh", "hpp", "hxx", "hm", "inl", "inc", "ipp", "xsd"]
 
     headers_list = [h for h in headers_dict if h not in sources_dict or is_header(h)]
-    sources_list = [s for s in sources_dict if s not in headers_dict or not is_header(s)]
-
-    return headers_list, sources_list
+    sources_dict = {s: o for s, o in sources_dict.items() if s not in headers_dict or not is_header(s)}
+    return headers_list, sources_dict
 
 def _unescape_arg(arg):
     if arg.startswith("\\-\\-"):

--- a/prelude/ide_integrations/visual_studio/utils.bxl
+++ b/prelude/ide_integrations/visual_studio/utils.bxl
@@ -165,7 +165,7 @@ def get_mode_config_path(mode_name):
 def get_root_path_relative_to(target_label):
     # Workaround: "".split("/") returns [""], which is not expected.
     if not target_label.package:
-        return "../.."
+        return "../../"
 
     # + 1 for the hash layer of directory and + 1 more for cell
     return "../" * (len(target_label.package.split("/")) + 2)


### PR DESCRIPTION
Presently, if you select a file in Solution Explorer and hit Ctrl+F7, it uses the default `ClCompile` task, which invokes the system-installed version of cl.exe corresponding to whatever version of Visual Studio you have installed.  It does not go through buck2 or invoke `buck2 build` in any way.  To fix this, we need to do things:

1. We need to associate the object file sub-target name with each source file so this can be passed to the buck2 build command.
2. We need to replace the `ClCompile` task with a custom one that invokes `Exec` to call buck2.

The first is done by Adding a piece of metadata to each `ClCompile` item.  So for example we need to generate something like this for each cpp file:

```
        <ClCompile Include="$(RepoRoot)\A\B\C\Foo\Foo.cpp">
            <BuckObjSubTarget>Foo/Foo.cpp.obj</BuckObjSubTarget>
        </ClCompile>
```

Second, we need to inject a replacement for the `ClCompile` task into every vcxproj.  This means putting the following harcoded snippet of MSBuild after all of the `ClCompile` items.

```
    <Target Name="ClCompile" Condition="'@(ClCompile)' != ''" DependsOnTargets="SelectClCompile">
        <Exec WorkingDirectory="$(RepoRoot)" Command="$(vs_buck_build_command)[objects][%(ClCompile.BuckObjSubTarget)] $(ExtraBuckOptions)"/>
    </Target>
```

One might wonder why this doesn't go inside of `vs_buck_build.props` like the other task replacements.  I was not able to make this work because of the `%(ClCompile.BuckObjSubTarget)` reference.  When I put the task inside of the props file, this would not resolve to anything, so the only way I could get it to work was to put it inside of every vcxproj.

After this PR, hitting Ctrl+F7 on a single file will invoke `buck2 build <target_name>[objects][foo.cpp.obj]`