### PR TITLE
remote_python_toolchain: allow overriding cpython urls

### DIFF
--- a/prelude/python/tools/BUCK
+++ b/prelude/python/tools/BUCK
@@ -148,3 +148,9 @@ prelude.python_bootstrap_binary(
     main = "create_link_tree.py",
     visibility = ["PUBLIC"],
 )
+
+prelude.python_bootstrap_binary(
+    name = "gather_libpython_symbols",
+    main = "gather_libpython_symbols.py",
+    visibility = ["PUBLIC"],
+)

--- a/prelude/python/tools/discover_python_archives.sh
+++ b/prelude/python/tools/discover_python_archives.sh
@@ -74,7 +74,7 @@ for platform in linux macos windows; do
         entry=$(get_entry "$version" "$archive_arch" "$archive_platform")
         url="$URL_PREFIX/"$(awk '{print $2}' <<< "$entry")
         sha256=$(awk '{print $1}' <<< "$entry")
-        output+="        \"$arch\": _Archive(url = \"$url\", sha256 = \"$sha256\"),\n"
+        output+="        \"$arch\": {\"sha256\": \"$sha256\", \"url\": \"$url\"},\n"
     done
     output+="    },\n"
 done

--- a/prelude/python/tools/discover_python_archives.sh
+++ b/prelude/python/tools/discover_python_archives.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+set -ueo pipefail
+
+version=${1:-3.13}
+release=${2:-}
+REPO="astral-sh/python-build-standalone"
+
+if [ -z "$release" ]; then
+    release=$(gh release -R "$REPO" list --limit 1 | awk '{print $1}')
+fi
+
+URL_PREFIX="https://github.com/$REPO/releases/download/$release"
+
+input=$(gh release -R "$REPO" download "$release" --pattern SHA256SUMS --output -)
+
+
+function get_entry() {
+    local version=$1
+    local arch=$2
+    local platform=$3
+
+    local match_count
+    local pat
+    pat="cpython-$version.*$arch.*$platform.*install_only_stripped.tar.gz"
+    match_count=$(echo "$input" | grep -c "$pat")
+    if [ "$match_count" -eq 0 ]; then
+        echo "No entry found for version $version, arch $arch, platform $platform" >&2
+        exit 1
+    fi
+
+    match=$(echo "$input" | grep "$pat")
+
+    if [[ "$match_count" -gt 1 ]]; then
+        echo "Multiple entries ($match_count) found for version $version, arch $arch, platform $platform:" >&2
+        echo "$match" >&2
+        exit 2
+    fi
+
+    echo "$match"
+}
+
+output="{\n"
+for platform in linux macos windows; do
+    case "$platform" in
+        linux)
+            archive_platform="unknown-linux-gnu"
+            ;;
+        macos)
+            archive_platform="apple-darwin"
+            ;;
+        windows)
+            archive_platform="pc-windows-msvc"
+            ;;
+    esac
+    output+="    \"$platform\": {\n"
+    for arch in arm64 x86_64; do
+        if [ "$platform" = "linux" ] && [ "$arch" = "x86_64" ]; then
+             # lowest arch level by default
+            # change this to x86_64_2 or 3 or 4 if you don't care about compatibility
+            archive_arch="x86_64-"
+        elif [ "$arch" = "arm64" ]; then
+            archive_arch="aarch64"
+        else
+            archive_arch="$arch"
+        fi
+        entry=$(get_entry "$version" "$archive_arch" "$archive_platform")
+        url="$URL_PREFIX/"$(awk '{print $2}' <<< "$entry")
+        sha256=$(awk '{print $1}' <<< "$entry")
+        output+="        \"$arch\": _Archive(url = \"$url\", sha256 = \"$sha256\"),\n"
+    done
+    output+="    },\n"
+done
+output+="}"
+
+printf "%b\n" "$output"

--- a/prelude/python/tools/gather_libpython_symbols.py
+++ b/prelude/python/tools/gather_libpython_symbols.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# pyre-strict
+
+import argparse
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+from shutil import which
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--nm", type=Path, help="Path to nm tool")
+    parser.add_argument("output", help="Output file path")
+    args = parser.parse_args()
+
+    nm: Path | None = args.nm
+    if nm is None:
+        maybe_nm = which("nm")
+        if not maybe_nm:
+            raise ValueError("nm tool was not specified and also not available on PATH")
+        nm = Path(maybe_nm)
+    if not nm.exists():
+        raise ValueError(f"nm tool not found at specified location: {nm!r}")
+
+    lib_dir = Path(sysconfig.get_config_var("installed_platbase")) / str(
+        sysconfig.get_config_var("platlibdir")
+    )
+    libpython = lib_dir / str(sysconfig.get_config_var("LDLIBRARY"))
+
+    if not libpython.exists():
+        raise RuntimeError(f"No libpython found in {libpython} ({lib_dir=})")
+
+    # Run nm on the library file
+    nm_output = subprocess.check_output([nm, libpython], text=True)
+
+    # Process the output and write linker args
+    with open(args.output, "w") as f:
+        for line in nm_output.splitlines():
+            # Look for lines containing ' T ' which indicates text (code) symbols
+            if " T " not in line:
+                continue
+            # Get the symbol name (third column)
+            symbol = line.split()[2]
+            # Write linker arguments
+            if sys.platform == "linux":
+                f.write(f"-Wl,--undefined={symbol}\n")
+            else:
+                f.write("-Wl,-U\n")
+                f.write(f"-Wl,{symbol}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/prelude/toolchains/demo.bzl
+++ b/prelude/toolchains/demo.bzl
@@ -16,7 +16,7 @@ load("@prelude//toolchains:haskell.bzl", "system_haskell_toolchain")
 load("@prelude//toolchains:java.bzl", "java_test_toolchain", "javacd_toolchain", "system_java_bootstrap_toolchain", "system_java_lib", "system_java_tool", "system_prebuilt_jar_bootstrap_toolchain")
 load("@prelude//toolchains:kotlin.bzl", "kotlincd_toolchain", "system_kotlin_bootstrap_toolchain")
 load("@prelude//toolchains:ocaml.bzl", "system_ocaml_toolchain")
-load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
+load("@prelude//toolchains:python.bzl", "remote_python_toolchain", "system_python_bootstrap_toolchain")
 load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
 load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 load("@prelude//toolchains:zip_file.bzl", "zip_file_toolchain")
@@ -223,7 +223,7 @@ def system_demo_toolchains():
         visibility = ["PUBLIC"],
     )
 
-    system_python_toolchain(
+    remote_python_toolchain(
         name = "python",
         visibility = ["PUBLIC"],
     )

--- a/prelude/toolchains/python.bzl
+++ b/prelude/toolchains/python.bzl
@@ -6,6 +6,7 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
+load("@prelude//:prelude.bzl", "native")
 load(
     "@prelude//python:toolchain.bzl",
     "PythonPlatformInfo",
@@ -76,3 +77,104 @@ system_python_toolchain = rule(
     },
     is_toolchain_rule = True,
 )
+
+def _remote_python_toolchain_impl(ctx) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        PythonToolchainInfo(
+            interpreter = ctx.attrs.interpreter[RunInfo],
+            host_interpreter = ctx.attrs.interpreter[RunInfo],
+            compile = ctx.attrs.compile[DefaultInfo].default_outputs[0],
+            package_style = "inplace",
+            native_link_strategy = "separate",
+            linker_flags = [],
+            binary_linker_flags = [],
+            extension_linker_flags = ctx.attrs.extension_linker_flags,
+        ),
+        PythonPlatformInfo(name = "x86_64"),
+    ]
+
+_remote_python_toolchain = rule(
+    impl = _remote_python_toolchain_impl,
+    attrs = {
+        "compile": attrs.default_only(attrs.dep(default = "prelude//python/tools:compile.py")),
+        "extension_linker_flags": attrs.list(attrs.arg()),
+        "interpreter": attrs.dep(providers = [RunInfo]),
+    },
+    is_toolchain_rule = True,
+    doc = "A python toolchain that uses a pre-built CPython installation, downloaded from the [python-build-standalone project](https://github.com/astral-sh/python-build-standalone)",
+)
+
+_Archive = record(url = str, sha256 = str)
+
+# archives for 3.13
+# update this by running `prelude//python/tools:discover_python_archives.sh`
+CPYTHON_ARCHIVE = {
+    "linux": {
+        "arm64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz", sha256 = "829d615905b5ae8c50353f2ceb3d6665793442d4cbc64503bc9b27b5b9f6fb8a"),
+        "x86_64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz", sha256 = "e3e280d4b1ead63de6ebc9816de71792fc8c71b7a6a999ea82f937047beba037"),
+    },
+    "macos": {
+        "arm64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-apple-darwin-install_only_stripped.tar.gz", sha256 = "c57e48145722a87e34a50a2c31d6b11f0830e62e26d759c11b6606a6a80e6243"),
+        "x86_64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-apple-darwin-install_only_stripped.tar.gz", sha256 = "7caed8ea779dcc5d091955628455823cb0e91587703d8b6f7dd285fb2b44d1e0"),
+    },
+    "windows": {
+        "arm64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-pc-windows-msvc-install_only_stripped.tar.gz", sha256 = "a24c09048d1c20ed01e58e7e59a5e43b79cb7a9f36c067fc24e17649e4301d54"),
+        "x86_64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-pc-windows-msvc-install_only_stripped.tar.gz", sha256 = "0de6eb2cb66211967874b0fb47cfc0299102e8a805f5319e108121e314083066"),
+    },
+}
+
+def remote_python_toolchain(
+        name: str,
+        visibility: list[str],
+        **kwargs) -> None:
+    native.http_archive(
+        name = "cpython_archive",
+        urls = [select({
+            "prelude//os:{}".format(os): select({
+                "prelude//cpu:{}".format(cpu): archive.url
+                for cpu, archive in value.items()
+            })
+            for os, value in CPYTHON_ARCHIVE.items()
+        })],
+        sha256 = select({
+            "prelude//os:{}".format(os): select({
+                "prelude//cpu:{}".format(cpu): archive.sha256
+                for cpu, archive in value.items()
+            })
+            for os, value in CPYTHON_ARCHIVE.items()
+        }),
+        strip_prefix = "python",
+        sub_targets = {
+            "include": [
+                select({"DEFAULT": "include/python3.13", "prelude//os:windows": "include"}),
+            ],
+            "lib": [select({"DEFAULT": "lib", "prelude//os:windows": "libs"})],
+            "python": [
+                select({"DEFAULT": "bin/python", "prelude//os:windows": "python.exe"}),
+            ],
+        },
+    )
+    native.command_alias(
+        name = "cpython",
+        exe = ":cpython_archive[python]",
+        visibility = visibility,
+        resources = [":cpython_archive"],
+    )
+    native.genrule(
+        name = "libpython_symbols",
+        out = "linker_args",
+        # TODO: is this necessary on Windows?
+        cmd = '$(exe_target prelude//python/tools:gather_libpython_symbols) "$OUT"',
+    )
+
+    _remote_python_toolchain(
+        name = name,
+        visibility = visibility,
+        interpreter = ":cpython",
+        extension_linker_flags = select({
+            "DEFAULT": ["-L$(location :cpython_archive[lib])", "@$(location :libpython_symbols)"],
+            "prelude//os:windows": ["/LIBPATH:$(location :cpython_archive[lib])"],
+        }),
+        **kwargs
+    )

--- a/prelude/toolchains/python.bzl
+++ b/prelude/toolchains/python.bzl
@@ -105,44 +105,43 @@ _remote_python_toolchain = rule(
     doc = "A python toolchain that uses a pre-built CPython installation, downloaded from the [python-build-standalone project](https://github.com/astral-sh/python-build-standalone)",
 )
 
-_Archive = record(url = str, sha256 = str)
-
 # archives for 3.13
 # update this by running `prelude//python/tools:discover_python_archives.sh`
 CPYTHON_ARCHIVE = {
     "linux": {
-        "arm64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz", sha256 = "829d615905b5ae8c50353f2ceb3d6665793442d4cbc64503bc9b27b5b9f6fb8a"),
-        "x86_64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz", sha256 = "e3e280d4b1ead63de6ebc9816de71792fc8c71b7a6a999ea82f937047beba037"),
+        "arm64": {"sha256": "829d615905b5ae8c50353f2ceb3d6665793442d4cbc64503bc9b27b5b9f6fb8a", "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"},
+        "x86_64": {"sha256": "e3e280d4b1ead63de6ebc9816de71792fc8c71b7a6a999ea82f937047beba037", "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"},
     },
     "macos": {
-        "arm64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-apple-darwin-install_only_stripped.tar.gz", sha256 = "c57e48145722a87e34a50a2c31d6b11f0830e62e26d759c11b6606a6a80e6243"),
-        "x86_64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-apple-darwin-install_only_stripped.tar.gz", sha256 = "7caed8ea779dcc5d091955628455823cb0e91587703d8b6f7dd285fb2b44d1e0"),
+        "arm64": {"sha256": "c57e48145722a87e34a50a2c31d6b11f0830e62e26d759c11b6606a6a80e6243", "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-apple-darwin-install_only_stripped.tar.gz"},
+        "x86_64": {"sha256": "7caed8ea779dcc5d091955628455823cb0e91587703d8b6f7dd285fb2b44d1e0", "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-apple-darwin-install_only_stripped.tar.gz"},
     },
     "windows": {
-        "arm64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-pc-windows-msvc-install_only_stripped.tar.gz", sha256 = "a24c09048d1c20ed01e58e7e59a5e43b79cb7a9f36c067fc24e17649e4301d54"),
-        "x86_64": _Archive(url = "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-pc-windows-msvc-install_only_stripped.tar.gz", sha256 = "0de6eb2cb66211967874b0fb47cfc0299102e8a805f5319e108121e314083066"),
+        "arm64": {"sha256": "a24c09048d1c20ed01e58e7e59a5e43b79cb7a9f36c067fc24e17649e4301d54", "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-aarch64-pc-windows-msvc-install_only_stripped.tar.gz"},
+        "x86_64": {"sha256": "0de6eb2cb66211967874b0fb47cfc0299102e8a805f5319e108121e314083066", "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20250807/cpython-3.13.6+20250807-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"},
     },
 }
 
 def remote_python_toolchain(
         name: str,
         visibility: list[str],
+        cpython_urls: dict[str, dict[str, dict[str, str]]] = CPYTHON_ARCHIVE,
         **kwargs) -> None:
     native.http_archive(
         name = "cpython_archive",
         urls = [select({
             "prelude//os:{}".format(os): select({
-                "prelude//cpu:{}".format(cpu): archive.url
+                "prelude//cpu:{}".format(cpu): archive["url"]
                 for cpu, archive in value.items()
             })
-            for os, value in CPYTHON_ARCHIVE.items()
+            for os, value in cpython_urls.items()
         })],
         sha256 = select({
             "prelude//os:{}".format(os): select({
-                "prelude//cpu:{}".format(cpu): archive.sha256
+                "prelude//cpu:{}".format(cpu): archive["sha256"]
                 for cpu, archive in value.items()
             })
-            for os, value in CPYTHON_ARCHIVE.items()
+            for os, value in cpython_urls.items()
         }),
         strip_prefix = "python",
         sub_targets = {


### PR DESCRIPTION
Summary:
This should give us some flexibility to use custom python versions with `remote_python_toolchain` without having to change prelude.
See the diff on top of this for an example.

Differential Revision: D79885048


