### PR TITLE
Add git commit and timestamp to OSS builds

### DIFF
--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -108,6 +108,10 @@ jobs:
           else
             CARGO=cargo
           fi
+          # Specify the release version information
+          commit_date=$(echo "${{ github.event.repository.updated_at }}" | sed 's/T.*//')
+          export BUCK2_SET_EXPLICIT_VERSION="$commit_date-${{ github.sha }}"
+          export BUCK2_RELEASE_TIMESTAMP="${{ github.event.repository.updated_at }}"
           $CARGO build --release --bin buck2 --bin rust-project --target ${{ matrix.target.triple }}
       - name: Sanity check with examples/with_prelude
         if: ${{ !matrix.target.cross }}


### PR DESCRIPTION
Summary:
Partially address https://github.com/facebook/buck2/issues/345

Changes the result of a self-hash to be: <YYYY-MM-DD of commit>-<commit>
Of particular note, all architectures will now supply the same version string.

See example in test plan

Differential Revision: D71744048
