### PR TITLE
envrc: minor improvements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,4 +3,6 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
 fi
 source_env_if_exists .envrc.local
+
+watch_file rust-toolchain
 use flake

--- a/.envrc
+++ b/.envrc
@@ -2,7 +2,8 @@
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
 fi
-source_env_if_exists .envrc.local
 
 watch_file rust-toolchain
 use flake
+
+source_env_if_exists .envrc.local


### PR DESCRIPTION
- Properly watch `rust-toolchain` inside `direnv` so that toolchain updates are properly accounted for.
- Source the local environment after using the flake and populating the environment. This gives access to the results of `use flake` in your own script.