### PR TITLE
Fix filegroup missing issue for -build-script-run targets

### DIFF
--- a/prelude/rust/cargo_buildscript.bzl
+++ b/prelude/rust/cargo_buildscript.bzl
@@ -174,10 +174,18 @@ def buildscript_run(
         **kwargs):
     filegroup_name = "{}-{}.crate".format(package_name, version)
     if not rule_exists(filegroup_name):
-        # In reindeer's `vendor = false` mode, this target will already exist;
-        # it is the `http_archive` containing the crate's sources. When
-        # vendoring, we need to make a filegroup referring to the vendored
-        # sources.
+        # For a buildscript executable to be able to access its crate's source
+        # files, we need to make a filegroup target referring to the source files.
+        # For downloaded crates.io dependencies, Reindeer already creates such
+        # targets with the `http_archive` rule, in other cases, i.e.,
+        #   - local crates (e.g., `my_crate = { path = "path/to/my_crate" }` in "[dependencies]" section),
+        #     + this also includes workspace members (when using Reindeer in `include_workspace_members = true` mode),
+        #   - git patches (e.g., `my_crate = { git = "http://..." }` in "[patch.crates-io]" section),
+        #   - vendored crates (when using Reindeer in `vendor = true` mode),
+        # no filegroup target will be explicitly stated in the genereated BUCK file.
+        #
+        # The first two cases are handled in @prelude//rust:cargo_package.bzl.
+        # Here handles the third case (vendored crates).
         prefix = "vendor/{}-{}".format(package_name, version)
         prefix_with_trailing_slash = "{}/".format(prefix)
 

--- a/prelude/rust/cargo_package.bzl
+++ b/prelude/rust/cargo_package.bzl
@@ -90,11 +90,50 @@ def apply_platform_attrs(
 
     return combined_attrs
 
+def fix_missing_filegroup_for_buildscript_run(filegroup_name, manifest_dir, srcs):
+    if len(srcs) == 1 and srcs[0].startswith(":"):
+        # In cases such as `srcs = [":thiserror-a2b02c8016a45f62.git"]`, this creates
+        # an alias like "thiserror-2.0.12.crate".
+        native.alias(
+            name = filegroup_name,
+            actual = srcs[0],
+            visibility = [],
+        )
+    elif not any([path.startswith(":") for path in srcs]):
+        # Otherwise `srcs` is a simple list of local source files, this creates a filegroup
+        # with source mapping like `srcs = { "src/lib.rs": "path/to/manifest/dir/src/lib.rs", ... }`,
+        # removing the "path/to/manifest/dir/" prefix.
+        manifest_dir_with_trailing_slash = "{}/".format(manifest_dir)
+        native.filegroup(
+            name = filegroup_name,
+            srcs = {
+                path.removeprefix(manifest_dir_with_trailing_slash): path
+                for path in srcs
+            },
+            copy = False,
+            visibility = [],
+        )
+    # The last case of filegroup missing is when using Reindeer in `vendor = true` mode,
+    # which is handled in @prelude//rust:cargo_buildscript.bzl by the `buildscript_run` macro.
+
 def _cargo_rust_binary(name, platform = {}, **kwargs):
     kwargs = apply_platform_attrs(platform, kwargs)
 
     rustc_flags = kwargs.get("rustc_flags", [])
     kwargs["rustc_flags"] = ["--cap-lints=allow"] + rustc_flags
+
+    env = kwargs.get("env", {})
+    manifest_dir = env.get("CARGO_MANIFEST_DIR", None)
+    package_name = env.get("CARGO_PKG_NAME", None)
+    version = env.get("CARGO_PKG_VERSION", None)
+
+    is_buildscript_build = kwargs.get("crate", None) == "build_script_build" and name.endswith("-build-script-build")
+    has_required_envs = manifest_dir != None and package_name != None and version != None
+
+    if is_buildscript_build and has_required_envs:
+        filegroup_name = "{}-{}.crate".format(package_name, version)
+        if not rule_exists(filegroup_name):
+            fix_missing_filegroup_for_buildscript_run(filegroup_name, manifest_dir, srcs = kwargs["srcs"])
 
     native.rust_binary(name = name, **kwargs)
 


### PR DESCRIPTION
Summary:
This fixes the issue where build scripts in local crates or git-patched crates fail to access source files.
Also updates some in-code documentations.

Relates to facebookincubator/reindeer#65.
Closes #914.