### PR TITLE
feat: add grpc keepalive settings for rbe

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -439,6 +439,12 @@ pub struct Buck2OssReConfiguration {
     pub max_concurrent_uploads_per_action: Option<usize>,
     /// Time that digests are assumed to live in CAS after being touched.
     pub cas_ttl_secs: Option<i64>,
+    /// Interval in seconds for HTTP/2 ping frames to detect stale connections.
+    pub grpc_keepalive_time_secs: Option<u64>,
+    /// Timeout in seconds for receiving HTTP/2 ping acknowledgement.
+    pub grpc_keepalive_timeout_secs: Option<u64>,
+    /// Whether to send HTTP/2 pings when connection is idle.
+    pub grpc_keepalive_while_idle: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -543,6 +549,18 @@ impl Buck2OssReConfiguration {
             cas_ttl_secs: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "cas_ttl_secs",
+            })?,
+            grpc_keepalive_time_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_keepalive_time_secs",
+            })?,
+            grpc_keepalive_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_keepalive_timeout_secs",
+            })?,
+            grpc_keepalive_while_idle: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_keepalive_while_idle",
             })?,
         })
     }

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -274,6 +274,17 @@ impl REClientBuilder {
                 channel = channel.tls_config(tls_config.clone())?;
             }
 
+            // Configure gRPC keepalive settings
+            if let Some(keepalive_time_secs) = opts.grpc_keepalive_time_secs {
+                channel = channel.http2_keep_alive_interval(Duration::from_secs(keepalive_time_secs));
+            }
+            if let Some(keepalive_timeout_secs) = opts.grpc_keepalive_timeout_secs {
+                channel = channel.keep_alive_timeout(Duration::from_secs(keepalive_timeout_secs));
+            }
+            if let Some(keepalive_while_idle) = opts.grpc_keepalive_while_idle {
+                channel = channel.keep_alive_while_idle(keepalive_while_idle);
+            }
+
             anyhow::Ok(
                 channel
                     .connect()


### PR DESCRIPTION
This adds settings comparable to bazel's [--grpc_keepalive_time](https://bazel.build/reference/command-line-reference#common_options-flag--grpc_keepalive_time) and [--grpc_keepalive_timeout](https://bazel.build/reference/command-line-reference#common_options-flag--grpc_keepalive_timeout). This is useful for remote execution behind a load balancer with aggressive connection keepalive settings to prevent these types of errors:

```
Error: (Error was returned on the stream by RE: RE channel error: status: Internal, message: "h2 protocol error: error reading a body from connection", details: [], metadata: MetadataMap { headers: {} }: error reading a body from connection: stream error received: unexpected internal error encountered)
```