### PR TITLE
shim: fix OSS buck2-on-buck2 build

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -136,7 +136,8 @@ memoffset = "0.6.4"
 mimalloc = { version = "0.1.46", default-features = false }
 multimap = "0.8.2"
 nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
-nom = "7.1.3"
+nom = "8"
+nom-language = "0.1"
 notify = "=5.0.0-pre.16"
 num-bigint = "0.4.3"
 num-traits = "0.2"


### PR DESCRIPTION
The shim Cargo file wasn't updated with the recent changes for `nom` v8. Trivial fix.