### PR TITLE
Update rustup installation command for Buck2

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -34,8 +34,8 @@ To get started, first install [rustup](https://rustup.rs/), then compile the
 `buck2` executable:
 
 ```bash
-rustup install nightly-2025-02-16
-cargo +nightly-2025-02-16 install --git https://github.com/facebook/buck2.git buck2
+rustup install nightly-2025-03-29-x86_64-unknown-linux-gnu
+cargo +nightly-2025-03-29 install --git https://github.com/facebook/buck2.git buck2
 ```
 
 The above commands install `buck2` into a suitable directory, such as

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -34,7 +34,7 @@ To get started, first install [rustup](https://rustup.rs/), then compile the
 `buck2` executable:
 
 ```bash
-rustup toolchain install nightly-2025-03-29
+rustup install nightly-2025-03-29
 cargo +nightly-2025-03-29 install --git https://github.com/facebook/buck2.git buck2
 ```
 

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -34,7 +34,7 @@ To get started, first install [rustup](https://rustup.rs/), then compile the
 `buck2` executable:
 
 ```bash
-rustup install nightly-2025-03-29-x86_64-unknown-linux-gnu
+rustup toolchain install nightly-2025-03-29
 cargo +nightly-2025-03-29 install --git https://github.com/facebook/buck2.git buck2
 ```
 


### PR DESCRIPTION
Revise the rustup installation command to use the latest nightly version for Buck2.

looks like the version in the [docs](https://buck2.build/docs/getting_started/install/) needs to be updated as following the version in the docs outputs this error:
`
buck2 only works with version rustc 1.87.0-nightly (920d95eaf 2025-03-28) of rustc, but you are using rustc 1.86.0-nightly (9cd60bd2c 2025-02-15). Correct version is installed automatically when rustup is used
`

seems like it needs to align with: https://github.com/facebook/buck2/blob/main/rust-toolchain and https://buck2.build/docs/about/getting_started/#installing-buck2

