### PR TITLE
Setup buck2 to build buck2 with remote execution

### DIFF
--- a/.github/actions/build_buck2_nativelink/action.yml
+++ b/.github/actions/build_buck2_nativelink/action.yml
@@ -1,0 +1,31 @@
+name: build_buck2_nativelink
+inputs:
+  NATIVELINK_HEADER_RW_KEY_SECRET:
+    description: ''
+    required: true
+runs:
+  using: composite
+  steps:
+  - name: Build `buck2` with `buck2` using remote execution
+    run: |-
+      {
+      echo "[buck2_re_client]
+      engine_address       = grpc://scheduler-buck2.build-faster.nativelink.net:443
+      action_cache_address = grpc://cas-buck2.build-faster.nativelink.net:443
+      cas_address          = grpc://cas-buck2.build-faster.nativelink.net:443
+      http_headers         = x-nativelink-api-key:${NATIVELINK_HEADER_RW_KEY}
+      tls = true
+      instance_name = main
+      enabled = true
+      capabilities = true
+      [build]
+        execution_platforms = prelude//platforms:default"
+      } > .buckconfig.local
+      if [[ -z ${NATIVELINK_HEADER_RW_KEY:+x} ]]; then
+        echo "Missing NativeLink Api key." >&2
+      else
+        $RUNNER_TEMP/artifacts/buck2 build //:buck2 -v 2
+      fi
+    env:
+      NATIVELINK_HEADER_RW_KEY: ${{ inputs.NATIVELINK_HEADER_RW_KEY_SECRET }}
+    shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,6 +78,9 @@ jobs:
         NATIVELINK_HEADER_RW_KEY_SECRET: ${{ secrets.NATIVELINK_HEADER_RW_KEY_SECRET }}
     - uses: ./.github/actions/setup_reindeer
     - uses: ./.github/actions/build_bootstrap
+    - uses: ./.github/actions/build_buck2_nativelink
+      with:
+        NATIVELINK_HEADER_RW_KEY_SECRET: ${{ secrets.NATIVELINK_HEADER_RW_KEY_SECRET }}
   windows-build-examples:
     runs-on: windows-8-core
     steps:

--- a/prelude/platforms/defs.bzl
+++ b/prelude/platforms/defs.bzl
@@ -17,7 +17,17 @@ def _execution_platform_impl(ctx: AnalysisContext) -> list[Provider]:
         configuration = cfg,
         executor_config = CommandExecutorConfig(
             local_enabled = True,
-            remote_enabled = False,
+            remote_enabled = True,
+            use_limited_hybrid = True,
+            allow_limited_hybrid_fallbacks = True,
+            allow_hybrid_fallbacks_on_failure = True,
+            remote_cache_enabled = True,
+            remote_execution_properties = {
+                "OSFamily": "linux",
+                "container-image": "docker://nativelink-toolchain-buck2:latest",
+            },
+            remote_execution_use_case = "buck2-default",
+            remote_output_paths = "output_paths",
             use_windows_path_separators = ctx.attrs.use_windows_path_separators,
         ),
     )


### PR DESCRIPTION
Summary:
Enable setup to build buck2 with remote execution.

* Create github action that generates .buckconfig.local using `NATIVELINK_HEADER_RW_KEY` from gha secrets.
* Set `container-image` used for remote execution specific to setup of buck2.
* Update .gitignore to include .buckconfig.local.
* Include a `platforms` configuration for prelude/platforms

Differential Revision: D74995911


