### PR TITLE
`//A/B/C` is a valid name for `//A/B/C:C`

### DIFF
--- a/app/buck2_build_api_tests/src/analysis/calculation.rs
+++ b/app/buck2_build_api_tests/src/analysis/calculation.rs
@@ -36,6 +36,7 @@ use buck2_core::configuration::data::ConfigurationData;
 use buck2_core::execution_types::executor_config::CommandExecutorConfig;
 use buck2_core::fs::project::ProjectRootTemp;
 use buck2_core::package::PackageLabel;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::provider::id::ProviderId;
 use buck2_core::provider::id::testing::ProviderIdExt;
 use buck2_core::target::label::interner::ConcurrentTargetLabelInterner;
@@ -169,6 +170,7 @@ async fn test_analysis_calculation() -> buck2_error::Result<()> {
             None,
             false,
             false,
+            InferTargetNames::No,
             None,
             Arc::new(ConcurrentTargetLabelInterner::default()),
         )?,

--- a/app/buck2_core/src/pattern/pattern.rs
+++ b/app/buck2_core/src/pattern/pattern.rs
@@ -336,7 +336,7 @@ impl<T: PatternType> ParsedPattern<T> {
             cell_alias_resolver,
             TargetParsingOptions {
                 relative: TargetParsingRel::RequireAbsolute(cell),
-                infer_target: false,
+                infer_target: InferTargetNames::No,
                 strip_package_trailing_slash: false,
             },
             pattern,
@@ -372,7 +372,7 @@ impl<T: PatternType> ParsedPattern<T> {
                     ),
                     Some(target_alias_resolver),
                 ),
-                infer_target: true,
+                infer_target: InferTargetNames::Yes,
                 strip_package_trailing_slash: true,
             },
             pattern,
@@ -382,18 +382,23 @@ impl<T: PatternType> ParsedPattern<T> {
         Self::from_parsed_pattern_with_modifiers(pattern_with_modifiers)
     }
 
+    /// Parse a TargetPattern out, resolving aliases via `cell_resolver` and resolving
+    /// relative targets as permitted by `relative`. If `infer_target` is `Yes`, a target
+    /// name is inferred when none is provided (e.g. `//foo/bar` is interpreted as
+    /// `//foo/bar:bar`).
     pub fn parse_not_relaxed(
         pattern: &str,
         relative: TargetParsingRel<'_>,
         cell_resolver: &CellResolver,
         cell_alias_resolver: &CellAliasResolver,
+        infer_target: InferTargetNames,
     ) -> buck2_error::Result<Self> {
         let pattern_with_modifiers = parse_target_pattern(
             cell_resolver,
             cell_alias_resolver,
             TargetParsingOptions {
                 relative,
-                infer_target: false,
+                infer_target,
                 strip_package_trailing_slash: false,
             },
             pattern,
@@ -476,7 +481,7 @@ impl<T: PatternType> ParsedPatternWithModifiers<T> {
             cell_alias_resolver,
             TargetParsingOptions {
                 relative: TargetParsingRel::RequireAbsolute(cell),
-                infer_target: false,
+                infer_target: InferTargetNames::No,
                 strip_package_trailing_slash: false,
             },
             pattern,
@@ -503,7 +508,7 @@ impl<T: PatternType> ParsedPatternWithModifiers<T> {
                     ),
                     Some(target_alias_resolver),
                 ),
-                infer_target: true,
+                infer_target: InferTargetNames::Yes,
                 strip_package_trailing_slash: true,
             },
             pattern,
@@ -522,7 +527,7 @@ impl<T: PatternType> ParsedPatternWithModifiers<T> {
             cell_alias_resolver,
             TargetParsingOptions {
                 relative,
-                infer_target: false,
+                infer_target: InferTargetNames::No,
                 strip_package_trailing_slash: false,
             },
             pattern,
@@ -1059,11 +1064,19 @@ impl<'a> TargetParsingRel<'a> {
     }
 }
 
+/// Whether to infer a target name from the last component of a package path when
+/// a pattern does not name one, making `//foo/bar` equivalent to `//foo/bar:bar`.
+#[derive(Copy, Clone, Dupe, Debug, Eq, PartialEq, Allocative, Pagable)]
+pub enum InferTargetNames {
+    Yes,
+    No,
+}
+
 #[derive(Clone, Dupe)]
 struct TargetParsingOptions<'a> {
     relative: TargetParsingRel<'a>,
     /// Whether to infer the target in a pattern such as `foo/bar` (to `foo/bar:bar`).
-    infer_target: bool,
+    infer_target: InferTargetNames,
     /// Whether to strip trailing slashes in package names, in e.g. `foo/bar/` or `foo/bar/:qux`.
     /// If not set, trailing slashes are an error. Note that this happens before target inference
     /// (if enabled), so e.g. `foo/bar/` becomes `foo/bar:bar`.
@@ -1119,10 +1132,9 @@ where
         pattern,
     } = lex;
 
-    let pattern = if infer_target {
-        pattern.infer_target()?
-    } else {
-        pattern.reject_ambiguity()?
+    let pattern = match infer_target {
+        InferTargetNames::Yes => pattern.infer_target()?,
+        InferTargetNames::No => pattern.reject_ambiguity()?,
     };
 
     // This allows things of the form `//foo` (having a cell alias) or `:bar` (no cell, no package,
@@ -1237,7 +1249,7 @@ where
         cell_alias_resolver,
         TargetParsingOptions {
             relative: TargetParsingRel::RequireAbsolute(cell_name),
-            infer_target: false,
+            infer_target: InferTargetNames::No,
             strip_package_trailing_slash: false,
         },
         alias,
@@ -1296,6 +1308,7 @@ mod tests {
     use crate::configuration::builtin::BuiltinPlatform;
     use crate::configuration::hash::ConfigurationHash;
     use crate::package::PackageLabel;
+    use crate::pattern::pattern::InferTargetNames;
     use crate::pattern::pattern::Modifiers;
     use crate::pattern::pattern::ParsedPattern;
     use crate::pattern::pattern::ParsedPatternWithModifiers;
@@ -1540,6 +1553,7 @@ mod tests {
                 ),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             )
             .unwrap()
         );
@@ -1553,6 +1567,7 @@ mod tests {
                 ),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             )
             .unwrap()
         );
@@ -1584,6 +1599,7 @@ mod tests {
                 ),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             )?
         );
         Ok(())
@@ -1596,6 +1612,22 @@ mod tests {
             CellRelativePath::unchecked_new("package").to_owned(),
         );
 
+        assert_eq!(
+            mk_target("root", "package/path", "path"),
+            ParsedPattern::<TargetPatternExtra>::parse_not_relaxed(
+                "path",
+                TargetParsingRel::AllowRelative(
+                    &CellPathWithAllowedRelativeDir::backwards_relative_not_supported(
+                        package.clone()
+                    ),
+                    Some(&NoAliases),
+                ),
+                &resolver(),
+                &alias_resolver(),
+                InferTargetNames::Yes,
+            )?
+        );
+
         assert_matches!(
             ParsedPattern::<TargetPatternExtra>::parse_not_relaxed(
                 "path",
@@ -1605,6 +1637,7 @@ mod tests {
                 ),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             ),
             Err(e) => {
                 assert!(
@@ -1734,6 +1767,7 @@ mod tests {
                 TargetParsingRel::AllowLimitedRelative(package.as_ref()),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             )?
         );
         assert_eq!(
@@ -1743,6 +1777,7 @@ mod tests {
                 TargetParsingRel::AllowLimitedRelative(package.as_ref()),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             )?
         );
         let err = ParsedPattern::<TargetPatternExtra>::parse_not_relaxed(
@@ -1750,6 +1785,7 @@ mod tests {
             TargetParsingRel::RequireAbsolute(CellName::testing_new("root")),
             &resolver(),
             &alias_resolver(),
+            InferTargetNames::No,
         )
         .unwrap_err();
         assert!(
@@ -1766,6 +1802,7 @@ mod tests {
                 TargetParsingRel::RequireAbsolute(CellName::testing_new("root")),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             )?
         );
 
@@ -1775,6 +1812,22 @@ mod tests {
                 TargetParsingRel::AllowLimitedRelative(package.as_ref()),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::Yes,
+            ),
+            Err(e) => {
+                assert!(
+                    format!("{e:?}").contains(&format!("{}", TargetPatternParseError::AbsoluteRequired))
+                );
+            }
+        );
+
+        assert_matches!(
+            ParsedPattern::<TargetPatternExtra>::parse_not_relaxed(
+                "foo/bar",
+                TargetParsingRel::AllowLimitedRelative(package.as_ref()),
+                &resolver(),
+                &alias_resolver(),
+                InferTargetNames::No,
             ),
             Err(e) => {
                 assert!(
@@ -1789,6 +1842,7 @@ mod tests {
                 TargetParsingRel::AllowLimitedRelative(package.as_ref()),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             ),
             Err(e) => {
                 assert!(
@@ -1802,6 +1856,7 @@ mod tests {
                 TargetParsingRel::RequireAbsolute(CellName::testing_new("root")),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             ),
             Err(e) => {
                 assert!(
@@ -2310,6 +2365,7 @@ mod tests {
                 ),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             )?
         );
 
@@ -2324,6 +2380,7 @@ mod tests {
                 ),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             ),
             &["Error parsing target pattern `../sibling:target`"],
         );
@@ -2340,6 +2397,7 @@ mod tests {
                 ),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             ),
             &["Error parsing target pattern `../../not_allowed:target`"],
         );
@@ -2522,6 +2580,7 @@ mod tests {
                 TargetParsingRel::RequireAbsolute(CellName::testing_new("root")),
                 &resolver(),
                 &alias_resolver(),
+                InferTargetNames::No,
             ),
             &["The ?modifier syntax is unsupported for this command"],
         );

--- a/app/buck2_interpreter_for_build/src/attrs/attrs_global.rs
+++ b/app/buck2_interpreter_for_build/src/attrs/attrs_global.rs
@@ -109,6 +109,7 @@ pub(crate) fn attr_coercion_context_for_bzl<'v>(
         build_context.cell_info().cell_alias_resolver().dupe(),
         // It is OK to not deduplicate because we don't coerce a lot of labels in bzl files.
         Arc::new(ConcurrentTargetLabelInterner::default()),
+        build_context.infer_target_names,
     ))
 }
 

--- a/app/buck2_interpreter_for_build/src/attrs/coerce/ctx.rs
+++ b/app/buck2_interpreter_for_build/src/attrs/coerce/ctx.rs
@@ -23,6 +23,7 @@ use buck2_core::cells::paths::CellRelativePathBuf;
 use buck2_core::package::PackageLabel;
 use buck2_core::package::package_relative_path::PackageRelativePath;
 use buck2_core::package::package_relative_path::PackageRelativePathBuf;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::pattern::pattern::ParsedPattern;
 use buck2_core::pattern::pattern::TargetParsingRel;
 use buck2_core::pattern::pattern_type::PatternType;
@@ -86,6 +87,10 @@ pub struct BuildAttrCoercionContext {
     current_dir_with_allowed_relative_dirs: CellPathWithAllowedRelativeDir,
     /// Does this package (if present) have a package boundary exception on it.
     package_boundary_exception: bool,
+    /// Whether to infer a target name when a pattern does not provide one,
+    /// making `//foo/bar` equivalent to `//foo/bar:bar`. Controlled by the
+    /// `buck2.infer_target_names` buckconfig.
+    infer_target_names: InferTargetNames,
     /// Allocator for `label_cache`.
     alloc: Bump,
     global_label_interner: Arc<ConcurrentTargetLabelInterner>,
@@ -121,6 +126,7 @@ impl BuildAttrCoercionContext {
         package_boundary_exception: bool,
         global_label_interner: Arc<ConcurrentTargetLabelInterner>,
         current_dir_with_allowed_relative_dirs: CellPathWithAllowedRelativeDir,
+        infer_target_names: InferTargetNames,
     ) -> Self {
         Self {
             cell_resolver,
@@ -129,6 +135,7 @@ impl BuildAttrCoercionContext {
             enclosing_package,
             current_dir_with_allowed_relative_dirs,
             package_boundary_exception,
+            infer_target_names,
             alloc: Bump::new(),
             global_label_interner,
             label_cache: RefCell::new(HashTable::new()),
@@ -144,6 +151,7 @@ impl BuildAttrCoercionContext {
         cell_name: CellName,
         cell_alias_resolver: CellAliasResolver,
         global_label_interner: Arc<ConcurrentTargetLabelInterner>,
+        infer_target_names: InferTargetNames,
     ) -> Self {
         Self::new(
             cell_resolver,
@@ -156,6 +164,7 @@ impl BuildAttrCoercionContext {
                 cell_name,
                 CellRelativePathBuf::unchecked_new("".into()),
             )),
+            infer_target_names,
         )
     }
 
@@ -166,6 +175,7 @@ impl BuildAttrCoercionContext {
         package_boundary_exception: bool,
         global_label_interner: Arc<ConcurrentTargetLabelInterner>,
         current_dir_with_allowed_relative_dirs: CellPathWithAllowedRelativeDir,
+        infer_target_names: InferTargetNames,
     ) -> Self {
         Self::new(
             cell_resolver,
@@ -175,6 +185,7 @@ impl BuildAttrCoercionContext {
             package_boundary_exception,
             global_label_interner,
             current_dir_with_allowed_relative_dirs,
+            infer_target_names,
         )
     }
 
@@ -203,6 +214,7 @@ impl BuildAttrCoercionContext {
             target_parsing_rel,
             &self.cell_resolver,
             &self.cell_alias_resolver,
+            self.infer_target_names,
         )
     }
 

--- a/app/buck2_interpreter_for_build/src/attrs/coerce/testing.rs
+++ b/app/buck2_interpreter_for_build/src/attrs/coerce/testing.rs
@@ -21,6 +21,7 @@ use buck2_core::cells::cell_path_with_allowed_relative_dir::CellPathWithAllowedR
 use buck2_core::cells::cell_root_path::CellRootPathBuf;
 use buck2_core::cells::name::CellName;
 use buck2_core::package::PackageLabel;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::target::label::interner::ConcurrentTargetLabelInterner;
 use buck2_interpreter::extra::InterpreterHostArchitecture;
 use buck2_interpreter::extra::InterpreterHostPlatform;
@@ -73,6 +74,7 @@ pub fn coercion_ctx_listing(package_listing: PackageListing) -> impl AttrCoercio
         CellPathWithAllowedRelativeDir::backwards_relative_not_supported(
             package.as_cell_path().to_owned(),
         ),
+        InferTargetNames::No,
     )
 }
 
@@ -111,6 +113,7 @@ pub fn to_value<'v>(env: &Module<'v>, globals: &Globals, content: &str) -> Value
             bzl_path: import_path,
         }),
         false,
+        InferTargetNames::No,
     );
 
     let mut eval = Evaluator::new(env);

--- a/app/buck2_interpreter_for_build/src/interpreter/build_context.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/build_context.rs
@@ -17,6 +17,7 @@ use buck2_core::cells::CellResolver;
 use buck2_core::cells::build_file_cell::BuildFileCell;
 use buck2_core::cells::cell_path::CellPath;
 use buck2_core::package::PackageLabel;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_interpreter::build_context::STARLARK_PATH_FROM_BUILD_CONTEXT;
 use buck2_interpreter::file_type::StarlarkFileType;
 use buck2_interpreter::paths::path::StarlarkPath;
@@ -174,6 +175,11 @@ pub struct BuildContext<'a> {
     /// When true, rule function is no-op.
     pub(crate) ignore_attrs_for_profiling: bool,
 
+    /// Whether to infer a target name when a label pattern does not provide one,
+    /// making `//foo/bar` equivalent to `//foo/bar:bar`. Controlled by the
+    /// `buck2.infer_target_names` buckconfig.
+    pub(crate) infer_target_names: InferTargetNames,
+
     /// Peak allocated bytes limit for starlark.
     pub(crate) starlark_peak_allocated_byte_limit: OnceCell<Option<u64>>,
 }
@@ -186,6 +192,7 @@ impl<'a> BuildContext<'a> {
         host_info: &'a HostInfo,
         additional: PerFileTypeContext,
         ignore_attrs_for_profiling: bool,
+        infer_target_names: InferTargetNames,
     ) -> BuildContext<'a> {
         let buckconfigs = LegacyBuckConfigsForStarlark::new(buckconfigs);
         BuildContext {
@@ -194,6 +201,7 @@ impl<'a> BuildContext<'a> {
             host_info,
             additional,
             ignore_attrs_for_profiling,
+            infer_target_names,
             starlark_peak_allocated_byte_limit: OnceCell::new(),
         }
     }

--- a/app/buck2_interpreter_for_build/src/interpreter/configuror.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/configuror.rs
@@ -15,6 +15,7 @@ use allocative::Allocative;
 use buck2_common::package_listing::listing::PackageListing;
 use buck2_core::build_file_path::BuildFilePath;
 use buck2_core::cells::cell_path_with_allowed_relative_dir::CellPathWithAllowedRelativeDir;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::target::label::interner::ConcurrentTargetLabelInterner;
 use buck2_interpreter::extra::InterpreterHostArchitecture;
 use buck2_interpreter::extra::InterpreterHostPlatform;
@@ -75,6 +76,10 @@ pub struct BuildInterpreterConfiguror {
     host_info: HostInfo,
     record_target_call_stack: bool,
     skip_targets_with_duplicate_names: bool,
+    /// Whether to infer a target name when a pattern in a build or bzl file does
+    /// not provide one, making `//foo/bar` equivalent to `//foo/bar:bar`.
+    /// Controlled by the `buck2.infer_target_names` buckconfig.
+    infer_target_names: InferTargetNames,
     #[pagable(discard = "Default::default()")]
     global_target_interner: Arc<ConcurrentTargetLabelInterner>,
     /// For test.
@@ -89,6 +94,7 @@ impl BuildInterpreterConfiguror {
         host_xcode_version: Option<XcodeVersionInfo>,
         record_target_call_stack: bool,
         skip_targets_with_duplicate_names: bool,
+        infer_target_names: InferTargetNames,
         additional_globals: Option<AdditionalGlobalsFn>,
         global_target_interner: Arc<ConcurrentTargetLabelInterner>,
     ) -> buck2_error::Result<Arc<Self>> {
@@ -97,9 +103,14 @@ impl BuildInterpreterConfiguror {
             host_info: HostInfo::new(host_platform, host_architecture, host_xcode_version),
             record_target_call_stack,
             skip_targets_with_duplicate_names,
+            infer_target_names,
             additional_globals,
             global_target_interner,
         }))
+    }
+
+    pub(crate) fn infer_target_names(&self) -> InferTargetNames {
+        self.infer_target_names
     }
 
     pub(crate) fn additional_globals(&self) -> Option<&AdditionalGlobalsFn> {
@@ -146,6 +157,7 @@ impl BuildInterpreterConfiguror {
             package_boundary_exception,
             self.global_target_interner.dupe(),
             current_dir_with_allowed_relative_dirs,
+            self.infer_target_names,
         );
 
         let imports = loaded_modules.imports().cloned().collect();

--- a/app/buck2_interpreter_for_build/src/interpreter/interpreter_for_dir.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/interpreter_for_dir.rs
@@ -509,6 +509,7 @@ impl InterpreterForDir {
             host_info,
             extra_context,
             self.ignore_attrs_for_profiling,
+            self.global_state.configuror.infer_target_names(),
         );
 
         let print = EventDispatcherPrintHandler(get_dispatcher());

--- a/app/buck2_interpreter_for_build/src/interpreter/testing.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/testing.rs
@@ -25,6 +25,7 @@ use buck2_core::cells::cell_path_with_allowed_relative_dir::CellPathWithAllowedR
 use buck2_core::cells::cell_root_path::CellRootPathBuf;
 use buck2_core::cells::name::CellName;
 use buck2_core::fs::project_rel_path::ProjectRelativePath;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::target::label::interner::ConcurrentTargetLabelInterner;
 use buck2_interpreter::dice::starlark_provider::StarlarkEvalKind;
 use buck2_interpreter::extra::InterpreterHostArchitecture;
@@ -214,6 +215,7 @@ impl Tester {
                     None,
                     false,
                     false,
+                    InferTargetNames::No,
                     Some(AdditionalGlobalsFn(Arc::new(FnWrapper(Box::new(
                         move |globals_builder| {
                             for additional_globals in &additional_globals {

--- a/app/buck2_interpreter_for_build_tests/src/attr.rs
+++ b/app/buck2_interpreter_for_build_tests/src/attr.rs
@@ -17,6 +17,7 @@ use buck2_core::cells::name::CellName;
 use buck2_core::cells::paths::CellRelativePath;
 use buck2_core::package::PackageLabel;
 use buck2_core::package::package_relative_path::PackageRelativePathBuf;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::plugins::PluginKindSet;
 use buck2_core::target::label::interner::ConcurrentTargetLabelInterner;
 use buck2_interpreter_for_build::attrs::coerce::attr_type::AttrTypeExt;
@@ -126,6 +127,7 @@ fn attr_coercer_coerces() -> buck2_error::Result<()> {
             CellPathWithAllowedRelativeDir::backwards_relative_not_supported(
                 package.as_cell_path().to_owned(),
             ),
+            InferTargetNames::No,
         );
         let label_coercer = AttrType::dep(ProviderIdSet::EMPTY, PluginKindSet::EMPTY);
         let string_coercer = AttrType::string();
@@ -305,12 +307,14 @@ fn coercing_src_to_path_works() -> buck2_error::Result<()> {
         CellPathWithAllowedRelativeDir::backwards_relative_not_supported(
             package.as_cell_path().to_owned(),
         ),
+        InferTargetNames::No,
     );
     let no_package_ctx = BuildAttrCoercionContext::new_no_package(
         cell_resolver,
         CellName::testing_new("root"),
         cell_alias_resolver,
         Arc::new(ConcurrentTargetLabelInterner::default()),
+        InferTargetNames::No,
     );
 
     let err = no_package_ctx

--- a/app/buck2_interpreter_for_build_tests/src/tests.rs
+++ b/app/buck2_interpreter_for_build_tests/src/tests.rs
@@ -22,6 +22,7 @@ use buck2_core::cells::name::CellName;
 use buck2_core::fs::project::ProjectRootTemp;
 use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
 use buck2_core::package::PackageLabel;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::target::label::interner::ConcurrentTargetLabelInterner;
 use buck2_events::dispatch::EventDispatcher;
 use buck2_interpreter::dice::starlark_debug::SetStarlarkDebugger;
@@ -67,6 +68,7 @@ pub(crate) async fn calculation(fs: &ProjectRootTemp) -> DiceTransaction {
             None,
             false,
             false,
+            InferTargetNames::No,
             None,
             Arc::new(ConcurrentTargetLabelInterner::default()),
         )

--- a/app/buck2_query_impls/src/dice.rs
+++ b/app/buck2_query_impls/src/dice.rs
@@ -32,6 +32,7 @@ use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePath;
 use buck2_core::global_cfg_options::GlobalCfgOptions;
 use buck2_core::package::PackageLabel;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::pattern::pattern::ParsedPattern;
 use buck2_core::pattern::pattern::ParsedPatternWithModifiers;
 use buck2_core::pattern::pattern::TargetParsingRel;
@@ -152,6 +153,7 @@ impl LiteralParser {
             ),
             &self.cell_resolver,
             &self.cell_alias_resolver,
+            InferTargetNames::No,
         )
     }
 

--- a/app/buck2_server/src/ctx.rs
+++ b/app/buck2_server/src/ctx.rs
@@ -64,6 +64,7 @@ use buck2_core::facebook_only;
 use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePath;
 use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::pattern::pattern::ParsedPattern;
 use buck2_core::pattern::pattern::ParsedPatternWithModifiers;
 use buck2_core::pattern::pattern_type::ConfiguredProvidersPatternExtra;
@@ -620,6 +621,19 @@ impl DiceUpdater for DiceCommandUpdater<'_, '_> {
 
         let cell_resolver = cells_and_configs.cell_resolver;
 
+        let infer_target_names = if cells_and_configs
+            .root_config
+            .parse::<bool>(BuckconfigKeyRef {
+                section: "buck2",
+                property: "infer_target_names",
+            })?
+            .unwrap_or(false)
+        {
+            InferTargetNames::Yes
+        } else {
+            InferTargetNames::No
+        };
+
         let configuror = BuildInterpreterConfiguror::new(
             prelude_path(&cell_resolver)?,
             self.interpreter_platform,
@@ -627,6 +641,7 @@ impl DiceUpdater for DiceCommandUpdater<'_, '_> {
             self.interpreter_xcode_version.clone(),
             self.cmd_ctx.record_target_call_stacks,
             self.cmd_ctx.skip_targets_with_duplicate_names,
+            infer_target_names,
             None,
             // New interner for each transaction.
             Arc::new(ConcurrentTargetLabelInterner::default()),

--- a/app/buck2_server/src/lsp.rs
+++ b/app/buck2_server/src/lsp.rs
@@ -17,6 +17,8 @@ use buck2_build_api::actions::artifact::get_artifact_fs::GetArtifactFs;
 use buck2_cli_proto::*;
 use buck2_common::dice::cells::HasCellResolver;
 use buck2_common::file_ops::dice::DiceFileComputations;
+use buck2_common::legacy_configs::dice::HasLegacyConfigs;
+use buck2_common::legacy_configs::key::BuckconfigKeyRef;
 use buck2_common::package_listing::dice::DicePackageListingResolver;
 use buck2_core::bxl::BxlFilePath;
 use buck2_core::bzl::ImportPath;
@@ -27,6 +29,7 @@ use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePath;
 use buck2_core::package::package_relative_path::PackageRelativePath;
 use buck2_core::package::source_path::SourcePath;
+use buck2_core::pattern::pattern::InferTargetNames;
 use buck2_core::pattern::pattern::ParsedPattern;
 use buck2_core::pattern::pattern::TargetParsingRel;
 use buck2_core::pattern::pattern_type::ProvidersPatternExtra;
@@ -492,16 +495,33 @@ impl<'a> BuckLspContext<'a> {
         current_package: CellPathRef<'_>,
         literal: &str,
     ) -> buck2_error::Result<Option<StringLiteralResult>> {
-        let (artifact_fs, cell_alias_resolver, dir_with_allowed_relative_dirs) = self
-            .with_dice_ctx(|mut dice_ctx| async move {
+        let (artifact_fs, cell_alias_resolver, dir_with_allowed_relative_dirs, infer_target_names) =
+            self.with_dice_ctx(|mut dice_ctx| async move {
+                let artifact_fs = dice_ctx.get_artifact_fs().await?;
+                let infer_target_names = if dice_ctx
+                    .parse_legacy_config_property(
+                        artifact_fs.cell_resolver().root_cell(),
+                        BuckconfigKeyRef {
+                            section: "buck2",
+                            property: "infer_target_names",
+                        },
+                    )
+                    .await?
+                    .unwrap_or(false)
+                {
+                    InferTargetNames::Yes
+                } else {
+                    InferTargetNames::No
+                };
                 Ok((
-                    dice_ctx.get_artifact_fs().await?,
+                    artifact_fs,
                     dice_ctx
                         .get_cell_alias_resolver(current_package.cell())
                         .await?,
                     dice_ctx
                         .dirs_allowing_relative_paths(current_package.to_owned())
                         .await?,
+                    infer_target_names,
                 ))
             })
             .await?;
@@ -515,6 +535,7 @@ impl<'a> BuckLspContext<'a> {
             },
             cell_resolver,
             &cell_alias_resolver,
+            infer_target_names,
         ) {
             Ok(ParsedPattern::Target(package, target, _)) => {
                 let res = self


### PR DESCRIPTION
> Prefer using the short name when referring to an eponymous target (`//x` instead of `//x:x`). If
> you are in the same package, prefer the local reference (`:x` instead of `//x`).

See: https://bazel.build/build/style-guide#target-naming

This syntax is supported on the command-line, but not in BUCK files. Unfortunately, the only(?) Starlark formatter (buildifier: https://github.com/bazelbuild/buildtools) automatically abbreviates targets on the assumption that this syntax is valid, which causes errors when using Buck2:

    ...
    4: Error coercing "//src/Foo"
    5: Invalid absolute target pattern `//src/Foo` is not allowed
    6: Expected a `:`, a trailing `/...` or the literal `...`.

We can adjust the parsing rules to allow this syntax in more places.

Supercedes https://github.com/facebook/buck2/pull/925