### PR TITLE
Use unique clap argument IDs

### DIFF
--- a/app/buck2_cmd_debug_client/src/chrome_trace.rs
+++ b/app/buck2_cmd_debug_client/src/chrome_trace.rs
@@ -103,13 +103,13 @@ pub struct ChromeTraceCommand {
 
     /// The path to read the event log from.
     #[clap(
-        long,
+        long = "path",
         help = "A path to an event-log file to read from. Only works for log files with a single command in them. If no event-log is passed, the most recent one will be used.",
         value_name = "PATH",
         // Hide because `event_log` below subsumes this.
         hide = true
     )]
-    pub path: Option<PathArg>,
+    pub event_log_path: Option<PathArg>,
 
     #[clap(
         long,
@@ -1658,7 +1658,7 @@ impl BuckSubcommand for ChromeTraceCommand {
         _events_ctx: &mut EventsCtx,
     ) -> ExitResult {
         // For backward compatibility, use the path field if it's set
-        let log = if let Some(path) = self.path {
+        let log = if let Some(path) = self.event_log_path {
             EventLogPathBuf::infer(path.resolve(&ctx.working_dir))?
         } else {
             self.event_log.get(&ctx).await?


### PR DESCRIPTION
Running `buck2 debug chrome-trace` in debug mode would panic as clap has a debug assert to check for duplicate argument IDs.  It is my understanding that duplicating argument IDs can cause bugs in release mode, even if they are under different subcommands.