### PR TITLE
vsgo: Emit toolchain compiler settings into generated vcxprojs.

### DIFF
--- a/prelude/ide_integrations/visual_studio/gen_filters.bxl
+++ b/prelude/ide_integrations/visual_studio/gen_filters.bxl
@@ -6,7 +6,7 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
-load("get_attrs.bxl", "get_attrs")
+load("get_attrs.bxl", "get_attrs", "get_cxx_toolchain")
 load("get_vs_settings.bxl", "get_vs_settings")
 load("utils.bxl", "dedupe_by_value", "dirname", "get_project_file_path", "h")
 
@@ -124,12 +124,13 @@ def _main(bxl_ctx):
     target_node = bxl_ctx.configured_targets(target_label)
     actions = bxl_ctx.bxl_actions().actions
     attrs = get_attrs(target_node, bxl_ctx)
+    toolchain = get_cxx_toolchain(target_node, bxl_ctx)
     attrs_outfile = actions.write_json(get_project_file_path(target_node.label, ".json"), attrs)
     filters_artifact = actions.declare_output(get_project_file_path(target_node.label, ".vcxproj.filters"))
 
     def f(ctx, artifacts, outputs, attrs_outfile = attrs_outfile, filters_artifact = filters_artifact, target = target_node, cli_args = bxl_ctx.cli_args, buck_root = bxl_ctx.root()):
         attrs_input = artifacts[attrs_outfile].read_json()
-        vs_settings = get_vs_settings(target, attrs_input, {}, cli_args, buck_root, ctx)
+        vs_settings = get_vs_settings(target, toolchain, attrs_input, {}, cli_args, buck_root, ctx)
         content = gen_filters(vs_settings)
         ctx.bxl_actions().actions.write(outputs[filters_artifact].as_output(), content, allow_args = True)
 

--- a/prelude/ide_integrations/visual_studio/gen_vcxproj.bxl
+++ b/prelude/ide_integrations/visual_studio/gen_vcxproj.bxl
@@ -158,7 +158,6 @@ def _main(bxl_ctx):
     dynamic = [attrs_outfile]
 
     cxx_toolchain_target = get_cxx_toolchain(target_node, bxl_ctx)
-    cxx_toolchain_info = None
     toolchain_settings_file_out = None
 
     if cxx_toolchain_target:

--- a/prelude/ide_integrations/visual_studio/gen_vcxproj.bxl
+++ b/prelude/ide_integrations/visual_studio/gen_vcxproj.bxl
@@ -6,13 +6,14 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
+load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
 load("constants.bxl", "BY_MODES")
 load("gen_user_macros.bxl", "gen_user_macros")
-load("get_attrs.bxl", "get_attrs")
-load("get_compiler_settings.bxl", "gen_compiler_settings")
+load("get_attrs.bxl", "get_attrs", "get_cxx_toolchain")
+load("get_compiler_settings.bxl", "gen_compiler_settings", "materialize_compiler_settings_file")
 load("get_linker_settings.bxl", "gen_linker_settings")
 load("get_vs_settings.bxl", "get_vs_settings")
-load("utils.bxl", "get_mode_config_path", "get_project_file_path", "get_root_path_relative_to", "get_vs_configuration", "h", "log_debug")
+load("utils.bxl", "get_mode_config_path", "get_project_file_path", "get_root_path_relative_to", "get_vs_configuration", "h", "log_debug", "merge")
 
 def _gen_project_configurations(project_configurations):
     return h("ItemGroup", [
@@ -154,14 +155,38 @@ def _main(bxl_ctx):
     attrs_outfile = actions.write_json(get_project_file_path(target_node.label, ".json"), attrs)
     vcxproj_artifact = actions.declare_output(get_project_file_path(target_node.label, ".vcxproj"))
 
-    def f(ctx, artifacts, outputs, attrs_outfile = attrs_outfile, vcxproj_artifact = vcxproj_artifact, target = target_node, cli_args = bxl_ctx.cli_args, buck_root = bxl_ctx.root()):
+    dynamic = [attrs_outfile]
+
+    cxx_toolchain_target = get_cxx_toolchain(target_node, bxl_ctx)
+    cxx_toolchain_info = None
+    toolchain_settings_file_out = None
+
+    if cxx_toolchain_target:
+        label = cxx_toolchain_target.label.configured_target()
+        cxx_toolchain_target_node = bxl_ctx.configured_targets(label)
+        cxx_toolchain_analysis_result = bxl_ctx.analysis(cxx_toolchain_target_node)
+        cxx_toolchain_info = cxx_toolchain_analysis_result.providers().get(CxxToolchainInfo)
+
+        toolchain_settings_file_out = materialize_compiler_settings_file(cxx_toolchain_target_node, actions, cxx_toolchain_info, bxl_ctx)
+        dynamic.append(toolchain_settings_file_out)
+
+    def f(ctx, artifacts, outputs, attrs_outfile = attrs_outfile, cxx = toolchain_settings_file_out, vcxproj_artifact = vcxproj_artifact, target = target_node, cli_args = bxl_ctx.cli_args, buck_root = bxl_ctx.root()):
         attrs_input = artifacts[attrs_outfile].read_json()
-        vs_settings = get_vs_settings(target, attrs_input, {}, cli_args, buck_root, ctx)
+
+        vs_settings = get_vs_settings(target, cxx_toolchain_target, attrs_input, {}, cli_args, buck_root, ctx)
+        if cxx:
+            cxx_input = artifacts[cxx].read_json()
+            aggregated_compiler_settings = merge(
+                vs_settings["CompilerSettings"],
+                cxx_input["exported_compiler_settings"]
+            )
+            vs_settings["CompilerSettings"] = aggregated_compiler_settings
+
         vcxproj_content = gen_vcxproj(target, vs_settings, cli_args, buck_root)
         ctx.bxl_actions().actions.write(outputs[vcxproj_artifact].as_output(), vcxproj_content, allow_args = True)
 
     actions.dynamic_output(
-        dynamic = [attrs_outfile],
+        dynamic = dynamic,
         inputs = [],
         outputs = [
             vcxproj_artifact.as_output(),

--- a/prelude/ide_integrations/visual_studio/get_attrs.bxl
+++ b/prelude/ide_integrations/visual_studio/get_attrs.bxl
@@ -70,6 +70,10 @@ def get_unified_value(attrs, common_key: str, platform_key: str, toolchain = "wi
                 all_flags.extend(flags)
     return all_flags
 
+def get_cxx_toolchain(target: bxl.ConfiguredTargetNode, bxl_ctx) -> Dependency|None:
+    attrs = target.resolved_attrs_lazy(bxl_ctx)
+    return attrs.get("_cxx_toolchain")
+
 # TODO: Implement actual toolchain names
 def _platform_regex_match(plat, toolchain = "windows") -> bool:
     """Return if given platform entry matches specified toolchain"""

--- a/prelude/ide_integrations/visual_studio/get_compiler_settings.bxl
+++ b/prelude/ide_integrations/visual_studio/get_compiler_settings.bxl
@@ -115,7 +115,7 @@ def materialize_compiler_settings_file(target_node, actions, cxx_toolchain_info,
 
     cxxflags_artifact = None
     if cxx_toolchain_info:
-        cxxflags_artifact, _ = actions.write("cxxflags", cxx_toolchain_info.cxx_compiler_info.compiler_flags, allow_args = True)
+        cxxflags_artifact, _ = actions.write(get_project_file_path(target_node.label, ".cxxflags"), cxx_toolchain_info.cxx_compiler_info.compiler_flags, allow_args = True)
 
     attrs_outfile = actions.write_json(get_project_file_path(target_node.label, ".attrs.json"), attrs, pretty = True)
     out = actions.declare_output(get_project_file_path(target_node.label, ".compiler_settings.json"))

--- a/prelude/ide_integrations/visual_studio/get_compiler_settings.bxl
+++ b/prelude/ide_integrations/visual_studio/get_compiler_settings.bxl
@@ -114,9 +114,8 @@ def materialize_compiler_settings_file(target_node, actions, cxx_toolchain_info,
     attrs = get_attrs(target_node, bxl_ctx)
 
     cxxflags_artifact = None
-    cxxflags_macro_artifacts = None
     if cxx_toolchain_info:
-        cxxflags_artifact, cxxflags_macro_artifacts = actions.write("cxxflags", cxx_toolchain_info.cxx_compiler_info.compiler_flags, allow_args = True)
+        cxxflags_artifact, _ = actions.write("cxxflags", cxx_toolchain_info.cxx_compiler_info.compiler_flags, allow_args = True)
 
     attrs_outfile = actions.write_json(get_project_file_path(target_node.label, ".attrs.json"), attrs, pretty = True)
     out = actions.declare_output(get_project_file_path(target_node.label, ".compiler_settings.json"))

--- a/prelude/ide_integrations/visual_studio/get_compiler_settings.bxl
+++ b/prelude/ide_integrations/visual_studio/get_compiler_settings.bxl
@@ -6,6 +6,7 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
+load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
 load("flags_parser_utils.bxl", "flatten_flag_lists", "get_compiler_settings_from_flags")
 load("get_attrs.bxl", "get_attrs")
 load("utils.bxl", "basename", "dedupe_by_value", "dirname", "escape_xml", "get_argsfiles_output_path", "get_project_file_path", "h", "normcase", "normpath")
@@ -109,28 +110,54 @@ def gen_compiler_settings(compiler_settings: dict):
         indent_level = 2,
     )
 
-def _main(bxl_ctx):
-    target = bxl_ctx.cli_args.target
-    target_node = bxl_ctx.configured_targets(target)
-    actions = bxl_ctx.bxl_actions().actions
+def materialize_compiler_settings_file(target_node, actions, cxx_toolchain_info, bxl_ctx):
     attrs = get_attrs(target_node, bxl_ctx)
+
+    cxxflags_artifact = None
+    cxxflags_macro_artifacts = None
+    if cxx_toolchain_info:
+        cxxflags_artifact, cxxflags_macro_artifacts = actions.write("cxxflags", cxx_toolchain_info.cxx_compiler_info.compiler_flags, allow_args = True)
+
     attrs_outfile = actions.write_json(get_project_file_path(target_node.label, ".attrs.json"), attrs, pretty = True)
     out = actions.declare_output(get_project_file_path(target_node.label, ".compiler_settings.json"))
 
     def f(ctx, artifacts, outputs, attrs_outfile = attrs_outfile, out = out, target = target_node):
         attrs_input = artifacts[attrs_outfile].read_json()
         settings = {}
-        settings["compiler_settings"] = get_compiler_settings(target, attrs_input)
-        settings["exported_compiler_settings"] = get_exported_compiler_settings(target, attrs_input, ctx)
+
+        if cxx_toolchain_info:
+            cxxflags = artifacts[cxxflags_artifact].read_string().splitlines()
+            exported_compiler_settings = get_compiler_settings_from_flags(cxxflags)
+        else:
+            exported_compiler_settings = get_exported_compiler_settings(target, attrs_input, ctx)
+
+        settings["compiler_settings"] = get_compiler_settings(target_node, attrs_input)
+        settings["exported_compiler_settings"] = exported_compiler_settings
 
         ctx.bxl_actions().actions.write_json(outputs[out].as_output(), settings, pretty = True)
 
+    dynamic = [attrs_outfile]
+    if cxxflags_artifact:
+        dynamic.append(cxxflags_artifact)
+
     actions.dynamic_output(
-        dynamic = [attrs_outfile],
+        dynamic = dynamic,
         inputs = [],
         outputs = [out.as_output()],
         f = f,
     )
+
+    return out
+
+def _main(bxl_ctx):
+    target = bxl_ctx.cli_args.target
+    target_node = bxl_ctx.configured_targets(target)
+    actions = bxl_ctx.bxl_actions().actions
+
+    cxx_toolchain_analysis_result = bxl_ctx.analysis(target_node)
+    cxx_toolchain_info = cxx_toolchain_analysis_result.providers().get(CxxToolchainInfo)
+
+    out = materialize_compiler_settings_file(target_node, actions, cxx_toolchain_info, bxl_ctx)
     bxl_ctx.output.print(bxl_ctx.output.ensure(out))
 
 main = bxl_main(

--- a/prelude/ide_integrations/visual_studio/get_vs_settings.bxl
+++ b/prelude/ide_integrations/visual_studio/get_vs_settings.bxl
@@ -147,10 +147,9 @@ def get_basic_vs_settings(target: bxl.ConfiguredTargetNode, cli_args):
 
     return basic_vs_settings
 
-def get_vs_settings_for_toolchain(target: bxl.ConfiguredTargetNode, compiler_settings: dict, vs_settings_dict: dict, cli_args, buck_root, bxl_ctx):
+def get_vs_settings_for_toolchain(target: bxl.ConfiguredTargetNode, compiler_settings: dict, cli_args):
     log_debug("# Getting VS settings for toolchain {}", target.label.raw_target(), log_level = cli_args.log_level)
-    mode_files = cli_args.mode_files
-
+    
     vs_settings = get_basic_vs_settings(target, cli_args)
 
     vs_settings["Headers"] = []

--- a/prelude/ide_integrations/visual_studio/get_vs_settings.bxl
+++ b/prelude/ide_integrations/visual_studio/get_vs_settings.bxl
@@ -7,7 +7,7 @@
 # above-listed licenses.
 
 load("constants.bxl", "ADDITIONAL_TARGETS", "BY_MODES", "DEBUG_ARGS", "DEBUG_CMD", "DEBUG_ENV", "DEBUG_PWD", "EXTRA_BUCK_OPTIONS", "IMMEDIATE_BUCK_OPTIONS")
-load("get_attrs.bxl", "get_attrs", "get_unified_value")
+load("get_attrs.bxl", "get_attrs", "get_unified_value", "get_cxx_toolchain")
 load("get_compiler_settings.bxl", "get_compiler_settings", "get_exported_compiler_settings")
 load("get_linker_settings.bxl", "get_exported_linker_settings", "get_linker_settings")
 load("utils.bxl", "dedupe_by_value", "dirname", "flatten_lists", "gen_guid", "get_output_path", "get_project_file_path", "get_vs_configuration", "infer_settings_by_modes", "log_debug", "log_warn", "merge", "suffix")
@@ -147,7 +147,27 @@ def get_basic_vs_settings(target: bxl.ConfiguredTargetNode, cli_args):
 
     return basic_vs_settings
 
-def get_vs_settings(target: bxl.ConfiguredTargetNode, attrs: dict, vs_settings_dict: dict, cli_args, buck_root, bxl_ctx):
+def get_vs_settings_for_toolchain(target: bxl.ConfiguredTargetNode, compiler_settings: dict, vs_settings_dict: dict, cli_args, buck_root, bxl_ctx):
+    log_debug("# Getting VS settings for toolchain {}", target.label.raw_target(), log_level = cli_args.log_level)
+    mode_files = cli_args.mode_files
+
+    vs_settings = get_basic_vs_settings(target, cli_args)
+
+    vs_settings["Headers"] = []
+    vs_settings["Sources"] = {}
+
+    vs_settings["ProjectConfigurations"] = []
+
+    vs_settings["CompilerSettings"] = {}
+    vs_settings["ExportedCompilerSettings"] = compiler_settings["exported_compiler_settings"]
+
+    vs_settings["LinkerSettings"] = {}
+    vs_settings["ExportedLinkerSettings"] = {}
+
+    return vs_settings
+
+
+def get_vs_settings(target: bxl.ConfiguredTargetNode, toolchain, attrs: dict, vs_settings_dict: dict, cli_args, buck_root, bxl_ctx):
     log_debug("# Getting VS settings for {}", target.label.raw_target(), log_level = cli_args.log_level)
     mode_files = cli_args.mode_files
 
@@ -208,6 +228,11 @@ def get_vs_settings(target: bxl.ConfiguredTargetNode, attrs: dict, vs_settings_d
             aggregated_private_linker_settings,
             vs_settings_dict.get(dep, {}).get("ExportedLinkerSettings", {}),
         )
+
+    if toolchain:
+        toolchain_compiler_settings = vs_settings_dict.get(toolchain.label, {}).get("ExportedCompilerSettings", {})
+        aggregated_private_compiler_settings = merge(aggregated_private_compiler_settings, toolchain_compiler_settings)
+
     vs_settings["CompilerSettings"] = merge(
         aggregated_private_compiler_settings,
         get_compiler_settings(target, attrs),
@@ -231,12 +256,13 @@ def _main(bxl_ctx):
     actions = bxl_ctx.bxl_actions().actions
 
     attrs = get_attrs(target_node, bxl_ctx)
+    toolchain = get_cxx_toolchain(target_node, bxl_ctx)
     attrs_artifact = actions.write_json(get_project_file_path(target_node.label, ".attrs.json"), attrs, pretty = True)
     vs_settings_artifact = actions.declare_output(get_project_file_path(target_node.label, ".vs_settings.json"))
 
     def f(ctx, artifacts, outputs, cli_args = bxl_ctx.cli_args, root = bxl_ctx.root()):
         attrs = artifacts[attrs_artifact].read_json()
-        vs_settings = get_vs_settings(target_node, attrs, {}, cli_args, root, ctx)
+        vs_settings = get_vs_settings(target_node, toolchain, attrs, {}, cli_args, root, ctx)
         ctx.bxl_actions().actions.write_json(outputs[vs_settings_artifact].as_output(), vs_settings, pretty = True)
 
     actions.dynamic_output(

--- a/prelude/ide_integrations/visual_studio/main.bxl
+++ b/prelude/ide_integrations/visual_studio/main.bxl
@@ -143,7 +143,6 @@ def _main(bxl_ctx):
                 attrs_artifact_dict[cxx_toolchain_label] = settings_file_artifact
  
                 toolchain_dep_dict[cxx_toolchain_label] = (cxx_toolchain, cxx_toolchain_target_node)
-                cxx_toolchain_target_node_label = cxx_toolchain_target_node.label
 
         attrs_outfile = actions.write_json(get_project_file_path(dep.label, ".attrs.json"), attrs, pretty = True) 
         attrs_artifact_dict[dep.label] = attrs_outfile
@@ -180,16 +179,14 @@ def _main(bxl_ctx):
             for dep in deps
         }
 
-        for dep, node in toolchain_deps:
-            label = dep.label
+        for dep, _ in toolchain_deps:
             content = artifacts[attrs_artifact_dict[dep.label]].read_json()
             attrs_content_dict[dep.label] = content
 
         vs_settings_dict = {}  # target label => vs_settings.
         for dep, node in toolchain_deps:
-            td_label = dep.label
             attrs = attrs_content_dict[dep.label]
-            vs_settings = get_vs_settings_for_toolchain(node, attrs, vs_settings_dict, cli_args, buck_root, ctx)
+            vs_settings = get_vs_settings_for_toolchain(node, attrs, cli_args)
             vs_settings_dict[dep.label] = vs_settings
             
         for dep in deps:

--- a/prelude/ide_integrations/visual_studio/main.bxl
+++ b/prelude/ide_integrations/visual_studio/main.bxl
@@ -6,13 +6,16 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
+load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+
 load("gen_filters.bxl", "gen_filters")
 load("gen_sln.bxl", "gen_sln")
 load("gen_vcxproj.bxl", "gen_vcxproj")
-load("get_attrs.bxl", "get_attrs")
+load("get_attrs.bxl", "get_attrs", "get_cxx_toolchain")
 load("get_deps.bxl", "get_deps")
-load("get_vs_settings.bxl", "get_basic_vs_settings", "get_vs_settings")
+load("get_vs_settings.bxl", "get_basic_vs_settings", "get_vs_settings", "get_vs_settings_for_toolchain")
 load("utils.bxl", "basename", "get_project_file_path", "log_debug")
+load("get_compiler_settings.bxl", "materialize_compiler_settings_file")
 
 def _match_recursive_target_types(target: bxl.ConfiguredTargetNode, recursive_target_types: list[str], bxl_ctx) -> bool:
     for type_regex in recursive_target_types:
@@ -116,11 +119,33 @@ def _main(bxl_ctx):
     attrs_artifact_dict = {}  # target label => attrs artifact
     vcxproj_artifact_dict = {}  # target label => vcxproj artifact
     filters_artifact_dict = {}  # target label => filters artifact
+    toolchain_dep_dict = {}
     for dep in deps:
         # Write the attrs to a json file so that all macros get resolved
         attrs = get_attrs(dep, bxl_ctx)
 
-        attrs_outfile = actions.write_json(get_project_file_path(dep.label, ".attrs.json"), attrs, pretty = True)
+        # Populate the compiler settings file for this target's cxx toolchain attribute.  Normally this is just toolchains//:cxx, and we need its settings file
+        # in order to parse the flags that were specified directly to its CxxCompilerInfo provider and get include directories and defines at the toolchain
+        # level.  However, it's not enough to simply parse `toolchains//:cxx`, because this can be overridden via a number of different methods (for example,
+        # via `cxx_toolchain_override` or by passing the `_cxx_toolchain` attribute to the cxx_library rule invocation).
+        cxx_toolchain = get_cxx_toolchain(dep, bxl_ctx)
+        # The target may not be a cxx library or related rule, in which case there will be no cxx toolchain.
+        if cxx_toolchain:
+            cxx_toolchain_label = cxx_toolchain.label
+            cxx_toolchain_artifact = attrs_artifact_dict.get(cxx_toolchain_label, None)
+            # Do this lazily.  Many targets can reference the same toolchain, but don't bother trying to run analysis or create the entry for the toolchain
+            # more than once.
+            if not cxx_toolchain_artifact:
+                cxx_toolchain_target_label = cxx_toolchain.label.configured_target()
+                cxx_toolchain_target_node = bxl_ctx.configured_targets(cxx_toolchain_target_label)
+                cxx_toolchain_info = bxl_ctx.analysis(cxx_toolchain_target_node).providers().get(CxxToolchainInfo)
+                settings_file_artifact = materialize_compiler_settings_file(cxx_toolchain_target_node, actions, cxx_toolchain_info, bxl_ctx)
+                attrs_artifact_dict[cxx_toolchain_label] = settings_file_artifact
+ 
+                toolchain_dep_dict[cxx_toolchain_label] = (cxx_toolchain, cxx_toolchain_target_node)
+                cxx_toolchain_target_node_label = cxx_toolchain_target_node.label
+
+        attrs_outfile = actions.write_json(get_project_file_path(dep.label, ".attrs.json"), attrs, pretty = True) 
         attrs_artifact_dict[dep.label] = attrs_outfile
 
         # Create the output artifacts. Contents will be written into these in the lambda function
@@ -134,6 +159,8 @@ def _main(bxl_ctx):
         # This is just for generating sln file since vs_settings_list is not available inside the lambda function
         # Sln file doesn't need any attr that involves macro so we're good here
         basic_vs_settings_list.append(get_basic_vs_settings(dep, bxl_ctx.cli_args))
+
+    toolchain_deps = toolchain_dep_dict.values()
 
     # This lambda function gets executed after attrs are written into the json files and then loads them back to get resolved macro values.
     # Params:
@@ -153,10 +180,22 @@ def _main(bxl_ctx):
             for dep in deps
         }
 
+        for dep, node in toolchain_deps:
+            label = dep.label
+            content = artifacts[attrs_artifact_dict[dep.label]].read_json()
+            attrs_content_dict[dep.label] = content
+
         vs_settings_dict = {}  # target label => vs_settings.
+        for dep, node in toolchain_deps:
+            td_label = dep.label
+            attrs = attrs_content_dict[dep.label]
+            vs_settings = get_vs_settings_for_toolchain(node, attrs, vs_settings_dict, cli_args, buck_root, ctx)
+            vs_settings_dict[dep.label] = vs_settings
+            
         for dep in deps:
             attrs = attrs_content_dict[dep.label]
-            vs_settings = get_vs_settings(dep, attrs, vs_settings_dict, cli_args, buck_root, ctx)
+            toolchain = get_cxx_toolchain(dep, ctx)
+            vs_settings = get_vs_settings(dep, toolchain, attrs, vs_settings_dict, cli_args, buck_root, ctx)
             vs_settings_dict[dep.label] = vs_settings
 
             if dep.label.raw_target() in deps_with_vcxproj:


### PR DESCRIPTION
Previously, if you set compiler flags and/or preprocessor definitions in your toolchain (e.g. via `CxxCompilerInfo`) these would not make it into the generated vcxproj's, leading to IntelliSense squigglies for system headers and certain other cases.   

Making this work is not trivial because the way that vsgo currently operates is by inspecting attributes of rules, which doesn't work in this case because the values we need are all stuffed away into `cmd_args` inside of a provider.  To solve this, for toolchains we have to run analysis on the toolchain target  to get the `CxxCompilerInfo`, then run a dynamic action that will resolve the `cmd_args` into actual paths and flags, and materialize a file with these values.  Then read these back later in the continuation to parse them out.

Incidentally, a similar strategy would also work to solve a current limitation of vsgo that the file extension is hardcoded to `.o`, even though you can change this in your toolchain (and a more natural extension in windows is `.obj`).  This was discussed in #868 but we did not arrive at a solution at the time.  Now, we could simply write out the extension from the provider to the same settings file and read it back later.  That isn't handled in this PR, but it's a nice consequence of this PR that the groundwork is laid for more advanced functionality such as the aforementioned in the future.