### PR TITLE
fix certificate errors caused by tonic upgrade

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -143,7 +143,7 @@ fn ttimestamp_from(ts: Option<::prost_types::Timestamp>) -> TTimestamp {
 }
 
 async fn create_tls_config(opts: &Buck2OssReConfiguration) -> anyhow::Result<ClientTlsConfig> {
-    let config = ClientTlsConfig::new();
+    let config = ClientTlsConfig::new().with_enabled_roots();
 
     let config = match opts.tls_ca_certs.as_ref() {
         Some(tls_ca_certs) => {


### PR DESCRIPTION
tonic was upgraded from 0.10 to 0.12 and it broke webpki roots in the RE client.  In tonic 0.12 an additional method needs to be called to add webpki roots to your TLS config.