### PR TITLE
adding cxx precompiled headers implementation to prelude

### DIFF
--- a/prelude/cxx/compile.bzl
+++ b/prelude/cxx/compile.bzl
@@ -267,9 +267,6 @@ def create_compile_cmds(
         if cxx_compile_cmd.compiler_type != "nasm":
             src_args.append("-c")
 
-        if compile_pch and cxx_compile_cmd.compiler_type == "windows":
-            cxx_compile_cmd.base_compile_cmd.add("-I", compile_pch.namespace)
-
         src_args.append(src.file)
 
         src_compile_command = CxxSrcCompileCommand(
@@ -369,7 +366,7 @@ def _compile_single_cxx(
             output_args = [
                 cmd_args(object.as_output(), format="/Fp{}"),
                 cmd_args(pch_object_output.as_output(), format="/Fo{}"),
-                cmd_args(compile_pch.basename_src, format="/Yc{}")
+                cmd_args(compile_pch.path, format="/Yc{}")
             ]
         else:
             output_args = [
@@ -1650,7 +1647,7 @@ def _get_use_pch_args(
     elif src_compile_cmd.cxx_compile_cmd.compiler_type in ["clang"]:
         pch_args.add("-Xclang", "-include-pch", "-Xclang", compile_with_pch.header)
     else:
-        print("Warning: Unsupported compiler type for precompiled header usage: {}".format(
+        fail("Warning: Unsupported compiler type for precompiled header usage: {}".format(
             src_compile_cmd.cxx_compile_cmd.compiler_type,
         ))
 

--- a/prelude/cxx/compile.bzl
+++ b/prelude/cxx/compile.bzl
@@ -57,6 +57,7 @@ load(
     ":headers.bzl",
     "CHeader",
     "CPrecompiledHeaderInfo",
+    "CxxPrecompiledHeader",
     "add_headers_dep_files",
 )
 load(":platform.bzl", "cxx_by_platform")
@@ -173,14 +174,19 @@ def create_compile_cmds(
         impl_params: CxxRuleConstructorParams,
         own_preprocessors: list[CPreprocessor],
         inherited_preprocessor_infos: list[CPreprocessorInfo],
-        add_coverage_instrumentation_compiler_flags: bool) -> CxxCompileCommandOutput:
+        add_coverage_instrumentation_compiler_flags: bool,
+        compile_pch: CxxPrecompiledHeader | None = None,
+    ) -> CxxCompileCommandOutput:
     """
     Forms the CxxSrcCompileCommand to use for each source file based on it's extension
     and optional source file flags. Returns CxxCompileCommandOutput containing an array
     of the generated compile commands and argsfile output.
     """
 
-    srcs_extensions = collect_extensions(impl_params.srcs)
+    if compile_pch:
+        srcs_extensions = set([CxxExtension(compile_pch.clanguage)])
+    else:
+        srcs_extensions = collect_extensions(impl_params.srcs)
     extension_for_plain_headers = detect_source_extension_for_plain_headers(srcs_extensions, impl_params.rule_type)
 
     srcs_with_flags = []  # type: [CxxSrcWithFlags]
@@ -223,8 +229,10 @@ def create_compile_cmds(
     cxx_compile_cmd_by_ext = {}  # type: dict[CxxExtension, CxxCompileCommand]
     argsfile_by_ext = {}  # type: dict[str, CompileArgsfile]
     xcode_argsfile_by_ext = {}  # type: dict[str, CompileArgsfile]
-
-    src_extensions = collect_source_extensions(srcs_with_flags, extension_for_plain_headers)
+    if compile_pch:
+        src_extensions = [CxxExtension(compile_pch.clanguage)]
+    else:
+        src_extensions = collect_source_extensions(srcs_with_flags, extension_for_plain_headers)
 
     # Deduplicate shared arguments to save memory. If we compile multiple files
     # of the same extension they will have some of the same flags. Save on
@@ -239,13 +247,17 @@ def create_compile_cmds(
         src_args = []
         src_args.extend(src.flags)
 
-        ext = get_source_extension(src, extension_for_plain_headers)
+        if compile_pch:
+            ext = CxxExtension(compile_pch.clanguage)
+        else:
+            ext = get_source_extension(src, extension_for_plain_headers)
+
         cxx_compile_cmd = cxx_compile_cmd_by_ext[ext]
 
         if add_coverage_instrumentation_compiler_flags and cxx_compile_cmd.compiler_type != "gcc":
             src_args.extend(ctx.attrs.coverage_instrumentation_compiler_flags)
 
-        if src.is_header:
+        if src.is_header or compile_pch:
             if cxx_compile_cmd.compiler_type in ["clang", "clang_windows", "gcc"]:
                 language_mode = get_header_language_mode(ext)
                 src_args.extend(["-x", language_mode] if language_mode else [])
@@ -254,6 +266,10 @@ def create_compile_cmds(
 
         if cxx_compile_cmd.compiler_type != "nasm":
             src_args.append("-c")
+
+        if compile_pch and cxx_compile_cmd.compiler_type == "windows":
+            cxx_compile_cmd.base_compile_cmd.add("-I", compile_pch.namespace)
+
         src_args.append(src.file)
 
         src_compile_command = CxxSrcCompileCommand(
@@ -303,7 +319,10 @@ def _compile_single_cxx(
         provide_syntax_only: bool,
         use_header_units: bool,
         separate_debug_info: bool,
-        cuda_compile_style: CudaCompileStyle | None) -> CxxCompileOutput:
+        cuda_compile_style: CudaCompileStyle | None,
+        precompiled_header: CPrecompiledHeaderInfo | None = None,
+        compile_pch: CxxPrecompiledHeader | None = None
+    ) -> CxxCompileOutput:
     """
     Construct a final compile command for a single CXX source based on
     `src_compile_command` and other compilation options.
@@ -338,7 +357,21 @@ def _compile_single_cxx(
 
     # For distributed NVCC compilation we will bind the object in the
     # cuda_compile function.
-    output_args = None if src_compile_cmd.src.extension == ".cu" else get_output_flags(compiler_type, object)
+    pch_object_output = None
+    if src_compile_cmd.src.extension == ".cu":
+        output_args = None
+    elif compile_pch and src_compile_cmd.cxx_compile_cmd.compiler_type == "windows":
+        pch_object_output = ctx.actions.declare_output(
+            folder_name,
+            "{}.pch.o".format(filename_base),
+        )
+        output_args = [
+            cmd_args(object.as_output(), format="/Fp{}"),
+            cmd_args(pch_object_output.as_output(), format="/Fo{}")
+        ]
+    else:
+        output_args = get_output_flags(compiler_type, object)
+
     cmd = _get_base_compile_cmd(
         bitcode_args = bitcode_args,
         src_compile_cmd = src_compile_cmd,
@@ -347,6 +380,27 @@ def _compile_single_cxx(
         use_header_units = use_header_units,
         output_args = output_args,
     )
+
+    if compile_pch:
+        if src_compile_cmd.cxx_compile_cmd.compiler_type == "windows":
+            cmd.add(cmd_args(compile_pch.basename_src, format="/Yc{}"))
+        elif src_compile_cmd.cxx_compile_cmd.compiler_type == "clang":
+            cmd.add(
+                "-Xclang", "-emit-pch",
+                "-Xclang", "-fno-pch-timestamp",
+                "-fpch-instantiate-templates",
+            )
+
+    if precompiled_header and precompiled_header.compiled:
+        pch_info = ctx.attrs.precompiled_header[DefaultInfo].sub_targets["pch"]
+        pch_subtargets = pch_info.get(DefaultInfo).sub_targets
+
+        pch_flavor = "default"
+        for flavor in flavors:
+            pch_flavor = flavor.value if flavor.value else pch_flavor
+
+        target = pch_subtargets[pch_flavor].get(CPrecompiledHeaderInfo)
+        cmd.add(_get_use_pch_args(src_compile_cmd, target, precompiled_header))
 
     action_dep_files = {}
 
@@ -453,6 +507,8 @@ def _compile_single_cxx(
         if cuda_compile_output:
             dist_nvcc_dag, dist_nvcc_env = cuda_compile_output
     else:
+        is_producing_compiled_pch = bool(compile_pch)
+        is_consuming_compiled_pch = bool(precompiled_header and precompiled_header.compiled)
         actions.run(
             cmd,
             category = src_compile_cmd.cxx_compile_cmd.category,
@@ -462,6 +518,7 @@ def _compile_single_cxx(
             allow_dep_file_cache_upload = False,
             error_handler = src_compile_cmd.error_handler,
             outputs_for_error_handler = outputs_for_error_handler,
+            local_only = is_producing_compiled_pch or is_consuming_compiled_pch,
         )
 
     # If we're building with split debugging, where the debug info is in the
@@ -597,6 +654,7 @@ def _compile_single_cxx(
         preproc = preproc,
         nvcc_dag = dist_nvcc_dag,
         nvcc_env = dist_nvcc_env,
+        pch_object_output = pch_object_output,
     )
 
 def _get_base_compile_cmd(
@@ -647,7 +705,10 @@ def compile_cxx(
         src_compile_cmds: list[CxxSrcCompileCommand],
         flavors: set[CxxCompileFlavor],
         provide_syntax_only: bool,
-        use_header_units: bool = False) -> list[CxxCompileOutput]:
+        use_header_units: bool = False,
+        precompiled_header: CPrecompiledHeaderInfo | None = None,
+        compile_pch: CxxPrecompiledHeader | None = None,
+    ) -> list[CxxCompileOutput]:
     """
     For a given list of src_compile_cmds, generate output artifacts.
     """
@@ -688,6 +749,8 @@ def compile_cxx(
             use_header_units = use_header_units,
             separate_debug_info = separate_debug_info,
             cuda_compile_style = cuda_compile_style,
+            precompiled_header = precompiled_header,
+            compile_pch = compile_pch,
         )
         objects.append(cxx_compile_output)
 
@@ -1368,7 +1431,7 @@ def _mk_argsfiles(
 
         # Workaround as that's not precompiled, but working just as prefix header.
         # Another thing is that it's clang specific, should be generalized.
-        if hasattr(ctx.attrs, "precompiled_header") and ctx.attrs.precompiled_header != None:
+        if hasattr(ctx.attrs, "precompiled_header") and ctx.attrs.precompiled_header != None and not ctx.attrs.precompiled_header[CPrecompiledHeaderInfo].compiled:
             target_args.add(["-include", headers_tag.tag_artifacts(ctx.attrs.precompiled_header[CPrecompiledHeaderInfo].header)])
         if hasattr(ctx.attrs, "prefix_header") and ctx.attrs.prefix_header != None:
             target_args.add(["-include", headers_tag.tag_artifacts(ctx.attrs.prefix_header)])
@@ -1495,6 +1558,11 @@ def _get_dep_tracking_mode(toolchain: Provider, file_type: DepFileType) -> DepTr
     else:
         return DepTrackingMode("makefile")
 
+def get_compiler_type(ctx: AnalysisContext, ext: CxxExtension) -> typing.Any:
+    toolchain = get_cxx_toolchain_info(ctx)
+    compiler_info = _get_compiler_info(toolchain, ext)
+    return compiler_info.compiler_type
+
 def _generate_base_compile_command(
         ctx: AnalysisContext,
         impl_params: CxxRuleConstructorParams,
@@ -1566,3 +1634,25 @@ def _generate_base_compile_command(
         allow_cache_upload = allow_cache_upload,
         allow_content_based_paths = allow_content_based_paths,
     )
+
+def _get_use_pch_args(
+    src_compile_cmd: CxxSrcCompileCommand,
+    compile_with_pch: CPrecompiledHeaderInfo,
+    precompiled_header: CPrecompiledHeaderInfo,
+) -> cmd_args:
+    if precompiled_header.clanguage != src_compile_cmd.src.extension:
+        return cmd_args()
+
+    pch_args = cmd_args()
+    if src_compile_cmd.cxx_compile_cmd.compiler_type in ["windows"]:
+        pch_args.add(cmd_args(compile_with_pch.basename, format="/Yu{}"))
+        pch_args.add(cmd_args(compile_with_pch.basename, format="/FI{}"))
+        pch_args.add(cmd_args(compile_with_pch.header, format="/Fp{}"))
+    elif src_compile_cmd.cxx_compile_cmd.compiler_type in ["clang"]:
+        pch_args.add("-Xclang", "-include-pch", "-Xclang", compile_with_pch.header)
+    else:
+        print("Warning: Unsupported compiler type for precompiled header usage: {}".format(
+            src_compile_cmd.cxx_compile_cmd.compiler_type,
+        ))
+
+    return pch_args

--- a/prelude/cxx/compile_types.bzl
+++ b/prelude/cxx/compile_types.bzl
@@ -154,6 +154,7 @@ CxxCompileOutput = record(
     nvcc_dag = field(Artifact | None, None),
     # Environment variables for the NVCC sub-commands.
     nvcc_env = field(Artifact | None, None),
+    pch_object_output = field(Artifact | None, None),
 )
 
 CxxCompileFlavor = enum(

--- a/prelude/cxx/cxx_library.bzl
+++ b/prelude/cxx/cxx_library.bzl
@@ -432,10 +432,11 @@ def cxx_library_parameterized(ctx: AnalysisContext, impl_params: CxxRuleConstruc
         basename = "{}{}".format(pch_artifact.basename, pch_clanguage)
         path = paths.join(pch_header.namespace, pch_header.name)
 
-        if compiler_type == "windows":
-            src_file = ctx.actions.declare_output("pch.h")
-            ctx.actions.write(src_file, '#include "{}"'.format(pch_header.name))
-            impl_params.srcs[0] = CxxSrcWithFlags(file = src_file)
+        pch_wrapper = ctx.actions.declare_output("pch_wrapper.cpp")
+        ctx.actions.write(pch_wrapper, '#include "{}"'.format(path))
+
+        ctx.attrs.headers.append(pch_artifact)
+        impl_params.srcs[0] = CxxSrcWithFlags(file = pch_wrapper)
 
         compile_pch = CxxPrecompiledHeader(
             header = ctx.attrs.srcs[0],

--- a/prelude/cxx/cxx_library.bzl
+++ b/prelude/cxx/cxx_library.bzl
@@ -745,7 +745,7 @@ def cxx_library_parameterized(ctx: AnalysisContext, impl_params: CxxRuleConstruc
     if impl_params.generate_providers.merged_native_link_info or impl_params.generate_providers.template_placeholders:
         # Gather link inputs.
         # Windows needs to include a linkable PCH object, this is not required for other platforms
-        inherited_non_exported_link = cxx_inherited_link_info(non_exported_deps + filter(None, [ctx.attrs.precompiled_header if compiler_type == "windows" else None]))
+        inherited_non_exported_link = cxx_inherited_link_info(non_exported_deps + filter(None, [ctx.attrs.precompiled_header]))
         inherited_exported_link = cxx_inherited_link_info(exported_deps)
 
         merged_native_link_info = create_merged_link_info(
@@ -1406,7 +1406,7 @@ def _form_library_outputs(
         if not compile_output:
             return (None, None)
 
-        objects = compile_output.pch_object_output if compile_output.pch_object_output else compile_output.stripped_objects if stripped else compile_output.objects
+        objects = compile_output.pch_object_output if pch else compile_output.stripped_objects if stripped else compile_output.objects
 
         if not objects:
             return (None, None)

--- a/prelude/cxx/headers.bzl
+++ b/prelude/cxx/headers.bzl
@@ -113,9 +113,22 @@ CxxHeadersLayout = record(
     naming = CxxHeadersNaming,
 )
 
+CxxPrecompiledHeader = record(
+    header = field(Artifact),
+    basename = field(str),
+    basename_src = field(str),
+    path = field(str),
+    namespace = field(str),
+    clanguage = field(str),
+)
+
 CPrecompiledHeaderInfo = provider(fields = {
     # Actual precompiled header ready to be used during compilation.
     "header": Artifact,
+    "basename": provider_field(typing.Any, default = None),
+    "path": provider_field(typing.Any, default = None),
+    "compiled": provider_field(bool, default = False),
+    "clanguage": provider_field(str | None, default = None),
 })
 
 def cxx_attr_header_namespace(ctx: AnalysisContext) -> str:
@@ -173,6 +186,10 @@ def as_headers(
                 headers.append(CHeader(artifact = header, name = "/".join(mapped_header), namespace = "", named = True))
 
     return headers
+
+def cxx_attr_precompiled_headers(ctx: AnalysisContext, headers_layout: CxxHeadersLayout) -> CHeader | None:
+    header = ctx.attrs.srcs[0]
+    return _get_attr_headers([header], headers_layout.namespace, headers_layout.naming)[0]
 
 def _get_attr_headers(xs: typing.Any, namespace: str, naming: CxxHeadersNaming) -> list[CHeader]:
     if type(xs) == type([]):

--- a/prelude/decls/cxx_rules.bzl
+++ b/prelude/decls/cxx_rules.bzl
@@ -441,6 +441,147 @@ cxx_genrule = prelude_rule(
     ),
 )
 
+library_attrs = (
+    # @unsorted-dict-items
+    cxx_common.srcs_arg() |
+    cxx_common.platform_srcs_arg() |
+    cxx_common.headers_arg() |
+    cxx_common.platform_headers_arg() |
+    cxx_common.exported_headers_arg() |
+    cxx_common.exported_header_style_arg() |
+    cxx_common.exported_platform_headers_arg() |
+    cxx_common.header_namespace_arg() |
+    cxx_common.preprocessor_flags_arg() |
+    cxx_common.lang_preprocessor_flags_arg() |
+    cxx_common.platform_preprocessor_flags_arg() |
+    cxx_common.lang_platform_preprocessor_flags_arg() |
+    cxx_common.exported_preprocessor_flags_arg(exported_preprocessor_flags_type = attrs.list(attrs.arg(), default = [])) |
+    cxx_common.exported_lang_preprocessor_flags_arg() |
+    cxx_common.exported_platform_preprocessor_flags_arg() |
+    cxx_common.exported_lang_platform_preprocessor_flags_arg() |
+    cxx_common.compiler_flags_arg() |
+    cxx_common.lang_compiler_flags_arg() |
+    cxx_common.platform_compiler_flags_arg() |
+    cxx_common.lang_platform_compiler_flags_arg() |
+    cxx_common.linker_extra_outputs_arg() |
+    cxx_common.linker_flags_arg() |
+    cxx_common.local_linker_flags_arg() |
+    cxx_common.platform_linker_flags_arg() |
+    cxx_common.exported_linker_flags_arg() |
+    cxx_common.exported_post_linker_flags_arg() |
+    cxx_common.exported_platform_linker_flags_arg() |
+    cxx_common.exported_post_platform_linker_flags_arg() |
+    native_common.link_style() |
+    native_common.link_whole(link_whole_type = attrs.option(attrs.bool(), default = None)) |
+    native_common.soname() |
+    cxx_common.raw_headers_arg() |
+    cxx_common.raw_headers_as_headers_mode_arg() |
+    cxx_common.include_directories_arg() |
+    cxx_common.public_include_directories_arg() |
+    cxx_common.public_system_include_directories_arg() |
+    {
+        "deffile": attrs.option(attrs.source(), default = None, doc = """
+            Specifies the *.def file used on windows to modify a dll's exports in place of explicit `__declspec(dllexport)` declarations.
+              The default is to not use a defile.
+        """),
+        "used_by_wrap_script": attrs.bool(default = False, doc = """
+            When using an exopackage
+              Android, if this parameter is set to `True`, then the library is
+              included in the primary APK even if native libraries would otherwise not be
+              placed in it. This is intended for native libraries that are used by a
+              [wrap.sh](https://developer.android.com/ndk/guides/wrap-script)
+              script, which must be placed in the primary APK. Only one of
+              `can_be_asset` and `used_by_wrap_script` can be set
+              for a rule.
+        """),
+    } |
+    cxx_common.supported_platforms_regex_arg() |
+    cxx_common.force_static(force_static_type = attrs.option(attrs.bool(), default = None)) |
+    native_common.preferred_linkage(preferred_linkage_type = attrs.option(attrs.enum(Linkage.values()), default = None)) |
+    cxx_common.reexport_all_header_dependencies_arg() |
+    cxx_common.exported_deps_arg() |
+    cxx_common.exported_platform_deps_arg() |
+    cxx_common.precompiled_header_arg() |
+    apple_common.extra_xcode_sources() |
+    apple_common.extra_xcode_files() |
+    apple_common.uses_explicit_modules_arg() |
+    apple_common.meta_apple_library_validation_enabled_arg() |
+    cxx_common.version_arg() |
+    cxx_common.use_fbcc_rust_wrapper_arg() |
+    cxx_common.use_content_based_paths_arg() |
+    {
+        "archive_allow_cache_upload": attrs.bool(default = False),
+        "bridging_header": attrs.option(attrs.source(), default = None),
+        "can_be_asset": attrs.option(attrs.bool(), default = None),
+        "contacts": attrs.list(attrs.string(), default = []),
+        "cxx_runtime_type": attrs.option(attrs.enum(CxxRuntimeType), default = None),
+        "default_host_platform": attrs.option(attrs.configuration_label(), default = None),
+        "default_platform": attrs.option(attrs.string(), default = None),
+        "defaults": attrs.dict(key = attrs.string(), value = attrs.string(), sorted = False, default = {}),
+        "deps": attrs.list(attrs.dep(), default = []),
+        "devirt_enabled": attrs.bool(default = False),
+        "diagnostics": attrs.dict(key = attrs.string(), value = attrs.source(), sorted = False, default = {}),
+        "executable_name": attrs.option(attrs.string(), default = None),
+        "fat_lto": attrs.bool(default = False),
+        "focused_list_target": attrs.option(attrs.dep(), default = None),
+        "frameworks": attrs.list(attrs.string(), default = []),
+        "headers_as_raw_headers_mode": attrs.option(attrs.enum(HeadersAsRawHeadersMode), default = None),
+        "include_in_android_merge_map_output": attrs.bool(default = True),
+        "labels": attrs.list(attrs.string(), default = []),
+        "libraries": attrs.list(attrs.string(), default = []),
+        "licenses": attrs.list(attrs.source(), default = []),
+        "link_group": attrs.option(attrs.string(), default = None),
+        "link_group_map": LINK_GROUP_MAP_ATTR,
+        "module_name": attrs.option(attrs.string(), default = None),
+        "platform_deps": attrs.list(attrs.tuple(attrs.regex(), attrs.set(attrs.dep(), sorted = True)), default = []),
+        "post_linker_flags": attrs.list(attrs.arg(anon_target_compatible = True), default = []),
+        "post_platform_linker_flags": attrs.list(attrs.tuple(attrs.regex(), attrs.list(attrs.arg(anon_target_compatible = True))), default = []),
+        "prefix_header": attrs.option(attrs.source(), default = None),
+        "resources": attrs.named_set(attrs.source(), sorted = True, default = []),
+        "sdk_modules": attrs.list(attrs.string(), default = []),
+        "static_library_basename": attrs.option(attrs.string(), default = None),
+        "supports_merged_linking": attrs.option(attrs.bool(), default = None),
+        "thin_lto": attrs.bool(default = False),
+        "use_archive": attrs.option(attrs.bool(), default = None),
+        "uses_cxx_explicit_modules": attrs.bool(default = False),
+        "version_universe": attrs.option(attrs.string(), default = None),
+        "weak_framework_names": attrs.list(attrs.string(), default = []),
+        "use_header_units": attrs.bool(default = False, doc = """
+            If True, makes any header unit exported by a dependency (including
+            recursively) through export_header_unit available to the compiler. If
+            false, the compilation ignores header units, regardless of what is
+            exported by dependencies.
+        """),
+        "export_header_unit": attrs.option(attrs.enum(["include", "preload"]), default = None, doc = """
+            If not None, export a C++20 header unit visible to dependants (including
+            recursively) with use_header_units set to True.
+
+            "include": replace includes of each file in exported_headers or
+                raw_headers with an import of the precompiled header unit; files
+                that do not include any of those headers do not load the header
+                unit.
+
+            "preload": automatically load the precompiled header unit in any
+                dependant that uses header units.
+        """),
+        "export_header_unit_filter": attrs.list(attrs.string(), default = [], doc = """
+            A list of regexes. Each regex should match a set of headers in
+            exported_headers or raw_headers to be precompiled together into one
+            C++20 header unit.
+
+            When used with export_header_unit="include", this allows different
+            subsets of headers to be loaded only by files that use them. Each group
+            should only depend on headers in previous groups.
+
+            If a header is not matched by any group, it is not precompiled and will
+            be included textually. If no filter is specified, the rule excludes
+            inline headers based on a name heuristics (e.g. "-inl.h").
+        """),
+        "extra_dwp_flags": attrs.list(attrs.string(), default = []),
+    } |
+    buck.allow_cache_upload_arg()
+)
+
 cxx_library = prelude_rule(
     name = "cxx_library",
     docs = """
@@ -545,146 +686,7 @@ cxx_library = prelude_rule(
         ```
     """,
     further = None,
-    attrs = (
-        # @unsorted-dict-items
-        cxx_common.srcs_arg() |
-        cxx_common.platform_srcs_arg() |
-        cxx_common.headers_arg() |
-        cxx_common.platform_headers_arg() |
-        cxx_common.exported_headers_arg() |
-        cxx_common.exported_header_style_arg() |
-        cxx_common.exported_platform_headers_arg() |
-        cxx_common.header_namespace_arg() |
-        cxx_common.preprocessor_flags_arg() |
-        cxx_common.lang_preprocessor_flags_arg() |
-        cxx_common.platform_preprocessor_flags_arg() |
-        cxx_common.lang_platform_preprocessor_flags_arg() |
-        cxx_common.exported_preprocessor_flags_arg(exported_preprocessor_flags_type = attrs.list(attrs.arg(), default = [])) |
-        cxx_common.exported_lang_preprocessor_flags_arg() |
-        cxx_common.exported_platform_preprocessor_flags_arg() |
-        cxx_common.exported_lang_platform_preprocessor_flags_arg() |
-        cxx_common.compiler_flags_arg() |
-        cxx_common.lang_compiler_flags_arg() |
-        cxx_common.platform_compiler_flags_arg() |
-        cxx_common.lang_platform_compiler_flags_arg() |
-        cxx_common.linker_extra_outputs_arg() |
-        cxx_common.linker_flags_arg() |
-        cxx_common.local_linker_flags_arg() |
-        cxx_common.platform_linker_flags_arg() |
-        cxx_common.exported_linker_flags_arg() |
-        cxx_common.exported_post_linker_flags_arg() |
-        cxx_common.exported_platform_linker_flags_arg() |
-        cxx_common.exported_post_platform_linker_flags_arg() |
-        native_common.link_style() |
-        native_common.link_whole(link_whole_type = attrs.option(attrs.bool(), default = None)) |
-        native_common.soname() |
-        cxx_common.raw_headers_arg() |
-        cxx_common.raw_headers_as_headers_mode_arg() |
-        cxx_common.include_directories_arg() |
-        cxx_common.public_include_directories_arg() |
-        cxx_common.public_system_include_directories_arg() |
-        {
-            "deffile": attrs.option(attrs.source(), default = None, doc = """
-                Specifies the *.def file used on windows to modify a dll's exports in place of explicit `__declspec(dllexport)` declarations.
-                 The default is to not use a defile.
-            """),
-            "used_by_wrap_script": attrs.bool(default = False, doc = """
-                When using an exopackage
-                 Android, if this parameter is set to `True`, then the library is
-                 included in the primary APK even if native libraries would otherwise not be
-                 placed in it. This is intended for native libraries that are used by a
-                 [wrap.sh](https://developer.android.com/ndk/guides/wrap-script)
-                 script, which must be placed in the primary APK. Only one of
-                 `can_be_asset` and `used_by_wrap_script` can be set
-                 for a rule.
-            """),
-        } |
-        cxx_common.supported_platforms_regex_arg() |
-        cxx_common.force_static(force_static_type = attrs.option(attrs.bool(), default = None)) |
-        native_common.preferred_linkage(preferred_linkage_type = attrs.option(attrs.enum(Linkage.values()), default = None)) |
-        cxx_common.reexport_all_header_dependencies_arg() |
-        cxx_common.exported_deps_arg() |
-        cxx_common.exported_platform_deps_arg() |
-        cxx_common.precompiled_header_arg() |
-        apple_common.extra_xcode_sources() |
-        apple_common.extra_xcode_files() |
-        apple_common.uses_explicit_modules_arg() |
-        apple_common.meta_apple_library_validation_enabled_arg() |
-        cxx_common.version_arg() |
-        cxx_common.use_fbcc_rust_wrapper_arg() |
-        cxx_common.use_content_based_paths_arg() |
-        {
-            "archive_allow_cache_upload": attrs.bool(default = False),
-            "bridging_header": attrs.option(attrs.source(), default = None),
-            "can_be_asset": attrs.option(attrs.bool(), default = None),
-            "contacts": attrs.list(attrs.string(), default = []),
-            "cxx_runtime_type": attrs.option(attrs.enum(CxxRuntimeType), default = None),
-            "default_host_platform": attrs.option(attrs.configuration_label(), default = None),
-            "default_platform": attrs.option(attrs.string(), default = None),
-            "defaults": attrs.dict(key = attrs.string(), value = attrs.string(), sorted = False, default = {}),
-            "deps": attrs.list(attrs.dep(), default = []),
-            "devirt_enabled": attrs.bool(default = False),
-            "diagnostics": attrs.dict(key = attrs.string(), value = attrs.source(), sorted = False, default = {}),
-            "executable_name": attrs.option(attrs.string(), default = None),
-            "fat_lto": attrs.bool(default = False),
-            "focused_list_target": attrs.option(attrs.dep(), default = None),
-            "frameworks": attrs.list(attrs.string(), default = []),
-            "headers_as_raw_headers_mode": attrs.option(attrs.enum(HeadersAsRawHeadersMode), default = None),
-            "include_in_android_merge_map_output": attrs.bool(default = True),
-            "labels": attrs.list(attrs.string(), default = []),
-            "libraries": attrs.list(attrs.string(), default = []),
-            "licenses": attrs.list(attrs.source(), default = []),
-            "link_group": attrs.option(attrs.string(), default = None),
-            "link_group_map": LINK_GROUP_MAP_ATTR,
-            "module_name": attrs.option(attrs.string(), default = None),
-            "platform_deps": attrs.list(attrs.tuple(attrs.regex(), attrs.set(attrs.dep(), sorted = True)), default = []),
-            "post_linker_flags": attrs.list(attrs.arg(anon_target_compatible = True), default = []),
-            "post_platform_linker_flags": attrs.list(attrs.tuple(attrs.regex(), attrs.list(attrs.arg(anon_target_compatible = True))), default = []),
-            "prefix_header": attrs.option(attrs.source(), default = None),
-            "resources": attrs.named_set(attrs.source(), sorted = True, default = []),
-            "sdk_modules": attrs.list(attrs.string(), default = []),
-            "static_library_basename": attrs.option(attrs.string(), default = None),
-            "supports_merged_linking": attrs.option(attrs.bool(), default = None),
-            "thin_lto": attrs.bool(default = False),
-            "use_archive": attrs.option(attrs.bool(), default = None),
-            "uses_cxx_explicit_modules": attrs.bool(default = False),
-            "version_universe": attrs.option(attrs.string(), default = None),
-            "weak_framework_names": attrs.list(attrs.string(), default = []),
-            "use_header_units": attrs.bool(default = False, doc = """
-                If True, makes any header unit exported by a dependency (including
-                recursively) through export_header_unit available to the compiler. If
-                false, the compilation ignores header units, regardless of what is
-                exported by dependencies.
-            """),
-            "export_header_unit": attrs.option(attrs.enum(["include", "preload"]), default = None, doc = """
-                If not None, export a C++20 header unit visible to dependants (including
-                recursively) with use_header_units set to True.
-
-                "include": replace includes of each file in exported_headers or
-                    raw_headers with an import of the precompiled header unit; files
-                    that do not include any of those headers do not load the header
-                    unit.
-
-                "preload": automatically load the precompiled header unit in any
-                    dependant that uses header units.
-            """),
-            "export_header_unit_filter": attrs.list(attrs.string(), default = [], doc = """
-                A list of regexes. Each regex should match a set of headers in
-                exported_headers or raw_headers to be precompiled together into one
-                C++20 header unit.
-
-                When used with export_header_unit="include", this allows different
-                subsets of headers to be loaded only by files that use them. Each group
-                should only depend on headers in previous groups.
-
-                If a header is not matched by any group, it is not precompiled and will
-                be included textually. If no filter is specified, the rule excludes
-                inline headers based on a name heuristics (e.g. "-inl.h").
-            """),
-            "extra_dwp_flags": attrs.list(attrs.string(), default = []),
-        } |
-        buck.allow_cache_upload_arg()
-    ),
+    attrs = library_attrs,
 )
 
 cxx_precompiled_header = prelude_rule(
@@ -821,7 +823,14 @@ cxx_precompiled_header = prelude_rule(
                  have to be added to `deps` as usual.
             """),
             "version_universe": attrs.option(attrs.string(), default = None),
-        }
+            "pch_clanguage": attrs.option(attrs.string(), default = None, doc = """
+                The c-language extension to use for the precompiled header. Eg. .c, .cpp, .m, .mm, etc.
+            """),
+            "compile_pch_file": attrs.bool(default = False, doc = """
+                Whether to compile the precompiled header file or use legacy mode.
+            """)
+        } |
+        library_attrs
     ),
 )
 

--- a/prelude/rules_impl.bzl
+++ b/prelude/rules_impl.bzl
@@ -277,51 +277,54 @@ _dotnet_extra_attributes = {
     },
 }
 
+_cxx_extra_library_attrs = (
+    {
+        "auto_link_groups": attrs.bool(default = False),
+        # These flags will only be used to instrument a target
+        # when coverage for that target is enabled by `exported_needs_coverage_instrumentation`
+        # or by any of the target's dependencies.
+        "coverage_instrumentation_compiler_flags": attrs.list(attrs.string(), default = []),
+        "cuda_compile_style": attrs.enum(CudaCompileStyle.values(), default = "mono"),
+        "deps_query": attrs.option(attrs.query(), default = None),
+        "exported_needs_coverage_instrumentation": attrs.bool(default = False),
+        "extra_dwp_flags": attrs.list(attrs.string(), default = []),
+        "header_mode": attrs.option(attrs.enum(HeaderMode.values()), default = None),
+        "link_deps_query_whole": attrs.bool(default = False),
+        "link_execution_preference": link_execution_preference_attr(),
+        "link_group_map": LINK_GROUP_MAP_ATTR,
+        "link_ordering": attrs.option(attrs.enum(LinkOrdering.values()), default = None),
+        "precompiled_header": attrs.option(attrs.dep(providers = [CPrecompiledHeaderInfo]), default = None),
+        "prefer_stripped_objects": attrs.bool(default = False),
+        "preferred_linkage": attrs.enum(
+            Linkage.values(),
+            default = "any",
+            doc = """
+Determines what linkage is used when the library is depended on by another target. To
+control how the dependencies of this library are linked, use `link_style` instead.
+""",
+        ),
+        "resources": attrs.named_set(attrs.one_of(attrs.dep(), attrs.source(allow_directory = True)), sorted = True, default = []),
+        "separate_debug_info": attrs.bool(default = False),
+        "stub": attrs.bool(default = False),
+        "supports_header_symlink_subtarget": attrs.bool(default = False),
+        "supports_python_dlopen": attrs.option(attrs.bool(), default = None),
+        "supports_shlib_interfaces": attrs.bool(default = True),
+        "third_party_project": attrs.option(attrs.string(), default = None),
+        "_cxx_hacks": attrs.default_only(attrs.dep(default = "prelude//cxx/tools:cxx_hacks")),
+        "_cxx_toolchain": toolchains_common.cxx(),
+        "_is_building_android_binary": is_building_android_binary_attr(),
+    } |
+    apple_common.extra_xcode_sources() |
+    third_party_common.create_third_party_build_root_attrs()
+)
+
 cxx_extra_attributes = {
     "cxx_genrule": genrule_attributes() | {
         "_cxx_toolchain": toolchains_common.cxx(),
         "_exec_os_type": buck.exec_os_type_arg(),
     },
-    "cxx_library": (
-        {
-            "auto_link_groups": attrs.bool(default = False),
-            # These flags will only be used to instrument a target
-            # when coverage for that target is enabled by `exported_needs_coverage_instrumentation`
-            # or by any of the target's dependencies.
-            "coverage_instrumentation_compiler_flags": attrs.list(attrs.string(), default = []),
-            "cuda_compile_style": attrs.enum(CudaCompileStyle.values(), default = "mono"),
-            "deps_query": attrs.option(attrs.query(), default = None),
-            "exported_needs_coverage_instrumentation": attrs.bool(default = False),
-            "extra_dwp_flags": attrs.list(attrs.string(), default = []),
-            "header_mode": attrs.option(attrs.enum(HeaderMode.values()), default = None),
-            "link_deps_query_whole": attrs.bool(default = False),
-            "link_execution_preference": link_execution_preference_attr(),
-            "link_group_map": LINK_GROUP_MAP_ATTR,
-            "link_ordering": attrs.option(attrs.enum(LinkOrdering.values()), default = None),
-            "precompiled_header": attrs.option(attrs.dep(providers = [CPrecompiledHeaderInfo]), default = None),
-            "prefer_stripped_objects": attrs.bool(default = False),
-            "preferred_linkage": attrs.enum(
-                Linkage.values(),
-                default = "any",
-                doc = """
-Determines what linkage is used when the library is depended on by another target. To
-control how the dependencies of this library are linked, use `link_style` instead.
-""",
-            ),
-            "resources": attrs.named_set(attrs.one_of(attrs.dep(), attrs.source(allow_directory = True)), sorted = True, default = []),
-            "separate_debug_info": attrs.bool(default = False),
-            "stub": attrs.bool(default = False),
-            "supports_header_symlink_subtarget": attrs.bool(default = False),
-            "supports_python_dlopen": attrs.option(attrs.bool(), default = None),
-            "supports_shlib_interfaces": attrs.bool(default = True),
-            "third_party_project": attrs.option(attrs.string(), default = None),
-            "_cxx_hacks": attrs.default_only(attrs.dep(default = "prelude//cxx/tools:cxx_hacks")),
-            "_cxx_toolchain": toolchains_common.cxx(),
-            "_is_building_android_binary": is_building_android_binary_attr(),
-        } |
-        apple_common.extra_xcode_sources() |
-        third_party_common.create_third_party_build_root_attrs()
-    ),
+    "cxx_library": _cxx_extra_library_attrs,
+    "cxx_precompiled_header": _cxx_extra_library_attrs,
     "cxx_test": _merge_dictionaries(
         [
             re_test_common.test_args(),


### PR DESCRIPTION
This change updates the precompiled_header rule to compile a PCH and updates both cxx_library and cxx_executable to compile and link with it. PCH only work for local builds, and mentioned here (https://github.com/facebook/buck2/issues/877) there are potentially 1.5x-2x speedups on builds for using PCH. Noted here, the current precompiled_header implementation doesn't really work as expected (https://github.com/facebook/buck2/issues/368)

Some of the decisions I could use feedback on:

 - The current approach maintains backwards compatibility with the old precompiled_header rule in case anyone was depending on how it was implemented. Upgrading to the new version requires `compile_pch_file=True` and `pch_language=<any clanguage extension>`. Alternatively this could be named something like `precompiled_header_v2` without interfering with the old implementation

 - The PCH and consumer both need to have exactly matching flags. I was hoping to find a better way to match up the PCH rule with the consumer because this matching needs to be done by the developer

 - This re-uses the `cxx_library` internals of `cxx_library_parameterized`, which causes a bunch of shuffling of the input attrs so both the `cxx_library` and `precompiled_header` rule can receive the same inputs.

 - The PCH rule needs a pch_language to be specified. The cxx internals infers clanguage by file extension, which we cannot do with a `.pch` extension so we explicitly pass it in. An alternative could be for the PCH rule to return a provider with all flavors like how pic/non-pic currently work and have the consumer pluck out the correct one to use. This direction looks like it will involve more changes potentially around `MergedLinkInfo` and I'm not sure if we want to take that approach

example usage:
```bash
cxx_precompiled_header(
    name = "my_pch",
    src = "my_pch.pch",
    deps = [],

    # enabling new PCH flow needs these two fields
    compile_pch_file = True,
    pch_language = ".cpp",
)

cxx_library(
    name = "foo",
    srcs = ["foo.cpp"],
    precompiled_header = ":my_pch",
    deps = [],
)
```