### PR TITLE
Allow rustc_flags take Artifact as argument

### DIFF
--- a/prelude/rust/build.bzl
+++ b/prelude/rust/build.bzl
@@ -453,7 +453,7 @@ def rust_compile(
         incremental_enabled: bool,
         extra_link_args: list[typing.Any] = [],
         predeclared_output: Artifact | None = None,
-        extra_flags: list[[str, ResolvedStringWithMacros]] = [],
+        extra_flags: list[[str, ResolvedStringWithMacros, Artifact]] = [],
         allow_cache_upload: bool = False,
         # Setting this to true causes the diagnostic outputs that are generated
         # from this action to always be successfully generated, even if
@@ -892,7 +892,7 @@ def _lint_flags(compile_ctx: CompileContext, infallible_diagnostics: bool, is_cl
         _lintify("W", is_clippy, toolchain_info.warn_lints),
     )
 
-def _rustc_flags(flags: list[[str, ResolvedStringWithMacros]]) -> list[[str, ResolvedStringWithMacros]]:
+def _rustc_flags(flags: list[[str, ResolvedStringWithMacros, Artifact]]) -> list[[str, ResolvedStringWithMacros, Artifact]]:
     # Rustc's "-g" flag is documented as being exactly equivalent to
     # "-Cdebuginfo=2". Rustdoc supports the latter, it just doesn't have the
     # "-g" shorthand for it.


### PR DESCRIPTION
When using Buck2 to bootstrap the Rust compiler, the ability to create a sysroot directory is needed (i.e., to collect rustc binary and standard libraries structurally into a single directory). We refer to such a target as *a sysroot target*, and the resulting directory as *a sysroot artifact*.

When creating a Rust toolchain from a sysroot artifact, compiler flags `["--sysroot", sysroot_artifact]` should be set. The current implementation, however, doesn't allow an `Artifact` as rustc_flags argument. This PR extends it to allow an `Artifact` for rustc_flags.

Here is an example of creating a sysroot (steps 1 through 3) and creating a Rust toolchain based on sysroot artifacts (steps 4 through 6), along with the error message I encountered (step 7):

<img width="1255" alt="Bildschirmfoto 2025-04-10 um 00 01 47" src="https://github.com/user-attachments/assets/d3a3f782-5826-46cd-8dba-7d9e1a39df30" />