### PR TITLE
Raise file descriptor limits on Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ memchr = "2.4.1"
 memmap2 = "0.5.0"
 memoffset = "0.6.4"
 multimap = "0.8.2"
-nix = "0.22"
+nix = { version = "0.26", features = ["fs", "resource", "signal"] }
 nom = "7.1.3"
 notify = "=5.0.0"
 num-bigint = "0.4.3"

--- a/app/buck2_forkserver/src/unix.rs
+++ b/app/buck2_forkserver/src/unix.rs
@@ -14,3 +14,4 @@ mod service;
 
 pub use command::run_forkserver;
 pub use launch::launch_forkserver;
+pub use process_group::set_default_file_descriptor_limits;

--- a/app/buck2_forkserver/src/unix/process_group.rs
+++ b/app/buck2_forkserver/src/unix/process_group.rs
@@ -11,10 +11,14 @@ use std::os::unix::process::CommandExt;
 use std::process::Command as StdCommand;
 use std::process::ExitStatus;
 use std::process::Stdio;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use buck2_common::kill_util::try_terminate_process_gracefully;
 use buck2_error::BuckErrorContext;
+use nix::sys::resource;
+use nix::sys::resource::Resource;
+use nix::sys::resource::rlim_t;
 use nix::sys::signal;
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
@@ -24,6 +28,42 @@ use tokio::process::ChildStderr;
 use tokio::process::ChildStdout;
 use tokio::process::Command;
 
+/// Default soft and hard limits for `RLIMIT_NOFILE`.
+///
+/// If this isn't set, then the default limits are used.
+static REVERT_RLIMITS_TO: OnceLock<(rlim_t, rlim_t)> = OnceLock::new();
+
+/// Set the default file descriptor limits for subprocesses.
+///
+/// Returns `Err(())` if the default limits were already set.
+///
+/// While we increase the `RLIMIT_NOFILE` soft limit for ourselves (see #419), it's dangerous to set
+/// it for subprocesses, so we need to reset it before executing those. However, there's no way to
+/// access the default limits, so we rely on clients to call this function to set the correct
+/// defaults for subprocesses.
+///
+/// The `systemd.exec` man page says this about setting the limits with `ulimit -n` directly:
+///
+/// > Don't use. Be careful when raising the soft limit above 1024, since `select(2)`
+/// > cannot function with file descriptors above 1023 on Linux. Nowadays, the hard
+/// > limit defaults to 524288, a very high value compared to historical defaults.
+/// > Typically applications should increase their soft limit to the hard limit on
+/// > their own, if they are OK with working with file descriptors above 1023, i.e.
+/// > do not use `select(2)`. Note that file descriptors are nowadays accounted like
+/// > any other form of memory, thus there should not be any need to lower the hard
+/// > limit.
+///
+/// See: <https://www.freedesktop.org/software/systemd/man/devel/systemd.exec.html>
+#[allow(clippy::result_unit_err)]
+pub fn set_default_file_descriptor_limits(
+    soft_limit: rlim_t,
+    hard_limit: rlim_t,
+) -> Result<(), ()> {
+    super::process_group::REVERT_RLIMITS_TO
+        .set((soft_limit, hard_limit))
+        .map_err(|_| ())
+}
+
 pub(crate) struct ProcessCommandImpl {
     inner: Command,
 }
@@ -31,6 +71,17 @@ pub(crate) struct ProcessCommandImpl {
 impl ProcessCommandImpl {
     pub(crate) fn new(mut cmd: StdCommand) -> Self {
         cmd.process_group(0);
+        // If we have custom limits set, revert them for subprocesses.
+        if let Some((soft_limit, hard_limit)) = REVERT_RLIMITS_TO.get().copied() {
+            // Safety: We do not panic, allocate memory, or acquire locks here.
+            unsafe {
+                cmd.pre_exec(move || {
+                    // Reset the number of open file descriptors for subprocesses.
+                    resource::setrlimit(Resource::RLIMIT_NOFILE, soft_limit, hard_limit)
+                        .map_err(Into::into)
+                });
+            }
+        }
         Self { inner: cmd.into() }
     }
 


### PR DESCRIPTION
Closes #419

Fixes this error, very common on macOS where the default file descriptor soft limit is 1024:

    Internal error (stage: calculate_output_values_failed): collecting output ProjectRelativePathBuf("buck-out/v2/gen/root/aaaaaaaaaaaaaaaa/puppy/__puppy__/doggy"): Too many open files (os error 24)

I expect this will still need some work, let me know if there's a better place to put these functions.