### PR TITLE
Allow windows_resource() to take deps

### DIFF
--- a/prelude/cxx/windows_resource.bzl
+++ b/prelude/cxx/windows_resource.bzl
@@ -87,7 +87,7 @@ def windows_resource_impl(ctx: AnalysisContext) -> list[Provider]:
     )
 
     providers = [
-        DefaultInfo(default_output = rc_output),
+        DefaultInfo(default_output = None),
         SharedLibraryInfo(set = None),
         LinkGroupLibInfo(libs = {}),
         create_linkable_graph(ctx),

--- a/prelude/decls/cxx_rules.bzl
+++ b/prelude/decls/cxx_rules.bzl
@@ -862,6 +862,7 @@ windows_resource = prelude_rule(
         cxx_common.include_directories_arg() |
         {
             "labels": attrs.list(attrs.string(), default = []),
+            "deps": attrs.list(attrs.dep(), default = []),
         }
     ),
 )


### PR DESCRIPTION
We have a .rc file which does an include of a file in a different directory that is not part of the same package.  In order to support this, allow `windows_resource()` to accept a `deps` argument, and merge this in with the existing preprocessor info.

Also, less critical, but I decided to set the `.res` file as the rule's `default_output`.  It's nice to be able to `buck2 build` the resources target directly for debugging purposes.