### PR TITLE
Add github action support for riscv buck release

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -11,6 +11,10 @@
             "regex": "^buck2-aarch64-unknown-linux-musl.zst$",
             "path": "buck2-aarch64-unknown-linux-musl"
           },
+          "linux-riscv64": {
+            "regex": "^buck2-riscv64gc-unknown-linux-gnu.zst$",
+            "path": "buck2-riscv64gc-unknown-linux-gnu"
+          },
           "macos-x86_64": {
             "regex": "^buck2-x86_64-apple-darwin.zst$",
             "path": "buck2-x86_64-apple-darwin"
@@ -34,6 +38,10 @@
           "linux-aarch64": {
             "regex": "^rust-project-aarch64-unknown-linux-musl.zst$",
             "path": "rust-project-aarch64-unknown-linux-musl"
+          },
+          "linux-riscv64": {
+            "regex": "^rust-project-riscv64gc-unknown-linux-gnu.zst$",
+            "path": "rust-project-riscv64gc-unknown-linux-gnu"
           },
           "macos-x86_64": {
             "regex": "^rust-project-x86_64-apple-darwin.zst$",

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -62,6 +62,9 @@ jobs:
           - os: 'ubuntu-22.04'
             triple: 'x86_64-unknown-linux-musl'
             cross: true
+          - os: 'ubuntu-22.04'
+            triple: 'riscv64gc-unknown-linux-gnu'
+            cross: true
           - os: 'macos-13'
             triple: 'aarch64-apple-darwin'
             cross: true


### PR DESCRIPTION
I modified `.github` to add the riscv platform for the next release. I did an initial validation in my main branch, but I'm not sure if there's anything else I'm overlooking.