### PR TITLE
rust-project: allow specifying alternative buck2 commands

### DIFF
--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -52,11 +52,12 @@ pub(crate) fn to_project_json(
     expanded_and_resolved: ExpandedAndResolved,
     aliases: FxHashMap<Target, AliasedTargetInfo>,
     check_cycles: bool,
+    buck2_command: Option<String>,
     include_all_buildfiles: bool,
     extra_cfgs: &[String],
 ) -> Result<ProjectJson, anyhow::Error> {
     let mode = select_mode(None);
-    let buck = Buck::new(mode);
+    let buck = Buck::new(buck2_command, mode);
     let project_root = buck.resolve_project_root()?;
 
     let ExpandedAndResolved {
@@ -427,12 +428,16 @@ fn merge_unit_test_targets(
 
 #[derive(Debug, Default)]
 pub(crate) struct Buck {
+    command: String,
     mode: Option<String>,
 }
 
 impl Buck {
-    pub(crate) fn new(mode: Option<String>) -> Self {
-        Buck { mode }
+    pub(crate) fn new(command: Option<String>, mode: Option<String>) -> Self {
+        Buck {
+            command: command.unwrap_or_else(|| "buck2".into()),
+            mode,
+        }
     }
 
     /// Invoke `buck2` with the given subcommands.
@@ -462,7 +467,7 @@ impl Buck {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let mut cmd = Command::new("buck2");
+        let mut cmd = Command::new(&self.command);
 
         // rust-analyzer invokes the check-on-save command with `RUST_BACKTRACE=short`
         // set. Unfortunately, buck2 doesn't handle that well and becomes extremely

--- a/integrations/rust-project/src/cli/check.rs
+++ b/integrations/rust-project/src/cli/check.rs
@@ -23,11 +23,16 @@ pub(crate) struct Check {
 }
 
 impl Check {
-    pub(crate) fn new(mode: Option<String>, use_clippy: bool, saved_file: PathBuf) -> Self {
+    pub(crate) fn new(
+        buck2_command: Option<String>,
+        mode: Option<String>,
+        use_clippy: bool,
+        saved_file: PathBuf,
+    ) -> Self {
         let saved_file = safe_canonicalize(&saved_file);
 
         let mode = select_mode(mode.as_deref());
-        let buck = buck::Buck::new(mode);
+        let buck = buck::Buck::new(buck2_command, mode);
         Self {
             buck,
             use_clippy,

--- a/integrations/rust-project/src/cli/develop.rs
+++ b/integrations/rust-project/src/cli/develop.rs
@@ -37,6 +37,7 @@ pub(crate) struct Develop {
     pub(crate) buck: buck::Buck,
     pub(crate) check_cycles: bool,
     pub(crate) invoked_by_ra: bool,
+    pub(crate) buck2_command: Option<String>,
     pub(crate) include_all_buildfiles: bool,
 }
 
@@ -63,6 +64,7 @@ impl Develop {
             pretty,
             mode,
             check_cycles,
+            buck2_command,
             include_all_buildfiles,
             ..
         } = command
@@ -82,13 +84,14 @@ impl Develop {
             };
 
             let mode = select_mode(mode.as_deref());
-            let buck = buck::Buck::new(mode);
+            let buck = buck::Buck::new(buck2_command.clone(), mode);
 
             let develop = Develop {
                 sysroot,
                 buck,
                 check_cycles,
                 invoked_by_ra: false,
+                buck2_command,
                 include_all_buildfiles,
             };
             let out = OutputCfg { out, pretty };
@@ -104,7 +107,10 @@ impl Develop {
         }
 
         if let crate::Command::DevelopJson {
-            sysroot_mode, args, ..
+            sysroot_mode,
+            args,
+            buck2_command,
+            ..
         } = command
         {
             let out = Output::Stdout;
@@ -123,13 +129,14 @@ impl Develop {
                 }
             };
 
-            let buck = buck::Buck::new(mode);
+            let buck = buck::Buck::new(buck2_command.clone(), mode);
 
             let develop = Develop {
                 sysroot,
                 buck,
                 check_cycles: false,
                 invoked_by_ra: true,
+                buck2_command,
                 include_all_buildfiles: false,
             };
             let out = OutputCfg { out, pretty: false };
@@ -230,6 +237,7 @@ impl Develop {
             buck,
             check_cycles,
             include_all_buildfiles,
+            buck2_command,
             ..
         } = self;
 
@@ -262,6 +270,7 @@ impl Develop {
             sysroot,
             exclude_workspaces,
             *check_cycles,
+            buck2_command.clone(),
             *include_all_buildfiles,
             extra_cfgs,
         )
@@ -302,6 +311,7 @@ pub(crate) fn develop_with_sysroot(
     sysroot: Sysroot,
     exclude_workspaces: bool,
     check_cycles: bool,
+    buck2_command: Option<String>,
     include_all_buildfiles: bool,
     extra_cfgs: &[String],
 ) -> Result<ProjectJson, anyhow::Error> {
@@ -321,6 +331,7 @@ pub(crate) fn develop_with_sysroot(
         expanded_and_resolved,
         aliased_libraries,
         check_cycles,
+        buck2_command,
         include_all_buildfiles,
         extra_cfgs,
     )?;

--- a/integrations/rust-project/src/main.rs
+++ b/integrations/rust-project/src/main.rs
@@ -100,6 +100,10 @@ enum Command {
         #[clap(long)]
         check_cycles: bool,
 
+        /// Command used to run `buck2`. Defaults to `"buck2"`.
+        #[clap(long)]
+        buck2_command: Option<String>,
+
         /// The name of the client invoking rust-project, such as 'vscode'.
         #[clap(long)]
         client: Option<String>,
@@ -130,6 +134,10 @@ enum Command {
         #[clap(long)]
         client: Option<String>,
 
+        /// Command used to run `buck2`. Defaults to `"buck2"`.
+        #[clap(long)]
+        buck2_command: Option<String>,
+
         args: JsonArguments,
     },
     /// Build the saved file's owning target. This is meant to be used by IDEs to provide diagnostics on save.
@@ -144,6 +152,10 @@ enum Command {
         /// The name of the client invoking rust-project, such as 'vscode'.
         #[clap(long)]
         client: Option<String>,
+
+        /// Command used to run `buck2`. Defaults to `"buck2"`.
+        #[clap(long)]
+        buck2_command: Option<String>,
 
         /// The file saved by the user. `rust-project` will infer the owning target(s) of the saved file and build them.
         saved_file: PathBuf,
@@ -287,12 +299,13 @@ fn main() -> Result<(), anyhow::Error> {
             mode,
             use_clippy,
             saved_file,
+            buck2_command,
             ..
         } => {
             let subscriber = tracing_subscriber::registry().with(fmt.with_filter(filter));
             tracing::subscriber::set_global_default(subscriber)?;
 
-            cli::Check::new(mode, use_clippy, saved_file.clone())
+            cli::Check::new(buck2_command, mode, use_clippy, saved_file.clone())
                 .run()
                 .inspect_err(|e| crate::scuba::log_check_error(&e, &saved_file, use_clippy))
         }
@@ -376,6 +389,7 @@ fn json_args_pass() {
             args,
             sysroot_mode: SysrootMode::Rustc,
             client: None,
+            buck2_command: None,
         }),
         version: false,
     };
@@ -393,6 +407,7 @@ fn json_args_pass() {
             args,
             sysroot_mode: SysrootMode::Rustc,
             client: None,
+            buck2_command: None,
         }),
         version: false,
     };
@@ -410,6 +425,7 @@ fn json_args_pass() {
             args,
             sysroot_mode: SysrootMode::Rustc,
             client: None,
+            buck2_command: None,
         }),
         version: false,
     };

--- a/integrations/rust-project/src/sysroot.rs
+++ b/integrations/rust-project/src/sysroot.rs
@@ -83,6 +83,7 @@ pub(crate) fn resolve_buckconfig_sysroot(
         },
         true,
         false,
+        None,
         false,
         &[], // sysroot doesn't get any extra cfgs
     )?;


### PR DESCRIPTION
Refile of #774, which got lost somewhere in the covers. This is needed so that you can e.g. configure your editor to use the `rust-project` dotslash file, which then needs the `buck2` dotslash file.