### PR TITLE
buckconfig: specify default execution platforms

### DIFF
--- a/.buckconfig.d/common.buckconfig
+++ b/.buckconfig.d/common.buckconfig
@@ -16,5 +16,8 @@ toolchains = gh_facebook_buck2_shims_meta
 [external_cells]
 prelude = bundled
 
+[build]
+execution_platforms = prelude//platforms:default
+
 [parser]
 target_platform_detector_spec = target:root//...->prelude//platforms:default target:shim//...->prelude//platforms:default


### PR DESCRIPTION
Without this, configured BXL queries fail with a mysterious "Execution platforms are not enabled" error. This makes it possible to open buck2 in your editor (vscode, etc) and have it built and indexed using buck2/rust-project.