### PR TITLE
Make rust_proc_macro_alias inherit Rust toolchain's configurations

### DIFF
--- a/prelude/rust/proc_macro_alias.bzl
+++ b/prelude/rust/proc_macro_alias.bzl
@@ -7,6 +7,7 @@
 
 # Helper rule which introduces proc macros into the dependency graph
 
+load("@prelude//decls:toolchains_common.bzl", "toolchains_common")
 load(":link_info.bzl", "RustProcMacroMarker", "RustProcMacroPlugin")
 
 def _impl(ctx):
@@ -37,5 +38,6 @@ rust_proc_macro_alias = rule(
     attrs = {
         "actual_exec": attrs.exec_dep(),
         "actual_plugin": attrs.plugin_dep(kind = RustProcMacroPlugin),
+        "_rust_toolchain": toolchains_common.rust(),
     },
 )


### PR DESCRIPTION
This PR addresses an execution platform compatibility issue with proc macro aliases

In issue #900, @dtolnay provided a solution for propagating execution platform constraints through execution dependencies to build-script-build targets by setting `exec_compatible_with` on the Rust toolchain. Example dependency chain with build scripts look like:

`:my_crate`
-[dep]->
`:my_crate-build-script-run` (has toolchain_dep to the Rust toolchain)
-[exec_dep]->
`:my_crate-build-script-build`

This solution works for build scripts because the build-script-run target includes a toolchain dependency to the Rust toolchain.

However, this solution doesn't work for proc macro aliases because they lack a dependency on the Rust toolchain. Example dependency chain with proc macro aliases looks like:

`:crate_depending_on_my_crate`
-[dep]->
`:my_crate` (of rust_proc_macro_alias rule) (has no toolchain_dep to the Rust toolchain)
-[exec_dep]->
`:_my_crate` (of rust_library rule)

Since the rust_proc_macro_alias target has no dependency on the Rust toolchain, the `exec_compatible_with` setting doesn't propagate to it, resulting in potentially inconsistent execution platform resolution.

This PR resolves the issue by adding a Rust toolchain dependency on the rust_proc_macro_alias rule.