### PR TITLE
Add freebsd support in os_version()

### DIFF
--- a/app/buck2_events/src/metadata.rs
+++ b/app/buck2_events/src/metadata.rs
@@ -125,6 +125,8 @@ fn os_type() -> String {
         "darwin".to_owned()
     } else if cfg!(target_os = "windows") {
         "windows".to_owned()
+    } else if cfg!(target_os = "freebsd") {
+        "freebsd".to_owned()
     } else {
         "unknown".to_owned()
     }
@@ -135,7 +137,7 @@ fn os_version() -> Option<String> {
     winver::WindowsVersion::detect().map(|v| v.to_string())
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
 fn os_version() -> Option<String> {
     sys_info::os_release().ok()
 }

--- a/app/buck2_health_check/src/health_checks/vpn_check.rs
+++ b/app/buck2_health_check/src/health_checks/vpn_check.rs
@@ -100,7 +100,7 @@ impl VpnCheck {
         })
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "freebsd"))]
     fn cisco_iface_connected() -> buck2_error::Result<bool> {
         // Brittle check based on Cisco client's current behaviour.
         // Small section copied from https://fburl.com/code/g7ttsdz3


### PR DESCRIPTION
This fixes the build on FreeBSD. There are still 4 remaining failing tests at this commit:

```
error: 4 targets failed:
    `-p buck2_client --lib`
    `-p buck2_forkserver --lib`
    `-p buck2_server --lib`
    `-p buck2_util --lib`
```