### PR TITLE
fix(flake.nix): specify tokio_unstable cfg

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,14 +38,16 @@
           Security
         ]);
         packages = [ pkgs.cargo-bloat my-rust-bin pkgs.mold-wrapped pkgs.reindeer pkgs.lld_16 pkgs.clang_16 ];
-        shellHook = 
+        shellHook =
           ''
             export BUCK2_BUILD_PROTOC=${pkgs.protobuf}/bin/protoc
             export BUCK2_BUILD_PROTOC_INCLUDE=${pkgs.protobuf}/include
           ''
           # enable mold for linux users, for more tolerable link times
+          # we have to specify tokio_unstable in the RUSTFLAGS here since they override
+          # .cargo/config.toml that is the reasonable place to specify it
           + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-            export RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=mold $RUSTFLAGS"
+            export RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=mold --cfg=tokio_unstable $RUSTFLAGS"
           '';
       };
     });


### PR DESCRIPTION
This is supposed to be specified in .cargo/config.toml but since we add the environment variable, it overrides that.

Fixes: https://github.com/facebook/buck2/issues/941