### PR TITLE
Allow CAS TTL to be configurable

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -437,6 +437,8 @@ pub struct Buck2OssReConfiguration {
     pub max_total_batch_size: Option<usize>,
     /// Maximum number of concurrent upload requests for each action.
     pub max_concurrent_uploads_per_action: Option<usize>,
+    /// Time that digests are assumed to live in CAS after being touched.
+    pub cas_ttl_secs: Option<i64>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -537,6 +539,10 @@ impl Buck2OssReConfiguration {
             max_concurrent_uploads_per_action: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_concurrent_uploads_per_action",
+            })?,
+            cas_ttl_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "cas_ttl_secs",
             })?,
         })
     }


### PR DESCRIPTION
Expose the configuration named `cas_ttl_secs` to configure the assumed CAS TTL for bazel's remote execution API.