### PR TITLE
python_bootstrap: fix types

### DIFF
--- a/prelude/python_bootstrap/python_bootstrap.bzl
+++ b/prelude/python_bootstrap/python_bootstrap.bzl
@@ -10,7 +10,7 @@ load("@prelude//utils:utils.bzl", "flatten")
 
 PythonBootstrapSources = provider(fields = {"srcs": provider_field(typing.Any, default = None)})
 
-PythonBootstrapToolchainInfo = provider(fields = {"interpreter": provider_field(typing.Any, default = None)})
+PythonBootstrapToolchainInfo = provider(fields = {"interpreter": provider_field(str | cmd_args)})
 
 def python_bootstrap_library_impl(ctx: AnalysisContext) -> list[Provider]:
     tree = {src.short_path: src for src in ctx.attrs.srcs}

--- a/prelude/toolchains/python.bzl
+++ b/prelude/toolchains/python.bzl
@@ -23,7 +23,7 @@ _INTERPRETER = select({
 })
 
 def _python_bootstrap_toolchain_impl(ctx):
-    interpreter = ctx.attrs.interpreter.args if isinstance(ctx.attrs.interpreter, RunInfo) else ctx.attrs.interpreter
+    interpreter = ctx.attrs.interpreter if isinstance(ctx.attrs.interpreter, str) else ctx.attrs.interpreter[RunInfo].args
     return [
         DefaultInfo(),
         PythonBootstrapToolchainInfo(interpreter = interpreter),


### PR DESCRIPTION
Summary: interpreter should be either a string or a cmd_args instance.

Differential Revision: D80257336


