### PR TITLE
Add support for modifiers to the compilation database BXL script

### DIFF
--- a/prelude/cxx/tools/compilation_database.bxl
+++ b/prelude/cxx/tools/compilation_database.bxl
@@ -27,10 +27,10 @@ def _make_entry(ctx: bxl.Context, compile_command: CxxSrcCompileCommand) -> dict
 
 def _impl(ctx: bxl.Context):
     actions = ctx.bxl_actions().actions
-    targets = flatten(ctx.cli_args.targets)
 
     db = []
-    for _name, target in ctx.analysis(ctx.configured_targets(targets)).items():
+    targets = ctx.configured_targets(flatten(ctx.cli_args.targets), modifiers = ctx.modifiers)
+    for _name, target in ctx.analysis(targets).items():
         comp_db_info = target.providers().get(CxxCompilationDbInfo)
         if comp_db_info:
             db += [_make_entry(ctx, cc) for cc in comp_db_info.info.values()]


### PR DESCRIPTION
See the commit message for context, and https://github.com/cbarrete/buck2_example/blob/7fd287291f3600e80b94081c8a4f0d2fa355602b/BUCK for an example (run `buck2 bxl prelude//cxx/tools/compilation_database.bxl:generate -m cxx26 -- --targets //...` before and after this change).