### PR TITLE
Add constraint_overrides attribute to apple_test rule

### DIFF
--- a/prelude/apple/apple_rules_impl.bzl
+++ b/prelude/apple/apple_rules_impl.bzl
@@ -169,6 +169,7 @@ extra_attributes = {
         "files": attrs.list(attrs.one_of(attrs.dep(), attrs.source()), default = []),
     } | apple_common.skip_universal_resource_dedupe_arg(),
     "apple_spm_package": apple_spm_package_extra_attrs(),
+    "apple_test": constraint_overrides.attributes,
     "apple_toolchain": {
         # The Buck v1 attribute specs defines those as `attrs.source()` but
         # we want to properly handle any runnable tools that might have


### PR DESCRIPTION
Summary:
Apple_binary and library already have constraint_overrides attribute. On apple_test, it doesn't exist yet, so if it's sent in, buck hits a parse error.

None of the apple rules actually implement these constraint_override transitions yet.

Differential Revision: D71170042


