### PR TITLE
Fix typo in Update configurations_by_example.md

### DIFF
--- a/docs/rule_authors/configurations_by_example.md
+++ b/docs/rule_authors/configurations_by_example.md
@@ -110,12 +110,12 @@ constraint_setting(
 
 constraint_value(
     name = "dev",
-    constraint_settings = ":mode",
+    constraint_setting = ":mode",
 )
 
 constraint_value(
     name = "opt",
-    constraint_settings = ":mode",
+    constraint_setting = ":mode",
 )
 
 # can use config_setting to group constraint values into larger logical pieces


### PR DESCRIPTION
I had copied the changed lines (pre-change), and got an error message.  The edit I made fixed it.