### PR TITLE
Improve error message when calling project() on a symlink

### DIFF
--- a/app/buck2_build_api/src/artifact_groups/calculation.rs
+++ b/app/buck2_build_api/src/artifact_groups/calculation.rs
@@ -396,7 +396,7 @@ impl Key for EnsureProjectedArtifactKey {
 
         let value = extract_artifact_value(&builder, &base_path.join(path), digest_config)
             .with_buck_error_context(|| {
-                format!("The path `{path}` cannot be projected in the artifact `{base}`")
+                format!("The path `{path}` cannot be projected in the artifact `{base}`. Are you calling project() on a symlink?")
             })?
             .with_buck_error_context(|| {
                 format!("The path `{path}` does not exist in the artifact `{base}`")


### PR DESCRIPTION
Details can be found at: https://github.com/facebook/buck2/issues/906

Improve error message when calling project() on a symlink.
