### PR TITLE
buck2_external_cells_bundled: fix self-referential prelude target usage

### DIFF
--- a/.buckconfig.d/common.buckconfig
+++ b/.buckconfig.d/common.buckconfig
@@ -1,6 +1,9 @@
 [cells]
 prelude = prelude
 none = none
+# NOTE: only used to pick up source files off disk for source_listing(),
+# see <https://github.com/facebook/buck2/issues/971>
+prelude_on_disk = prelude
 
 [cell_aliases]
 config = prelude

--- a/app/buck2_external_cells_bundled/BUCK
+++ b/app/buck2_external_cells_bundled/BUCK
@@ -7,7 +7,10 @@ oncall("build_infra")
 bundled_cell(
     name = "prelude",
     include_from_file = "src/lib.rs",
-    source_listing = "prelude//:source_listing",
+    # NOTE: always use prelude_on_disk here! otherwise buck2-on-buck2 builds
+    # will be invalid due to weird circular prelude references.
+    # see <https://github.com/facebook/buck2/issues/971>
+    source_listing = "prelude_on_disk//:source_listing",
 )
 
 rust_library(


### PR DESCRIPTION
This is a subtle but where using `prelude//:source_listing` means that a buck2-on-buck2 build will produce an invalid binary, because `prelude//` refers to the prelude *inside the source binary*. Introduce a new cell and refer to it with that.

Closes #971.