### PR TITLE
Add docs for MacOS file descriptor limit issue

### DIFF
--- a/docs/about/bootstrapping.md
+++ b/docs/about/bootstrapping.md
@@ -31,7 +31,7 @@ Build `buck2` with `buck2`:
 buck2 build //:buck2
 ```
 
-## File descriptor limits
+## MacOS file descriptor limits
 
 Note that on MacOS, the default file descriptor limit is far too small. If you encounter
 "Too many open files (os error 24)" errors, do this:

--- a/docs/about/bootstrapping.md
+++ b/docs/about/bootstrapping.md
@@ -30,3 +30,16 @@ Build `buck2` with `buck2`:
 ```sh
 buck2 build //:buck2
 ```
+
+## File descriptor limits
+
+Note that on MacOS, the default file descriptor limit is far too small. If you encounter
+"Too many open files (os error 24)" errors, do this:
+
+```sh
+buck2 kill
+ulimit -n unlimited
+```
+
+And try again. [This PR](https://github.com/facebook/buck2/pull/928) should address the issue
+in Buck2 itself, once completed.

--- a/docs/about/getting_started.md
+++ b/docs/about/getting_started.md
@@ -47,6 +47,19 @@ Some of our rules use symlinks, which are disabled by default for non-admin
 Windows users. You can fix that by
 [enabling Developer Mode](https://pureinfotech.com/enable-developer-mode-windows-11/).
 
+### MacOS File descriptor limits
+
+Note that on MacOS, the default file descriptor limit is far too small. If you encounter
+"Too many open files (os error 24)" errors, do this:
+
+```sh
+buck2 kill
+ulimit -n unlimited
+```
+
+And try again. [This PR](https://github.com/facebook/buck2/pull/928) should address the issue
+in Buck2 itself, once completed.
+
 ## Compiling your first project
 
 This section covers the building of a

--- a/docs/about/getting_started.md
+++ b/docs/about/getting_started.md
@@ -47,7 +47,7 @@ Some of our rules use symlinks, which are disabled by default for non-admin
 Windows users. You can fix that by
 [enabling Developer Mode](https://pureinfotech.com/enable-developer-mode-windows-11/).
 
-### MacOS File descriptor limits
+### MacOS file descriptor limits
 
 Note that on MacOS, the default file descriptor limit is far too small. If you encounter
 "Too many open files (os error 24)" errors, do this:


### PR DESCRIPTION
Small doc changes with workaround for MacOS file descriptor limits. There is an open PR that will address this, but the contributor needs Meta feedback (requested a month ago).