### PR TITLE
nix: macOS support for development, small tweaks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,17 +31,14 @@
 
     in {
       devShells.default = pkgs.mkShell {
-        buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
-          CoreFoundation
-          CoreServices
-          IOKit
-          Security
+        buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux ([
+          pkgs.mold-wrapped
         ]) ++ [
           # NOTE (aseipp): needed on aarch64-linux, so that the linker can
           # properly find libatomic.so, but harmless elsewhere
           pkgs.stdenv.cc.cc
         ];
-        packages = [ my-rust-bin pkgs.dotslash pkgs.python3 pkgs.mold-wrapped pkgs.lld_20 pkgs.clang_20 ];
+        packages = [ my-rust-bin pkgs.dotslash pkgs.python3 pkgs.lld_20 pkgs.clang_20 ];
         shellHook =
           ''
             export BUCK2_BUILD_PROTOC=${pkgs.protobuf}/bin/protoc


### PR DESCRIPTION
This makes `nix develop` work correctly on macOS. You should also be able to bootstrap buck2 with buck2 on macOS using this.