### PR TITLE
Add support for compile buck2 at riscv64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ httparse = "1.7.1"
 httptest = "0.15"
 humantime = "2.0.1"
 hyper = { version = "0.14.26", features = ["client", "http1", "http2"] }
-hyper-proxy = { git = "https://github.com/get9/hyper-proxy", rev = "205e9fee42d469444d654d9fa207897f4a77d5b6", features = ["rustls"], default-features = false } # branch = tokio-rustls-0.23 Many PRs to bump versions (#28, #30, #31) are several years old, possibly abandoned crate. This fork contains changes from #28 + changes to upgrade rustls to 0.21.
+hyper-proxy = { git = "https://github.com/xizheyin/hyper-proxy", rev = "56ac58ce14107c5edaca75579c31baa6a71231b8", features = ["rustls"], default-features = false } # branch = tokio-rustls-0.23 Many PRs to bump versions (#28, #30, #31) are several years old, possibly abandoned crate. This fork contains changes from #28 + changes to upgrade rustls to 0.21, webpki to 0.22.
 hyper-rustls = { version = "0.24.0", features = ["http2"] }
 hyper-timeout = "0.4"
 hyper-unix-connector = "0.2"
@@ -454,5 +454,6 @@ incremental = true
 
 [patch.crates-io]
 # For https://github.com/jimblandy/perf-event/pull/29
-perf-event = { git = "https://github.com/krallin/perf-event.git", rev = "86224a9bc025d5d19f719542f27c8c629a08b167", version = "0.4" }
-perf-event-open-sys = { git = "https://github.com/krallin/perf-event.git", rev = "86224a9bc025d5d19f719542f27c8c629a08b167", version = "4.0" }
+perf-event = { git = "https://github.com/xizheyin/perf-event.git", rev = "4a824fe513fd57c360596d370a976908bc015d02", version = "0.4.8" }
+perf-event-open-sys = { git = "https://github.com/xizheyin/perf-event", rev = "4a824fe513fd57c360596d370a976908bc015d02", version = "5.0" }
+


### PR DESCRIPTION
In order to support riscv, I realized that there are some dependencies that don't support riscv.
1. The dependency `webpki v0.21` in `hyper-proxy` relies on `ring v0.16.*` which does not support riscv, so I updated it to `webpki v0.22`. see PR get9/hyper-proxy#3 and [this commit](https://github.com/xizheyin/hyper-proxy/commit/56ac58ce14107c5edaca75579c31baa6a71231b8).
2. For `perf-event`, [this fork](https://github.com/krallin/perf-event/tree/meta) version is too old, so I copied PR and rebase it at the latest version, thus ensuring compatibility. See https://github.com/xizheyin/perf-event/tree/buck2.

I replaced the dependencies with my fixed version that I forked.

cc @get9 @krallin 