### PR TITLE
`//A/B/C` is a valid name for `//A/B/C:C`

### DIFF
--- a/app/buck2_core/src/pattern/pattern.rs
+++ b/app/buck2_core/src/pattern/pattern.rs
@@ -298,7 +298,7 @@ impl<T: PatternType> ParsedPattern<T> {
             cell_alias_resolver,
             TargetParsingOptions {
                 relative,
-                infer_target: false,
+                infer_target: true,
                 strip_package_trailing_slash: false,
             },
             pattern,


### PR DESCRIPTION
> Prefer using the short name when referring to an eponymous target (`//x` instead of `//x:x`). If
> you are in the same package, prefer the local reference (`:x` instead of `//x`).

See: https://bazel.build/build/style-guide#target-naming

This syntax is supported on the command-line, but not in BUCK files. Unfortunately, the only(?) Starlark formatter (buildifier: https://github.com/bazelbuild/buildtools) automatically abbreviates targets on the assumption that this syntax is valid, which causes errors when using Buck2:

    ...
    4: Error coercing "//src/Foo"
    5: Invalid absolute target pattern `//src/Foo` is not allowed
    6: Expected a `:`, a trailing `/...` or the literal `...`.

We can adjust the parsing rules to allow this syntax in more places.