### PR TITLE
fix(starlark_lsp): hover should give docs for functions with no docstrings

### DIFF
--- a/starlark-rust/starlark/src/docs.rs
+++ b/starlark-rust/starlark/src/docs.rs
@@ -88,7 +88,8 @@ pub struct DocFunction {
     /// they are present.
     pub docs: Option<DocString>,
     /// The parameters that this function takes. Docs for these parameters should generally be
-    /// extracted from the main docstring's details.
+    /// extracted from the main docstring's details, but may be extracted from the definition if the
+    /// docstring is not present.
     pub params: DocParams,
     /// Details about what this function returns.
     pub ret: DocReturn,

--- a/starlark-rust/starlark_syntax/src/syntax/def.rs
+++ b/starlark-rust/starlark_syntax/src/syntax/def.rs
@@ -49,9 +49,14 @@ pub enum DefParamKind<'a, P: AstPayload> {
     Kwargs,
 }
 
+/// One function parameter.
 pub struct DefParam<'a, P: AstPayload> {
+    /// Name of the parameter.
     pub ident: &'a AstAssignIdentP<P>,
+    /// Whether this is a regular parameter (with optional default) or a varargs construct (*args,
+    /// **kwargs).
     pub kind: DefParamKind<'a, P>,
+    /// Type of the parameter. This is None when a type is not specified.
     pub ty: Option<&'a AstTypeExprP<P>>,
 }
 


### PR DESCRIPTION
I don't know why this was done, but it makes buck2 lsp have largely broken hover on most real code.

This area of the code needs tests. I will look into writing a test fixture when I triage more of these bugs.

Part of https://github.com/facebook/buck2/issues/899