### PR TITLE
Using dep files in "default" C++ toolchains

### DIFF
--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -19,6 +19,7 @@ load(
     "PicBehavior",
     "RcCompilerInfo",
     "ShlibInterfacesMode",
+    "DepTrackingMode",
 )
 load("@prelude//cxx:headers.bzl", "HeaderMode")
 load("@prelude//cxx:linker.bzl", "is_pdb_generated")
@@ -128,6 +129,15 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
     if hasattr(ctx.attrs, "supports_two_phase_compilation"):
         supports_two_phase_compilation = ctx.attrs.supports_two_phase_compilation
 
+    if cxx_tools_info.compiler_type == "clang" or cxx_tools_info.compiler_type == "clang_cl" or cxx_tools_info.compiler_type == "clang_windows":
+        cpp_dep_tracking_mode = DepTrackingMode("show_headers")
+    elif cxx_tools_info.compiler_type == "windows":
+        cpp_dep_tracking_mode = DepTrackingMode("show_includes")
+    elif cxx_tools_info.compiler_type == "gcc":
+        cpp_dep_tracking_mode = DepTrackingMode("makefile")
+    else:
+        cpp_dep_tracking_mode = DepTrackingMode("none")
+
     return [
         DefaultInfo(),
         CxxToolchainInfo(
@@ -207,9 +217,10 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
                 compiler_type = cxx_tools_info.compiler_type,
             ),
             header_mode = HeaderMode("symlink_tree_only"),
-            cpp_dep_tracking_mode = ctx.attrs.cpp_dep_tracking_mode,
+            cpp_dep_tracking_mode = cpp_dep_tracking_mode,
             pic_behavior = pic_behavior,
             llvm_link = llvm_link,
+            use_dep_files = True,
         ),
         CxxPlatformInfo(name = target_name),
     ]


### PR DESCRIPTION
Since it's such an important feature, I think the default should be true. Else some users might be unimpressed by Buck2's performance.
Let me know what you think.
I'm still testing to make sure it works:
- [x] Linux default Clang
- [x] Linux (compiler_type = "gcc", compiler = "gcc", cxx_compiler = "g++")
- [x] Windows default MSVC
- [x] Windows Clang (compiler_type = "clang", compiler = "clang.exe", cxx_compiler = "clang.exe", linker = "lld-link.exe", link_flags = ["libcmt.lib"])
- [x] Windows Clang (compiler_type = "clang_windows", compiler = "clang.exe", cxx_compiler = "clang.exe", linker = "lld-link.exe", link_flags = ["libcmt.lib"])
- [x] Windows Clang CL (compiler = "clang-cl.exe", cxx_compiler = "clang-cl.exe", linker = "lld-link.exe")

I don't have any apple devices.

I tested using the hello_world example. I added another .hpp, built :main, changed the new .hpp, built :main and then checked that nothing was built using buck2 log what-ran.

I didn't test using the `buck2 audit dep-files TARGET CATEGORY IDENTIFIER` command mentioned in https://buck2.build/docs/rule_authors/dep_files/ because I wasn't able to figure out what should be the CATEGORY or IDENTIFIER.