### PR TITLE
Export `get_exported_preprocessor_args` function from `preprocessor.bzl` so it can be reused.

### DIFF
--- a/prelude/cxx/preprocessor.bzl
+++ b/prelude/cxx/preprocessor.bzl
@@ -273,7 +273,7 @@ def cxx_exported_preprocessor_info(ctx: AnalysisContext, headers_layout: CxxHead
         include_dirs.extend([ctx.label.path.add(x) for x in ctx.attrs.public_include_directories])
         system_include_dirs.extend([ctx.label.path.add(x) for x in ctx.attrs.public_system_include_directories])
 
-    args = _get_exported_preprocessor_args(ctx, exported_header_map, style, compiler_type, raw_headers, extra_preprocessors)
+    args = get_exported_preprocessor_args(ctx, exported_header_map, style, compiler_type, raw_headers, extra_preprocessors)
 
     modular_args = []
     for pre in extra_preprocessors:
@@ -293,7 +293,7 @@ def cxx_exported_preprocessor_info(ctx: AnalysisContext, headers_layout: CxxHead
         header_units = header_units,
     )
 
-def _get_exported_preprocessor_args(ctx: AnalysisContext, headers: dict[str, Artifact], style: HeaderStyle, compiler_type: str, raw_headers: list[Artifact], extra_preprocessors: list[CPreprocessor]) -> CPreprocessorArgs:
+def get_exported_preprocessor_args(ctx: AnalysisContext, headers: dict[str, Artifact], style: HeaderStyle, compiler_type: str, raw_headers: list[Artifact], extra_preprocessors: list[CPreprocessor]) -> CPreprocessorArgs:
     header_root = prepare_headers(
         ctx,
         headers,


### PR DESCRIPTION
Internally, we have a rule that generates cxx headers from some internal idl-style language.  Right now we do some hackery to make a `cxx_library` that passes `exported_preprocessor_flags=["-I$(location :gen-target)"]` but this requires some hoops to jump through, and we'd like to simply return a `CPreprocessorInfo` so that cxx_library targets can simply take a dep.  We have this working internally but it requires calling this function, which is prefixed with an `_` so cannot be imported.  Just make this function public.