### PR TITLE
Add support for `cargo:rustc-env` outputs from build scripts

### DIFF
--- a/prelude/decls/rust_common.bzl
+++ b/prelude/decls/rust_common.bzl
@@ -112,6 +112,15 @@ def _env_arg():
 """),
     }
 
+def _env_flags_arg():
+    return {
+        "env_flags": attrs.list(attrs.arg(), default = [], doc = """
+    A sequence of "--env=NAME=VAL" flags for additional environment variables for this rule's
+     invocations of rustc. For example `env_flags = ["--env=NAME1=val1", "--env=NAME2=val2"]`.
+     The environment variable values may include macros which are expanded.
+"""),
+    }
+
 def _run_env_arg():
     return {
         "run_env": attrs.dict(key = attrs.string(), value = attrs.arg(), sorted = False, default = {}, doc = """
@@ -186,6 +195,7 @@ rust_common = struct(
     crate_root = _crate_root,
     default_roots_arg = _default_roots_arg,
     env_arg = _env_arg,
+    env_flags_arg = _env_flags_arg,
     run_env_arg = _run_env_arg,
     build_and_run_env_arg = _build_and_run_env_arg,
     mapped_srcs_arg = _mapped_srcs_arg,

--- a/prelude/decls/rust_rules.bzl
+++ b/prelude/decls/rust_rules.bzl
@@ -121,6 +121,7 @@ rust_binary = prelude_rule(
         rust_common.crate(crate_type = attrs.option(attrs.string(), default = None)) |
         rust_common.crate_root() |
         rust_common.env_arg() |
+        rust_common.env_flags_arg() |
         _rust_binary_attrs_group(prefix = "") |
         _rust_common_attributes(is_binary = True) |
         _RUST_EXECUTABLE_ATTRIBUTES |
@@ -186,6 +187,7 @@ rust_library = prelude_rule(
         rust_common.linker_flags_arg() |
         rust_common.exported_linker_flags_arg() |
         rust_common.env_arg() |
+        rust_common.env_flags_arg() |
         rust_common.crate(crate_type = attrs.option(attrs.string(), default = None)) |
         rust_common.crate_root() |
         native_common.preferred_linkage(preferred_linkage_type = attrs.enum(Linkage.values(), default = "any")) |

--- a/prelude/rust/build.bzl
+++ b/prelude/rust/build.bzl
@@ -1540,6 +1540,8 @@ def _rustc_invoke(
         compile_cmd.add(cmd_args("--env=", k, "=", v, delimiter = ""))
     for k, v in path_env.items():
         compile_cmd.add(cmd_args("--path-env=", k, "=", v, delimiter = ""))
+    for flag in ctx.attrs.env_flags:
+        compile_cmd.add(cmd_args(flag))
 
     build_status = None
     if infallible_diagnostics:

--- a/prelude/rust/build.bzl
+++ b/prelude/rust/build.bzl
@@ -1540,8 +1540,7 @@ def _rustc_invoke(
         compile_cmd.add(cmd_args("--env=", k, "=", v, delimiter = ""))
     for k, v in path_env.items():
         compile_cmd.add(cmd_args("--path-env=", k, "=", v, delimiter = ""))
-    for flag in ctx.attrs.env_flags:
-        compile_cmd.add(cmd_args(flag))
+    compile_cmd.add(cmd_args(ctx.attrs.env_flags))
 
     build_status = None
     if infallible_diagnostics:

--- a/prelude/rust/cargo_buildscript.bzl
+++ b/prelude/rust/cargo_buildscript.bzl
@@ -85,6 +85,7 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
     cwd = ctx.actions.declare_output("cwd", dir = True)
     out_dir = ctx.actions.declare_output("OUT_DIR", dir = True)
     rustc_flags = ctx.actions.declare_output("rustc_flags")
+    env_flags = ctx.actions.declare_output("env_flags")
 
     if ctx.attrs.manifest_dir != None:
         manifest_dir = ctx.attrs.manifest_dir[DefaultInfo].default_outputs[0]
@@ -97,7 +98,8 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
         cmd_args("--rustc-cfg=", ctx.attrs.rustc_cfg[DefaultInfo].default_outputs[0], delimiter = ""),
         cmd_args("--manifest-dir=", manifest_dir, delimiter = ""),
         cmd_args("--create-cwd=", cwd.as_output(), delimiter = ""),
-        cmd_args("--outfile=", rustc_flags.as_output(), delimiter = ""),
+        cmd_args("--rustc-flags-outfile=", rustc_flags.as_output(), delimiter = ""),
+        cmd_args("--env-flags-outfile=", env_flags.as_output(), delimiter = ""),
     ]
 
     # See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
@@ -144,6 +146,7 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
         sub_targets = {
             "out_dir": [DefaultInfo(default_output = out_dir)],
             "rustc_flags": [DefaultInfo(default_output = rustc_flags)],
+            "env_flags": [DefaultInfo(default_output = env_flags)],
         },
     )]
 


### PR DESCRIPTION
### Summary
This PR adds support for collecting `cargo:rustc-env` outputs from build scripts.

Relates to facebookincubator/reindeer#74.

### Changes
- Allow the build script runner to collect `cargo:rustc-env` outputs as a sequence of `--env`/`--path-env` flags
- Add an `[env_flags]` sub-target for retrieving the flags output from build-script-run
- Add an `env_flags` attribute  to `rust_library`/`rust_binary` rules that accepts such flags

Example with `env_flags` attribute and `[env_flags]` sub-target:
```starlark
cargo.rust_library(
    name = "mime_guess-2.0.5",
    env_flags = ["@$(location :mime_guess-2.0.5-build-script-run[env_flags])"],
    # ...
)
```

After the PR to Reindeer, the `env_flags = ["@$(... [env_flags])"],` line will be automatically added, when `buildscript.run = true`.

### Details
For each `cargo:rustc-env={key}={value}` output from a build script:

**If `value` is an absolute path to an artifact**, e.g.,

- `/nativelink_work_dir/[hash]/work/buck-out/.../outfile` in remote execution,
- `/buck_root_dir/buck-out/.../outfile` in local execution,

generate a `--path-env={key}={relative_path}` flag where `relative_path` is the path with "workdir-prefix" trimmed, e.g.:

```
--path-env=OUTFILE_PATH=buck-out/.../outfile
```

**Otherwise**,

generate a standard `--env={key}={value}` flag, e.g.:

```
--env=RING_CORE_PREFIX=ring_core_0_17_8_
```

This aligns with [the behavior of `process_env`](https://github.com/facebook/buck2/blob/7f4cd1cb28f94b3927d04314816ee69d5f616f95/prelude/rust/build.bzl#L1642-L1649) in `prelude/rust/build.bzl` when dealing with paths in environment settings.

### Testing
A [demonstration repository](https://github.com/yxdai-nju/buck2-buildscript-envflags-demo) verifies this works for `mime_guess` and `ring` crates, both have `cargo:rustc-env` outputs from build scripts.

Closes #918.