### PR TITLE
Allow `buck2 test` to build DefaultInfo and RunInfo providers

### DIFF
--- a/app/buck2_cli_proto/daemon.proto
+++ b/app/buck2_cli_proto/daemon.proto
@@ -522,6 +522,14 @@ message TestRequest {
 
   // Should you add tests that are on the `tests` attribute of the target.
   bool ignore_tests_attribute = 13;
+
+    // Whether `DefaultInfo` providers for targets matching `target_patterns`
+  // should be built instead of only test ones.
+  bool build_default_info = 15;
+
+  // Whether `RunInfo` providers for targets matching `target_patterns`
+  // should be built instead of only test ones.
+  bool build_run_info = 16;
 }
 
 message BxlRequest {

--- a/app/buck2_client/src/commands/test.rs
+++ b/app/buck2_client/src/commands/test.rs
@@ -154,6 +154,27 @@ If include patterns are present, regardless of whether exclude patterns are pres
     #[clap(name = "TEST_EXECUTOR_ARGS", raw = true)]
     test_executor_args: Vec<String>,
 
+    #[clap(
+        long,
+        group = "default-info",
+        help = "Also build default info (this is not the default)"
+    )]
+    build_default_info: bool,
+
+    /// Do not build default info (this is the default)
+    #[allow(unused)]
+    #[clap(long, group = "default-info")]
+    skip_default_info: bool,
+
+    /// Also build runtime dependencies (this is not the default)
+    #[clap(long, group = "run-info")]
+    build_run_info: bool,
+
+    /// Do not build runtime dependencies (this is the default)
+    #[allow(unused)]
+    #[clap(long, group = "run-info")]
+    skip_run_info: bool,
+
     /// This option does nothing. It is here to keep compatibility with Buck1 and ci
     #[clap(long = "deep", hide = true)]
     _deep: bool,
@@ -210,6 +231,8 @@ impl StreamingCommand for TestCommand {
                     }),
                     timeout: self.timeout_options.overall_timeout()?,
                     ignore_tests_attribute: self.ignore_tests_attribute,
+                    build_default_info: self.build_default_info,
+                    build_run_info: self.build_run_info,
                 },
                 events_ctx,
                 ctx.console_interaction_stream(&self.common_opts.console_opts),


### PR DESCRIPTION
This is a reboot of https://github.com/facebook/buck2/pull/702, which I had abandoned because the base had diverged too much.