### PR TITLE
Flips default `use_fbcode_metadata` value

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -514,7 +514,7 @@ impl Buck2OssReConfiguration {
                     section: BUCK2_RE_CLIENT_CFG_SECTION,
                     property: "use_fbcode_metadata",
                 })?
-                .unwrap_or(true),
+                .unwrap_or(false),
             max_decoding_message_size: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_decoding_message_size",


### PR DESCRIPTION
Hi folks 👋🏼 back in https://github.com/facebook/buck2/pull/502 there was some discussion on what the default value for `use_fbcode_metadata` should be. From what I can tell, [there was agreement in defaulting it to `false`](https://github.com/facebook/buck2/pull/502#issuecomment-1833193410) but that never happened.

This just flips that flag since OSS users can't leverage the default metadata buck2 sends because `fbcode/remote_execution/grpc/metadata.proto` is not open source (or at least does not live in this repo), and the config option is undocumented so it's hard for users to track down why metadata might be missing.