### PR TITLE
HACKING.md: document running checks and tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,6 @@
+# shellcheck shell=bash
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
 fi
+source_env_if_exists .envrc.local
 use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Cargo.lock
 buck-out
 /.direnv
 .buckconfig.local
+.envrc.local
 
 # symlinks
 /examples/with_prelude/prelude

--- a/HACKING.md
+++ b/HACKING.md
@@ -43,7 +43,11 @@ nix develop . # add 'rustc' and 'cargo' to $PATH
 cargo build --release --bin=buck2
 ```
 
-A Nix package (e.g. `nix build .#buck2`) does not yet exist.
+A Nix package (e.g. `nix build .#buck2`) does not yet exist; see `buck2` in
+nixpkgs for inspiration for writing one.
+
+An `.envrc` file using the Nix flake is provided for `direnv` users:
+`direnv allow` will give a usable development environment.
 
 [Nix]: https://nixos.org/nix
 
@@ -83,6 +87,42 @@ export BUCK2_BUILD_PROTOC_INCLUDE=/opt/protobuf/include
 ```
 
 Buck2 should then build with `cargo` using the steps above.
+
+### Building buck2 with buck2
+
+See [Bootstrapping] for details; the gist is: use `reindeer --third-party-dir
+shim/third-party/rust buckify` to generate BUCK files for Cargo dependencies,
+then `buck2 build //:buck2` will work.
+
+[Bootstrapping]: ./docs/about/bootstrapping.md
+
+## Running tests and lints
+
+It's possible to run buck2's test suite with `cargo test`.
+
+[Currently][clippy-bug], `cargo clippy` will generate spurious warnings as the
+canonical lint configuration is in `lint_levels.bzl` rather than `Cargo.toml`, so
+it's recommended to use `test.py` instead.
+
+[clippy-bug]: https://github.com/facebook/buck2/issues/943
+
+To run the build, tests, rustdoc, and lints in the same way as buck2's OSS CI,
+run:
+
+```
+python3 test.py --git
+```
+
+Various checks can be run individually with `--lint-only`, `--test-only` and
+similar; see `python3 test.py --help` for details.
+
+N.B. This command will not run Starlark lints since the Starlark linter is
+[disabled due to Git gremlins][Git gremlins] that may be fixable with enough
+effort.
+FIXME: It may be possible to use Sapling on OSS Buck2 to get a working Starlark
+linter, but the instructions to do so would need to be written.
+
+[Git gremlins]: https://github.com/facebook/buck2/commit/54f986c0329f4f60e9057d7e86f3d361f1b5e1bf)
 
 ## Coding conventions
 

--- a/test.py
+++ b/test.py
@@ -31,15 +31,6 @@ lint_levels = importlib.machinery.SourceFileLoader(
 ).load_module()
 
 
-def is_opensource() -> bool:
-    # @oss-disable[end= ]: return False
-    return True # @oss-enable
-
-
-def is_macos() -> bool:
-    return sys.platform == "darwin"
-
-
 def is_windows() -> bool:
     return sys.platform == "win32"
 
@@ -477,12 +468,8 @@ def main() -> None:
             starlark_linter(args.buck2, args.git)
 
     if not (args.rustfmt_only or args.lint_starlark_only):
-        if args.ci and is_opensource() and is_macos():
-            # TODO(nga): re-enable with next rust version bump (current is nightly-2024-02-01)
-            print_error("Clippy crashes on macOS; skipping")
-        else:
-            with timing():
-                clippy(package_args, args.clippy_fix)
+        with timing():
+            clippy(package_args, args.clippy_fix)
 
     if not args.lint_starlark_only:
         with timing():


### PR DESCRIPTION
This was missing info that is what external contributors would want to find to be able to do core development tasks without reading the CI definitions.

This also reenables clippy on macOS since it seems to work on my machine, probably was fixed upstream.

CC: https://github.com/facebook/buck2/issues/948, which still needs a better error message
CC: https://github.com/facebook/buck2/issues/943, which is still a footgun, but at least it's documented how to do correctly now