### PR TITLE
build: improve error messages if reindeer shims aren't generated

### DIFF
--- a/shim/.buckconfig
+++ b/shim/.buckconfig
@@ -5,6 +5,13 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+[buildfile]
+# see <https://github.com/facebook/buck2/pull/956> -- this helps us make
+# error messages when the user doesn't run "reindeer" much more obvious,
+# because the default BUCK file just errors out. We then make reindeer generate
+# BUCK.reindeer to override that.
+name = BUCK.reindeer,BUCK
+
 [cells]
 gh_facebook_buck2_shims_meta = .
 

--- a/shim/.gitignore
+++ b/shim/.gitignore
@@ -8,5 +8,5 @@
 # We currently expect end users to run reindeer vendor themselves
 # so mark these things as to ignore
 /third-party/rust/.cargo/
-/third-party/rust/BUCK
+/third-party/rust/BUCK.reindeer
 /third-party/rust/vendor/

--- a/shim/third-party/rust/BUCK
+++ b/shim/third-party/rust/BUCK
@@ -1,0 +1,15 @@
+
+fail("""----------------------------------------------------
+
+You need to generate BUCK dependencies from Cargo.toml using reindeer!
+
+Try this:
+
+    ./bootstrap/reindeer --third-party-dir shim/third-party/rust buckify
+
+See the following links for more information:
+
+    <https://buck2.build/docs/about/bootstrapping/>
+    <https://dotslash-cli.com>
+
+----------------------------------------------------""")

--- a/shim/third-party/rust/reindeer.toml
+++ b/shim/third-party/rust/reindeer.toml
@@ -23,7 +23,7 @@ bindeps = true
 
 [buck]
 # Name of the generated file.
-file_name = "BUCK"
+file_name = "BUCK.reindeer"
 
 # Rules used for various kinds of targets.
 rust_library = "cargo.rust_library"


### PR DESCRIPTION
This makes it way easier to test buck2-with-buck2 bootstrap builds. It also tries to fix https://github.com/facebook/buck2/issues/948