### PR TITLE
prelude/go: Fix wrong starlark load paths for OSS

### DIFF
--- a/docs/users/languages/go/toolchains.md
+++ b/docs/users/languages/go/toolchains.md
@@ -99,8 +99,8 @@ with system toolchains, such as building ASM files.
 ### Example Configuration
 
 ```python
-load("@prelude//fbcode/buck2/prelude/toolchains/go:system_go_bootstrap_toolchain.bzl", "system_go_bootstrap_toolchain")
-load("@prelude//fbcode/buck2/prelude/toolchains/go:system_go_toolchain.bzl", "system_go_toolchain")
+load("@prelude///toolchains/go:system_go_bootstrap_toolchain.bzl", "system_go_bootstrap_toolchain")
+load("@prelude///toolchains/go:system_go_toolchain.bzl", "system_go_toolchain")
 
 system_go_toolchain(
     name = "go",

--- a/prelude/toolchains/go.bzl
+++ b/prelude/toolchains/go.bzl
@@ -6,11 +6,11 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
-load("@prelude//fbcode/buck2/prelude/toolchains/go:system_go_bootstrap_toolchain.bzl", _system_go_bootstrap_toolchain = "system_go_bootstrap_toolchain")
-load("@prelude//fbcode/buck2/prelude/toolchains/go:system_go_toolchain.bzl", _system_go_toolchain = "system_go_toolchain")
+load("@prelude//toolchains/go:system_go_bootstrap_toolchain.bzl", _system_go_bootstrap_toolchain = "system_go_bootstrap_toolchain")
+load("@prelude//toolchains/go:system_go_toolchain.bzl", _system_go_toolchain = "system_go_toolchain")
 
-# deprecated: use `@prelude//fbcode/buck2/prelude/toolchains/go:system_go_bootstrap_toolchain.bzl` instead
+# deprecated: use `@prelude///toolchains/go:system_go_bootstrap_toolchain.bzl` instead
 system_go_bootstrap_toolchain = _system_go_bootstrap_toolchain
 
-# deprecated: use `@prelude//fbcode/buck2/prelude/toolchains/go:system_go_toolchain.bzl` instead
+# deprecated: use `@prelude///toolchains/go:system_go_toolchain.bzl` instead
 system_go_toolchain = _system_go_toolchain


### PR DESCRIPTION
The issue was introduced in
Differential Revision: D79265796
Commit: ff865194a85b093d09b1e51fd0707522697100ee
