### PR TITLE
buck2_daemon: automatically max out fd limits on startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ memmap2 = "0.5.0"
 memoffset = "0.6.4"
 mimalloc = "0.1.46"
 multimap = "0.8.2"
-nix = "0.22"
+nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 nom = "7.1.3"
 notify = "=5.0.0"
 num-bigint = "0.4.3"

--- a/app/buck2_common/src/lib.rs
+++ b/app/buck2_common/src/lib.rs
@@ -55,6 +55,7 @@ pub mod memory_tracker;
 pub mod package_boundary;
 pub mod package_listing;
 pub mod pattern;
+pub mod rlimits;
 pub mod scope;
 pub mod sqlite;
 pub mod starlark_profiler;

--- a/app/buck2_common/src/rlimits.rs
+++ b/app/buck2_common/src/rlimits.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+#[cfg(unix)]
+static REVERT_RLIMITS_TO: std::sync::OnceLock<(nix::libc::rlim_t, nix::libc::rlim_t)> =
+    std::sync::OnceLock::new();
+
+#[cfg(unix)]
+pub fn raise_file_descriptor_limits() -> nix::Result<()> {
+    use nix::sys::resource;
+    use nix::sys::resource::Resource;
+
+    let (soft_limit, hard_limit) = resource::getrlimit(Resource::RLIMIT_NOFILE)?;
+
+    // If the soft limit is already maxxed out or "big enough", don't mess with it.
+    //
+    // The "big enough" value is the default value on Linux.
+    if soft_limit == hard_limit || soft_limit >= 0x80_000 {
+        return Ok(());
+    }
+
+    // We don't care if the limits were already set, so ignore any errors.
+    let _ = REVERT_RLIMITS_TO
+        .set((soft_limit, hard_limit))
+        .map_err(|_| ());
+
+    // > The hard limit acts as a ceiling for the soft limit: an unprivileged process may set only
+    // > its soft limit to a value in the range from 0 up to the hard limit, and (irreversibly)
+    // > lower its hard limit.
+    //
+    // See: https://man7.org/linux/man-pages/man2/getrlimit.2.html
+    let new_soft_limit = soft_limit.max(hard_limit);
+
+    // Set the number of open file descriptors.
+    //
+    // The `systemd.exec` man page says this about setting the limits with `ulimit -n`
+    // directly:
+    //
+    // > Don't use. Be careful when raising the soft limit above 1024, since `select(2)`
+    // > cannot function with file descriptors above 1023 on Linux. Nowadays, the hard
+    // > limit defaults to 524288, a very high value compared to historical defaults.
+    // > Typically applications should increase their soft limit to the hard limit on
+    // > their own, if they are OK with working with file descriptors above 1023, i.e.
+    // > do not use `select(2)`. Note that file descriptors are nowadays accounted like
+    // > any other form of memory, thus there should not be any need to lower the hard
+    // > limit.
+    //
+    // However, this is practically not an issue for Buck for a number of
+    // reasons, most importantly it is in fact a program that needs a lot of
+    // open files. But also, it doesn't matter what the systemd man page says
+    // in reality, because if the user hits the soft limit, they're just going
+    // to run `ulimit -n 10000000` and move on, so we might as well just do
+    // effectively that for them. Therefore, we don't reset rlimits anywhere and
+    // just let all subprocesses inherit this.
+    //
+    // See: https://www.freedesktop.org/software/systemd/man/devel/systemd.exec.html
+    // And: https://github.com/facebook/buck2/pull/986
+    resource::setrlimit(Resource::RLIMIT_NOFILE, new_soft_limit, hard_limit)?;
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn raise_file_descriptor_limits() -> buck2_error::Result<()> {
+    Ok(())
+}

--- a/app/buck2_daemon/src/daemon.rs
+++ b/app/buck2_daemon/src/daemon.rs
@@ -270,6 +270,11 @@ impl DaemonCommand {
 
         maybe_schedule_termination()?;
 
+        // Raise file descriptor limits. The default on modern macOS is
+        // pathetically low (256!!!), and distros like Fedora Asahi have a limit
+        // as low as 1024, which can easily be exceeded on any modern machine.
+        buck2_common::rlimits::raise_file_descriptor_limits()?;
+
         // Higher performance for jemalloc, recommended (but may not have any effect on Mac)
         // https://github.com/jemalloc/jemalloc/blob/dev/TUNING.md#notable-runtime-options-for-performance-tuning
         memory::enable_background_threads()?;


### PR DESCRIPTION
This automatically increases the fd limit of the buck2d process up to whatever the existing user hard limit is, or a reasonable limit (0x80000) if the soft limit is already good enough. This is not configurable and it always happens without question.

The logic behind this is simple: there is never, ever, ever a scenario where I am thinking to myself: "You know what would be great? If my build system ran out of file descriptors and the build failed". Yet this happens all the time with on buck2 on macOS and (apparently?) my Fedora Asahi laptop, where the default soft limits are very, very low.

When I run `buck2 build`, I am asking it to build things. Buck is good at building things, and often it builds lots of things. The soft limit is a simple guardrail, but only that. And if too many files are open due to something like an excessive number of actions, the reality is that there is very little chance the file descriptor table is actually the limiting resource, versus the underlying machine resources (net/disk/cpu/memory).

Just always set the rlimit to the hard cap. This will be inherited by children including the forkserver, which is completely fine.

Fixes #419. Closes #928. Closes #981.