### PR TITLE
feat: support configuring the manifold URL

### DIFF
--- a/app/buck2_client_ctx/src/client_ctx.rs
+++ b/app/buck2_client_ctx/src/client_ctx.rs
@@ -20,6 +20,7 @@ use buck2_common::argv::Argv;
 use buck2_common::init::LogDownloadMethod;
 use buck2_common::invocation_paths::InvocationPaths;
 use buck2_common::invocation_paths_result::InvocationPathsResult;
+use buck2_common::manifold::BucketsConfig;
 use buck2_core::error::buck2_hard_error_env;
 use buck2_error::BuckErrorContext;
 use buck2_event_observer::verbosity::Verbosity;
@@ -292,6 +293,14 @@ impl<'a> ClientCommandContext<'a> {
             .immediate_config
             .daemon_startup_config()?
             .log_download_method
+            .clone())
+    }
+
+    pub fn buckets_config(&self) -> buck2_error::Result<Option<BucketsConfig>> {
+        Ok(self
+            .immediate_config
+            .daemon_startup_config()?
+            .buckets_config
             .clone())
     }
 }

--- a/app/buck2_cmd_debug_client/src/upload_re_logs.rs
+++ b/app/buck2_cmd_debug_client/src/upload_re_logs.rs
@@ -34,7 +34,7 @@ impl BuckSubcommand for UploadReLogsCommand {
     ) -> ExitResult {
         buck2_core::facebook_only();
         events_ctx.log_invocation_record = false;
-        let manifold = ManifoldClient::new().await?;
+        let manifold = ManifoldClient::new_with_config(ctx.buckets_config()?).await?;
         // TODO: This should receive the path from the caller.
         let re_logs_dir = ctx.paths()?.re_logs_dir();
         upload_re_logs(

--- a/app/buck2_cmd_rage_client/src/dice.rs
+++ b/app/buck2_cmd_rage_client/src/dice.rs
@@ -47,7 +47,11 @@ pub async fn upload_dice_dump(
         )
         .await?;
 
-    Ok(manifold_leads(&manifold_bucket, manifold_filename))
+    Ok(manifold_leads(
+        manifold,
+        &manifold_bucket,
+        manifold_filename,
+    ))
 }
 
 struct DiceDump {

--- a/app/buck2_cmd_rage_client/src/manifold.rs
+++ b/app/buck2_cmd_rage_client/src/manifold.rs
@@ -15,11 +15,23 @@ use buck2_common::manifold::ManifoldClient;
 use buck2_fs::async_fs_util;
 use buck2_fs::paths::abs_path::AbsPath;
 
-pub(crate) fn manifold_leads(bucket: &Bucket, filename: String) -> String {
-    let full_path = format!("{}/{}", bucket.name, filename);
-    let command = format!("manifold get {full_path}");
-    let url = format!("https://interncache-all.fbcdn.net/manifold/{full_path}");
-    format!("{command}\n{url}")
+pub(crate) fn manifold_leads(
+    manifold: &ManifoldClient,
+    bucket: &Bucket,
+    filename: String,
+) -> String {
+    let url = manifold.file_view_url(bucket, &filename);
+    let command = manifold.file_dump_command(bucket, &filename);
+    let mut out = String::new();
+    if let Some(url) = url {
+        out.push_str(&url);
+    }
+    if let Some(command) = command {
+        out.push('\n');
+        out.push_str(&command);
+    }
+
+    out
 }
 
 pub(crate) async fn file_to_manifold(
@@ -36,7 +48,7 @@ pub(crate) async fn file_to_manifold(
         .read_and_upload(bucket, &filename, Default::default(), &mut file)
         .await?;
 
-    Ok(manifold_leads(&bucket, filename))
+    Ok(manifold_leads(manifold, &bucket, filename))
 }
 
 pub(crate) async fn buf_to_manifold(
@@ -51,5 +63,5 @@ pub(crate) async fn buf_to_manifold(
         .read_and_upload(bucket, &filename, Default::default(), &mut cursor)
         .await?;
 
-    Ok(manifold_leads(&bucket, filename))
+    Ok(manifold_leads(manifold, &bucket, filename))
 }

--- a/app/buck2_cmd_rage_client/src/rage.rs
+++ b/app/buck2_cmd_rage_client/src/rage.rs
@@ -114,7 +114,7 @@ impl RageCommand {
         let client_ctx = ctx.empty_client_context("rage")?;
 
         // Don't fail the rage if you can't figure out whether to do vpnless.
-        let manifold = ManifoldClient::new().await?;
+        let manifold = ManifoldClient::new_with_config(ctx.buckets_config()?).await?;
 
         let rage_id = TraceId::new();
         let mut manifold_id = format!("{rage_id}");
@@ -535,7 +535,7 @@ async fn upload_re_logs_impl(
     let filename = format!("flat/{}-re_logs.zst", &re_session_id);
     upload_re_logs(manifold, bucket, re_logs_dir, &re_session_id, &filename).await?;
 
-    Ok(manifold_leads(&bucket, filename))
+    Ok(manifold_leads(manifold, &bucket, filename))
 }
 
 async fn dispatch_result_event(

--- a/app/buck2_common/src/init.rs
+++ b/app/buck2_common/src/init.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 
 use crate::legacy_configs::configs::LegacyBuckConfig;
 use crate::legacy_configs::key::BuckconfigKeyRef;
+use crate::manifold::BucketsConfig;
 
 pub const DEFAULT_RETAINED_EVENT_LOGS: usize = 12;
 
@@ -460,6 +461,7 @@ pub struct DaemonStartupConfig {
     pub http: HttpConfig,
     pub resource_control: ResourceControlConfig,
     pub log_download_method: LogDownloadMethod,
+    pub buckets_config: Option<BucketsConfig>,
     pub health_check_config: HealthCheckConfig,
     pub retained_event_logs: usize,
 }
@@ -535,6 +537,7 @@ impl DaemonStartupConfig {
                 .map(ToOwned::to_owned),
             http: HttpConfig::from_config(config)?,
             resource_control: ResourceControlConfig::from_config(config)?,
+            buckets_config: BucketsConfig::from_config(config)?,
             log_download_method,
             health_check_config: HealthCheckConfig::from_config(config)?,
             retained_event_logs: config
@@ -571,6 +574,8 @@ impl DaemonStartupConfig {
             } else {
                 LogDownloadMethod::None
             },
+            // TODO(jadel): is this a regression in test vs before?
+            buckets_config: None,
             health_check_config: HealthCheckConfig::default(),
             retained_event_logs: DEFAULT_RETAINED_EVENT_LOGS,
         }

--- a/app/buck2_event_log/src/lib.rs
+++ b/app/buck2_event_log/src/lib.rs
@@ -31,9 +31,6 @@ pub mod write;
 pub mod writer;
 
 pub fn should_upload_log() -> buck2_error::Result<bool> {
-    if buck2_core::is_open_source() {
-        return Ok(false);
-    }
     Ok(!buck2_env!(
         "BUCK2_TEST_DISABLE_LOG_UPLOAD",
         bool,

--- a/app/buck2_file_watcher/src/watchman/core.rs
+++ b/app/buck2_file_watcher/src/watchman/core.rs
@@ -209,7 +209,8 @@ async fn with_timeout<R>(
 }
 
 async fn write_to_manifold(buf: &[u8], name: &str) -> Option<String> {
-    let manifold = ManifoldClient::new().await.ok()?;
+    // FIXME(jadel): thread configuration through
+    let manifold = ManifoldClient::new_with_config(None).await.ok()?;
 
     let filename = format!("flat/{}_{}_logs", uuid::Uuid::new_v4(), name);
     let ttl = Ttl::from_days(14); // 14 days should be plenty of time to take action
@@ -222,12 +223,7 @@ async fn write_to_manifold(buf: &[u8], name: &str) -> Option<String> {
         .await
         .ok()?;
 
-    let url = format!(
-        "https://interncache-all.fbcdn.net/manifold/{}/{}",
-        bucket.name, filename
-    );
-
-    Some(url)
+    manifold.file_view_url(&bucket, &filename)
 }
 
 async fn cmd_logs_to_manifold(cmd: &str, args: Vec<&str>) -> Option<String> {


### PR DESCRIPTION
I have a highly trivial Manifold implementation internally at Mercury for which I would like to set up for buck2 to receive rage and all that at. This allows for fully implementing the build logs feature mentioned in https://github.com/facebook/buck2/issues/441.

There's still a buck2_core::facebook_only() or two that need removed and some more tidying.