### PR TITLE
README: Clarify public prelude is a subset of the prelude used at Meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ If these headline features make you interested &mdash; check out the
 Buck2 currently **does not have a stable release tag at this time**. Pre-release
 tags/binaries, and stable tags/binaries, will come at later dates. Despite that,
 it is used extensively inside of Meta on vast amounts of code every day, and
-[buck2-prelude](/prelude/) is the same code used internally for all these
-builds, as well.
+[buck2-prelude](/prelude/) is the same code used internally for all
+these builds, as well. (However, Meta retains large amounts of Starlark
+code which builds on top of the prelude.)
 
 Meta just uses the latest committed `HEAD` version of Buck2 at all times. Your
 mileage may vary &mdash; but at the moment, tracking `HEAD` is ideal for


### PR DESCRIPTION
The README (falsely?) claims that the `prelude` directory "is the same code used internally for these builds", but it's only a subset of the actual prelude used internally at Meta, as far as I can tell.

For example, the `PythonToolchainInfo` `bundled_interpreter` and `pex_executor` fields aren't used anywhere in the public prelude. Presumably they're used internally for something at Meta. Also, tools like `@fbcode_macros//build_defs:python_pytest.bzl` are not made public, despite being needed to run tests in this repo (#1026). These ommissions make it challenging to use Buck2 outside of Meta.