### PR TITLE
setup GH action to build buck2 with NativeLink RE

### DIFF
--- a/.github/actions/build_buck2_nativelink/action.yml
+++ b/.github/actions/build_buck2_nativelink/action.yml
@@ -1,0 +1,31 @@
+name: build_buck2_nativelink
+inputs:
+  NATIVELINK_HEADER_RW_KEY_SECRET:
+    description: ''
+    required: true
+runs:
+  using: composite
+  steps:
+  - name: Build `buck2` with `buck2` using remote execution
+    run: |-
+      {
+      echo "[buck2_re_client]
+      engine_address       = grpc://scheduler-buck2.build-faster.nativelink.net:443
+      action_cache_address = grpc://cas-buck2.build-faster.nativelink.net:443
+      cas_address          = grpc://cas-buck2.build-faster.nativelink.net:443
+      http_headers         = x-nativelink-api-key:${NATIVELINK_HEADER_RW_KEY}
+      tls = true
+      instance_name = main
+      enabled = true
+      capabilities = true
+      [build]
+        execution_platforms = prelude//platforms:nativelink"
+      } > .buckconfig.local
+      if [[ -z ${NATIVELINK_HEADER_RW_KEY:+x} ]]; then
+        echo "Missing NativeLink Api key." >&2
+      else
+        $RUNNER_TEMP/artifacts/buck2 build //:buck2 -v 2
+      fi
+    env:
+      NATIVELINK_HEADER_RW_KEY: ${{ inputs.NATIVELINK_HEADER_RW_KEY_SECRET }}
+    shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,6 +78,9 @@ jobs:
         NATIVELINK_HEADER_RW_KEY_SECRET: ${{ secrets.NATIVELINK_HEADER_RW_KEY_SECRET }}
     - uses: ./.github/actions/setup_reindeer
     - uses: ./.github/actions/build_bootstrap
+    - uses: ./.github/actions/build_buck2_nativelink
+      with:
+        NATIVELINK_HEADER_RW_KEY_SECRET: ${{ secrets.NATIVELINK_HEADER_RW_KEY_SECRET }}
   windows-build-examples:
     runs-on: windows-8-core
     steps:

--- a/prelude/platforms/BUCK
+++ b/prelude/platforms/BUCK
@@ -2,6 +2,7 @@
 
 load("@prelude//utils:source_listing.bzl", "source_listing")
 load(":defs.bzl", "execution_platform", "host_configuration")
+load(":nativelink_defs.bzl", "nativelink_execution_platform")
 
 oncall("build_infra")
 
@@ -78,5 +79,12 @@ export_file(
         ":fat_platform_enabled": ["config//:none"],
         "DEFAULT": [],
     }),
+    visibility = ["PUBLIC"],
+)
+
+nativelink_execution_platform(
+    name = "nativelink",
+    cpu_configuration = host_configuration.cpu,
+    os_configuration = host_configuration.os,
     visibility = ["PUBLIC"],
 )

--- a/prelude/platforms/nativelink_defs.bzl
+++ b/prelude/platforms/nativelink_defs.bzl
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+def _nativelink_execution_platform(ctx):
+    constraints = dict()
+    constraints.update(ctx.attrs.cpu_configuration[ConfigurationInfo].constraints)
+    constraints.update(ctx.attrs.os_configuration[ConfigurationInfo].constraints)
+    cfg = ConfigurationInfo(constraints = constraints, values = {})
+
+    name = ctx.label.raw_target()
+    platform = ExecutionPlatformInfo(
+        label = name,
+        configuration = cfg,
+        executor_config = CommandExecutorConfig(
+            local_enabled = True,
+            remote_enabled = True,
+            use_limited_hybrid = True,
+            allow_limited_hybrid_fallbacks = True,
+            allow_hybrid_fallbacks_on_failure = True,
+            remote_cache_enabled = True,
+            remote_execution_properties = {
+                "OSFamily": "linux",
+                "container-image": "docker://nativelink-toolchain-buck2:latest",
+            },
+            remote_execution_use_case = "buck2-default",
+            remote_output_paths = "output_paths",
+        ),
+    )
+
+    return [
+        DefaultInfo(),
+        platform,
+        PlatformInfo(label = str(name), configuration = cfg),
+        ExecutionPlatformRegistrationInfo(platforms = [platform]),
+    ]
+
+nativelink_execution_platform = rule(
+    attrs = {
+        "cpu_configuration": attrs.dep(providers = [ConfigurationInfo]),
+        "os_configuration": attrs.dep(providers = [ConfigurationInfo]),
+    },
+    impl = _nativelink_execution_platform,
+)


### PR DESCRIPTION
Summary:
Enable setup to build buck2 with remote execution.

* Create github action that generates .buckconfig.local using `NATIVELINK_HEADER_RW_KEY` from gha secrets.
* Set `container-image` used for remote execution specific to setup of buck2.
* Update .gitignore to include .buckconfig.local.
* Include a `platforms` configuration for prelude/platforms

Differential Revision: D75071353


