### PR TITLE
buck2/python: add wheel example

### DIFF
--- a/examples/with_prelude/python/wheel/BUCK
+++ b/examples/with_prelude/python/wheel/BUCK
@@ -1,0 +1,22 @@
+load("@prelude//python:python_wheel.bzl", "python_wheel")
+load("//:test_utils.bzl", "assert_output")
+
+python_wheel(
+    name = "wheel",
+    libraries = ["//python/library:printlib"],
+    python = "py310",
+)
+
+python_binary(
+    name = "wheel_checker",
+    main = "wheel_checker.py",
+    resources = {
+        "printlib.whl": ":wheel",
+    },
+)
+
+assert_output(
+    name = "check_wheel",
+    command = "$(exe_target :wheel_checker)",
+    output = "Wheel OK",
+)

--- a/examples/with_prelude/python/wheel/wheel_checker.py
+++ b/examples/with_prelude/python/wheel/wheel_checker.py
@@ -1,0 +1,15 @@
+import importlib.resources
+import zipfile
+
+
+def main() -> None:
+    with importlib.resources.path(__package__, "printlib.whl") as wheel:
+        with zipfile.ZipFile(wheel) as zf:
+            if "printlib/print.py" in zf.namelist():
+                print("Wheel OK")
+            else:
+                print(f"print.py not found in {wheel=}. {zf.namelist()=}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prelude/python/python_wheel.bzl
+++ b/prelude/python/python_wheel.bzl
@@ -342,6 +342,14 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
 
     return providers
 
+_default_python = select({
+    "ovr_config//third-party/python/constraints:3.10": "py3.10",
+    "ovr_config//third-party/python/constraints:3.11": "py3.11",
+    "ovr_config//third-party/python/constraints:3.12": "py3.12",
+    "ovr_config//third-party/python/constraints:3.8": "py3.8",
+    "ovr_config//third-party/python/constraints:3.9": "py3.9",
+})
+
 python_wheel = rule(
     impl = _impl,
     cfg = constraint_overrides.transition,
@@ -349,13 +357,7 @@ python_wheel = rule(
         dist = attrs.option(attrs.string(), default = None),
         version = attrs.string(default = "1.0.0"),
         python = attrs.string(
-            default = select({
-                "ovr_config//third-party/python/constraints:3.10": "py3.10",
-                "ovr_config//third-party/python/constraints:3.11": "py3.11",
-                "ovr_config//third-party/python/constraints:3.12": "py3.12",
-                "ovr_config//third-party/python/constraints:3.8": "py3.8",
-                "ovr_config//third-party/python/constraints:3.9": "py3.9",
-            }),
+            # @oss-disable[end= ]: default = _default_python,
         ),
         entry_points = attrs.dict(
             key = attrs.string(),
@@ -375,8 +377,8 @@ python_wheel = rule(
         platform = attrs.string(
             default = select({
                 "DEFAULT": "any",
-                "ovr_config//os:linux-arm64": "linux_aarch64",
-                "ovr_config//os:linux-x86_64": "linux_x86_64",
+                # @oss-disable[end= ]: "ovr_config//os:linux-arm64": "linux_aarch64",
+                # @oss-disable[end= ]: "ovr_config//os:linux-x86_64": "linux_x86_64",
             }),
         ),
         libraries = attrs.list(attrs.dep(providers = [PythonLibraryInfo]), default = []),

--- a/prelude/python/tools/BUCK
+++ b/prelude/python/tools/BUCK
@@ -130,7 +130,8 @@ prelude.command_alias(
     name = "patchelf",
     args = [
         "--patchelf",
-        "$(exe_target fbsource//third-party/patchelf:patchelf)",
+        # @oss-disable[end= ]: "$(exe_target fbsource//third-party/patchelf:patchelf)",
+        "patchelf", # @oss-enable
     ],
     exe = ":patchelf.py",
     visibility = ["PUBLIC"],


### PR DESCRIPTION
Summary:
This checks if the produced wheel is a valid zipfile.
There are more things we could check:
* the wheel can be `pip install`ed
* non-python artifacts are handled
* wheel metadata is properly set
* ...

Closes #893.
Closes #889.

Differential Revision: D73107087


