### PR TITLE
nix: fix buck2 bootstrap build on aarch64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,11 @@
           CoreServices
           IOKit
           Security
-        ]);
+        ]) ++ [
+          # NOTE (aseipp): needed on aarch64-linux, so that the linker can
+          # properly find libatomic.so, but harmless elsewhere
+          pkgs.stdenv.cc.cc
+        ];
         packages = [ pkgs.cargo-bloat my-rust-bin pkgs.mold-wrapped pkgs.reindeer pkgs.lld_16 pkgs.clang_16 ];
         shellHook =
           ''


### PR DESCRIPTION
On aarch64-linux, the rustc toolchain apparently wants to produce binaries that need `libatomic.so.1`, because it might "outline" atomics into LL/SC conditionals (CAS is only available in ARM v8.1+). But it doesn't have that available to link against on its runpath, producing a binary with a eagerly-loaded library that doesn't have a proper path set, thus failing the build.

This fixes that, though in a silly twist of fate, by making it available the linker then realizes it has no actual dependency on libatomic.so, presumably because it generates actual CAS instructions, and thus the final binary actually has *no* dependency on it at all.

Presumably, this is a `nixpkgs` bug, or just a weird aarch64 interaction, but alas, ARM v8.0 can't die soon enough, and this makes things no worse on other platforms, so live with it.