### PR TITLE
Disable cell-segmentation of import paths with buckconfig

### DIFF
--- a/app/buck2_bxl/src/bxl/starlark_defs/eval_extra.rs
+++ b/app/buck2_bxl/src/bxl/starlark_defs/eval_extra.rs
@@ -11,7 +11,12 @@
 use std::io::Write;
 use std::sync::Arc;
 
+use buck2_common::legacy_configs::dice::HasLegacyConfigs;
+use buck2_common::legacy_configs::key::BuckconfigKeyRef;
 use buck2_events::dispatch::console_message;
+use buck2_interpreter::bxl_read_config::BXL_READ_CONFIG;
+use buck2_interpreter::bxl_read_config::BxlConfigValue;
+use futures::FutureExt;
 use starlark::eval::Evaluator;
 use starlark::values::ProvidesStaticType;
 
@@ -83,6 +88,43 @@ impl<'d> BxlEvalExtra<'d> {
         }
         .ok_or_else(|| BxlScopeError::UnavailableOutsideBxl.into())
     }
+}
+
+/// Implementation of [`BXL_READ_CONFIG`]: read a buckconfig value from the cell
+/// that owns the `.bxl`.
+fn bxl_read_config(
+    eval: &mut Evaluator,
+    section: &str,
+    key: &str,
+) -> buck2_error::Result<BxlConfigValue> {
+    let extra = match BxlEvalExtra::from_context(eval) {
+        Ok(extra) => extra,
+        // Not a BXL evaluation; let the caller fall through to its own handling.
+        Err(_) => return Ok(BxlConfigValue::NotBxl),
+    };
+
+    let cell = extra.core.cell_name();
+    let section = section.to_owned();
+    let key = key.to_owned();
+    let value = extra.dice.via(move |dice| {
+        async move {
+            dice.get_legacy_config_property(
+                cell,
+                BuckconfigKeyRef {
+                    section: &section,
+                    property: &key,
+                },
+            )
+            .await
+        }
+        .boxed_local()
+    })?;
+
+    Ok(BxlConfigValue::Bxl(value))
+}
+
+pub(crate) fn init_bxl_read_config() {
+    BXL_READ_CONFIG.init(bxl_read_config);
 }
 
 impl<'e> ErrorPrinter for BxlEvalExtra<'e> {

--- a/app/buck2_bxl/src/lib.rs
+++ b/app/buck2_bxl/src/lib.rs
@@ -28,6 +28,7 @@ pub fn init_late_bindings() {
         bxl::calculation::init_bxl_calculation_impl();
         commands::init_bxl_server_commands();
         bxl::starlark_defs::context::anon_target::init_eval_bxl_for_anon_target();
+        bxl::starlark_defs::eval_extra::init_bxl_read_config();
     });
 }
 

--- a/app/buck2_cmd_audit_server/src/starlark/module.rs
+++ b/app/buck2_cmd_audit_server/src/starlark/module.rs
@@ -15,6 +15,7 @@ use buck2_cmd_audit_client::starlark::module::StarlarkModuleCommand;
 use buck2_common::dice::cells::HasCellResolver;
 use buck2_core::cells::build_file_cell::BuildFileCell;
 use buck2_core::cells::cell_path_with_allowed_relative_dir::CellPathWithAllowedRelativeDir;
+use buck2_interpreter::import_paths::HasImportPaths;
 use buck2_interpreter::load_module::InterpreterCalculation;
 use buck2_interpreter::parse_import::ParseImportOptions;
 use buck2_interpreter::parse_import::RelativeImports;
@@ -40,6 +41,7 @@ pub(crate) async fn server_execute(
                 .ctx()
                 .get_cell_alias_resolver(current_cell_path.cell())
                 .await?;
+            let cell_segmentation = dice_ctx.get_cell_segmentation().await?;
 
             let import_path = parse_bzl_path_with_config(
                 &cell_alias_resolver,
@@ -55,6 +57,7 @@ pub(crate) async fn server_execute(
                     allow_missing_at_symbol: true,
                 },
                 current_cell,
+                cell_segmentation,
             )?;
 
             let loaded_module = dice_ctx

--- a/app/buck2_cmd_docs_server/src/starlark_.rs
+++ b/app/buck2_cmd_docs_server/src/starlark_.rs
@@ -7,7 +7,6 @@
  * of this source tree. You may select, at your option, one of the
  * above-listed licenses.
  */
-
 use std::path::PathBuf;
 
 use buck2_cli_proto::new_generic::DocsOutputFormat;
@@ -22,6 +21,7 @@ use buck2_core::cells::cell_path::CellPath;
 use buck2_core::cells::cell_path_with_allowed_relative_dir::CellPathWithAllowedRelativeDir;
 use buck2_core::cells::name::CellName;
 use buck2_hash::StdBuckHashSet;
+use buck2_interpreter::import_paths::HasImportPaths;
 use buck2_interpreter::load_module::InterpreterCalculation;
 use buck2_interpreter::parse_import::ParseImportOptions;
 use buck2_interpreter::parse_import::RelativeImports;
@@ -76,6 +76,7 @@ fn parse_starlark_paths(
     cell_resolver: &CellAliasResolver,
     current_dir: &CellPath,
     symbol_patterns: &[String],
+    cell_segmentation: bool,
 ) -> buck2_error::Result<StdBuckHashSet<StarlarkFilePath>> {
     let parse_options = ParseImportOptions {
         allow_missing_at_symbol: true,
@@ -96,7 +97,7 @@ fn parse_starlark_paths(
                 Ok(StarlarkFilePath::Bxl(BxlFilePath::new(path)?))
             } else {
                 Ok(StarlarkFilePath::Bzl(
-                    ImportPath::new_with_build_file_cells(path, current_cell)?,
+                    ImportPath::new_with_build_file_cells(path, current_cell, cell_segmentation)?,
                 ))
             }
         })
@@ -115,11 +116,13 @@ pub(crate) async fn docs_starlark(
         .ctx()
         .get_cell_alias_resolver(current_cell_path.cell())
         .await?;
+    let cell_segmentation = dice_ctx.get_cell_segmentation().await?;
 
     let lookups = parse_starlark_paths(
         &cell_alias_resolver,
         &current_cell_path,
         &request.symbol_patterns,
+        cell_segmentation,
     )?;
 
     let docs: Vec<_> = dice_ctx

--- a/app/buck2_common/src/legacy_configs/configs.rs
+++ b/app/buck2_common/src/legacy_configs/configs.rs
@@ -33,6 +33,14 @@ use crate::legacy_configs::parser::LegacyConfigParser;
 #[derive(Clone, Dupe, Debug, Allocative, Pagable)]
 pub struct LegacyBuckConfig(pub(crate) Arc<ConfigData>);
 
+impl LegacyBuckConfig {
+    /// Get a short-lived impl of [crate::legacy_configs::view::LegacyBuckConfigView] by simply borrowing self.
+    ///
+    /// This helps find the methods on an owned LegacyBuckConfig instead of typing `(&config).xxx`.
+    pub fn view(&self) -> &Self {
+        self
+    }
+}
 #[derive(Debug, Allocative, Pagable)]
 pub(crate) struct ConfigData {
     pub(crate) values: SortedMap<String, LegacyBuckConfigSection>,

--- a/app/buck2_core/src/bzl.rs
+++ b/app/buck2_core/src/bzl.rs
@@ -39,6 +39,12 @@ pub struct ImportPath {
     path: CellPath,
     /// The cell of the top-level build module that this is being loaded
     /// (perhaps transitively) into.
+    ///
+    /// This segments import paths such that each .bzl file is parsed once per importing cell.
+    ///
+    /// This may, if `cell_segmentation` is `false`, be overridden to match `path.cell()`.
+    /// This negates the segmentation. All cells resolve a given load() path to the
+    /// same ImportPath. Hence Buck parses each .bzl file once globally.
     build_file_cell: BuildFileCell,
 }
 
@@ -48,12 +54,13 @@ impl ImportPath {
     /// This function is for call sites where we don't care about the build file cell.
     pub fn new_same_cell(path: CellPath) -> buck2_error::Result<Self> {
         let build_file_cell = BuildFileCell::new(path.cell());
-        Self::new_with_build_file_cells(path, build_file_cell)
+        Self::new_with_build_file_cells(path, build_file_cell, false)
     }
 
     pub fn new_with_build_file_cells(
         path: CellPath,
-        build_file_cell: BuildFileCell,
+        mut build_file_cell: BuildFileCell,
+        cell_segmentation: bool,
     ) -> buck2_error::Result<Self> {
         if path.parent().is_none() {
             return Err(ImportPathError::Invalid(path).into());
@@ -67,6 +74,10 @@ impl ImportPath {
             return Err(ImportPathError::Suffix(path).into());
         }
 
+        if !cell_segmentation {
+            build_file_cell = BuildFileCell::new(path.cell());
+        }
+
         Ok(Self {
             path,
             build_file_cell,
@@ -76,7 +87,8 @@ impl ImportPath {
     /// LSP creates imports for non-bzl files.
     pub fn new_hack_for_lsp(
         path: CellPath,
-        build_file_cell: BuildFileCell,
+        mut build_file_cell: BuildFileCell,
+        cell_segmentation: bool,
     ) -> buck2_error::Result<Self> {
         if path.parent().is_none() {
             return Err(ImportPathError::Invalid(path).into());
@@ -84,6 +96,10 @@ impl ImportPath {
 
         if path.path().as_str().contains('?') {
             return Err(ImportPathError::Invalid(path).into());
+        }
+
+        if !cell_segmentation {
+            build_file_cell = BuildFileCell::new(path.cell());
         }
 
         Ok(Self {
@@ -112,6 +128,8 @@ impl ImportPath {
         Self::new_with_build_file_cells(
             cell_path,
             BuildFileCell::new(CellName::testing_new(build_file_cell)),
+            // All the tests are written for cell_segmentation being enabled.
+            true,
         )
         .unwrap()
     }

--- a/app/buck2_core/src/bzl.rs
+++ b/app/buck2_core/src/bzl.rs
@@ -114,7 +114,7 @@ impl ImportPath {
         Self::testing_new_cross_cell(cell, cell_relative_path, filename, cell)
     }
 
-    pub fn testing_new_cross_cell(
+    fn testing_new_cross_cell(
         cell: &str,
         cell_relative_path: &str,
         filename: &str,
@@ -128,7 +128,8 @@ impl ImportPath {
         Self::new_with_build_file_cells(
             cell_path,
             BuildFileCell::new(CellName::testing_new(build_file_cell)),
-            // All the tests are written for cell_segmentation being enabled.
+            // At the time of writing, no tests need this function,
+            // but if they did, they'd want cell_segmentation enabled.
             true,
         )
         .unwrap()

--- a/app/buck2_interpreter/src/bxl_read_config.rs
+++ b/app/buck2_interpreter/src/bxl_read_config.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is dual-licensed under either the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree or the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree. You may select, at your option, one of the
+ * above-listed licenses.
+ */
+
+use std::sync::Arc;
+
+use buck2_util::late_binding::LateBinding;
+use starlark::eval::Evaluator;
+
+/// Result of trying to read a buckconfig value while evaluating a `.bxl` script,
+/// where there is no `BuildContext`.
+pub enum BxlConfigValue {
+    /// The current evaluation is not a BXL evaluation; the caller should fall
+    /// through to its normal handling.
+    NotBxl,
+    /// A BXL evaluation. The value is the config value, or `None` if unset.
+    Bxl(Option<Arc<str>>),
+}
+
+/// Reads a buckconfig value from the cell that owns the `.bxl` file while a BXL
+/// script is being evaluated.
+///
+/// `read_config` should work when evaluated in a BXL context, using the BXL file's
+/// cell for buckconfig lookups. This hook, implemented in `buck2_bxl`, lets it
+/// work there by reading straight from DICE.
+pub static BXL_READ_CONFIG: LateBinding<
+    fn(&mut Evaluator, &str, &str) -> buck2_error::Result<BxlConfigValue>,
+> = LateBinding::new("BXL_READ_CONFIG");

--- a/app/buck2_interpreter/src/import_paths.rs
+++ b/app/buck2_interpreter/src/import_paths.rs
@@ -36,13 +36,18 @@ use crate::package_imports::PackageImplicitImports;
 pub struct ImplicitImportPaths {
     pub root_import: Option<ImportPath>,
     pub package_imports: PackageImplicitImports,
+    /// Stores buckconfig value
+    pub cell_segmentation: bool,
 }
 
 impl ImplicitImportPaths {
+    /// `config` is the legacy buckconfig for this particular cell.
+    /// But `cell_segmentation` must come from root buckconfig; see [GetCellSegmentation] trait.
     pub fn parse(
         mut config: impl LegacyBuckConfigView,
         cell_name: BuildFileCell,
         cell_alias_resolver: &CellAliasResolver,
+        cell_segmentation: bool,
     ) -> buck2_error::Result<ImplicitImportPaths> {
         // Oddly, the root import is defined to use a more path-like representation than
         // normal imports. e.g. it uses `cell//path/to/file.bzl` instead of
@@ -59,7 +64,7 @@ impl ImplicitImportPaths {
 
                 // root imports are only going to be used by a top-level module in the cell they
                 // are defined, so we can set the build_file_cell early.
-                ImportPath::new_with_build_file_cells(path, cell_name)
+                ImportPath::new_with_build_file_cells(path, cell_name, cell_segmentation)
             })
             .map_or(Ok(None), |e: buck2_error::Result<ImportPath>| e.map(Some))?;
         let package_imports = PackageImplicitImports::new(
@@ -71,10 +76,12 @@ impl ImplicitImportPaths {
                     property: "package_includes",
                 })?
                 .as_deref(),
+            cell_segmentation,
         )?;
         Ok(ImplicitImportPaths {
             root_import,
             package_imports,
+            cell_segmentation,
         })
     }
 
@@ -83,8 +90,47 @@ impl ImplicitImportPaths {
     }
 }
 
+pub trait GetCellSegmentation {
+    /// (Call only on the root buckconfig, please.)
+    ///
+    /// When true, this segments import paths such that each .bzl file
+    /// is parsed once per importing cell.
+    ///
+    /// When false, all load()s of the same cell path (after alias
+    /// resolution) resolve to the same import path, and so each .bzl file
+    /// is parsed once globally.
+    ///
+    /// Buck2 has historically enabled cell segmentation of import paths,
+    /// except when importing from prelude. It causes issues for OSS users,
+    /// who make more use of bzl rules defined in cells other than prelude.
+    /// Most pointedly around transitive sets:
+    /// <https://github.com/facebook/buck2/issues/683>
+    ///
+    /// Every Buck2 user has tested this being false to some degreee by
+    /// using the prelude, which has always been special-cased to
+    /// disable cell segmentation.
+    fn get_cell_segmentation(&mut self) -> buck2_error::Result<bool>;
+}
+
+impl<T> GetCellSegmentation for T
+where
+    T: LegacyBuckConfigView,
+{
+    fn get_cell_segmentation(&mut self) -> buck2_error::Result<bool> {
+        let disable = self
+            .parse(BuckconfigKeyRef {
+                section: "buck2",
+                property: "disable_cell_segmentation",
+            })?
+            .unwrap_or(false);
+        Ok(!disable)
+    }
+}
+
 #[async_trait]
 pub trait HasImportPaths {
+    async fn get_cell_segmentation(&mut self) -> buck2_error::Result<bool>;
+
     async fn import_paths_for_cell(
         &mut self,
         cell_name: BuildFileCell,
@@ -93,6 +139,12 @@ pub trait HasImportPaths {
 
 #[async_trait]
 impl HasImportPaths for DiceComputations<'_> {
+    async fn get_cell_segmentation(&mut self) -> buck2_error::Result<bool> {
+        self.get_legacy_root_config_on_dice()
+            .await?
+            .view(self)
+            .get_cell_segmentation()
+    }
     async fn import_paths_for_cell(
         &mut self,
         cell_name: BuildFileCell,
@@ -125,11 +177,13 @@ impl HasImportPaths for DiceComputations<'_> {
                 let config = ctx.get_legacy_config_on_dice(self.cell_name.name()).await?;
                 let cell_alias_resolver =
                     ctx.get_cell_alias_resolver(self.cell_name.name()).await?;
+                let cell_segmentation = ctx.get_cell_segmentation().await?;
 
                 Ok(Arc::new(ImplicitImportPaths::parse(
                     config.view(ctx),
                     self.cell_name,
                     &cell_alias_resolver,
+                    cell_segmentation,
                 )?))
             }
 

--- a/app/buck2_interpreter/src/lib.rs
+++ b/app/buck2_interpreter/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod allow_relative_paths;
 pub mod build_context;
+pub mod bxl_read_config;
 pub mod coerce;
 pub mod dice;
 pub mod downstream_crate_starlark_defs;

--- a/app/buck2_interpreter/src/package_imports.rs
+++ b/app/buck2_interpreter/src/package_imports.rs
@@ -70,10 +70,13 @@ impl PackageImplicitImports {
     /// package_mapping:
     /// `package_path`=>`import_path`::`symbol_spec`::`symbol_spec`::
     /// `symbol_spec`::... symbol_spec: `alias`=`symbol` | `symbol`
+    ///
+    /// cell_segmentation is from the root buckconfig. See [crate::import_paths::GetCellSegmentation].
     pub fn new(
         cell_name: BuildFileCell,
         cell_alias_resolver: CellAliasResolver,
         encoded_mappings: Option<&str>,
+        cell_segmentation: bool,
     ) -> buck2_error::Result<Self> {
         let mut mappings = OrderedMap::new();
         if let Some(value) = encoded_mappings {
@@ -99,7 +102,11 @@ impl PackageImplicitImports {
                     parse_import(&cell_alias_resolver, relative_import_option, import)?;
                 // Package implicit imports are only going to be used for a top-level module in
                 // the same cell, so we can set that early.
-                let import_path = ImportPath::new_with_build_file_cells(import_path, cell_name)?;
+                let import_path = ImportPath::new_with_build_file_cells(
+                    import_path,
+                    cell_name,
+                    cell_segmentation,
+                )?;
                 let mut symbols = OrderedMap::new();
                 for spec in symbol_specs.split("::") {
                     let (alias, symbol) = match spec.split_once('=') {
@@ -166,6 +173,8 @@ mod tests {
             Some(
                 "src=>//:src.bzl::symbols,src/bin=>//:bin.bzl::symbols , other=>@cell1//:other.bzl::alias1=symbol1::alias2=symbol2::symbol3",
             ),
+            // cell_segmentation
+            true,
         )?;
 
         assert_eq!(

--- a/app/buck2_interpreter/src/parse_import.rs
+++ b/app/buck2_interpreter/src/parse_import.rs
@@ -157,9 +157,10 @@ pub fn parse_bzl_path_with_config(
     import: &str,
     opts: &ParseImportOptions,
     build_cell_path: BuildFileCell,
+    cell_segmentation: bool,
 ) -> buck2_error::Result<ImportPath> {
     let path = parse_import_with_config(cell_resolver, import, opts)?;
-    ImportPath::new_with_build_file_cells(path, build_cell_path)
+    ImportPath::new_with_build_file_cells(path, build_cell_path, cell_segmentation)
 }
 
 #[cfg(test)]

--- a/app/buck2_interpreter_for_build/src/interpreter/functions/read_config.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/functions/read_config.rs
@@ -40,6 +40,37 @@ pub(crate) fn register_read_config(globals: &mut GlobalsBuilder) {
     ///
     /// In general the use of `.buckconfig` is discouraged in favour of `select`,
     /// but it can still be useful.
+    ///
+    /// ### Cell segmentation
+    ///
+    /// Historically, Buck has re-evaluated each .bzl file once per cell it is imported
+    /// into. That meant that `read_config` would read from a cell based on where the
+    /// chain of imports started. Re-evaluating came with undesirable behaviour for
+    /// cross-cell type checking so this behaviour can now be disabled, but be aware
+    /// that this affects read_config().
+    ///
+    /// In the prelude, and when you disable this behaviour for all cells with the
+    /// buckconfig `buck2.disable_cell_segmentation`, the cell that this reads from
+    /// depends on the function call stack.
+    ///
+    /// ```python
+    /// # root .buckconfig
+    /// [buck2]
+    ///     disable_cell_segmentation = true
+    ///
+    /// # hello//:world.bzl
+    /// ABC_DEF = read_config("abc", "def")
+    /// def dynamic() -> str:
+    ///     return read_config("abc", "def")
+    ///
+    /// # root//BUCK
+    /// load("@hello//:world.bzl", "ABC_DEF", "dynamic")
+    /// print(ABC_DEF)      # from hello/.buckconfig
+    /// print(dynamic())    # from root .buckconfig
+    /// ```
+    ///
+    /// Please note that you can no longer read_config during analysis.
+    /// Previously this may have worked occasionally due to inlining.
     //
     // Unlike read_root_config, this is NOT speculative_exec_safe.
     // Its return value depends on the call stack.

--- a/app/buck2_interpreter_for_build/src/interpreter/functions/read_config.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/functions/read_config.rs
@@ -40,7 +40,9 @@ pub(crate) fn register_read_config(globals: &mut GlobalsBuilder) {
     ///
     /// In general the use of `.buckconfig` is discouraged in favour of `select`,
     /// but it can still be useful.
-    #[starlark(speculative_exec_safe)]
+    //
+    // Unlike read_root_config, this is NOT speculative_exec_safe.
+    // Its return value depends on the call stack.
     fn read_config<'v>(
         section: StringValue,
         key: StringValue,

--- a/app/buck2_interpreter_for_build/src/interpreter/functions/read_config.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/functions/read_config.rs
@@ -7,7 +7,8 @@
  * of this source tree. You may select, at your option, one of the
  * above-listed licenses.
  */
-
+use buck2_interpreter::bxl_read_config::BXL_READ_CONFIG;
+use buck2_interpreter::bxl_read_config::BxlConfigValue;
 use starlark::environment::GlobalsBuilder;
 use starlark::eval::Evaluator;
 use starlark::starlark_module;
@@ -80,10 +81,27 @@ pub(crate) fn register_read_config(globals: &mut GlobalsBuilder) {
         default: Option<Value<'v>>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> starlark::Result<Value<'v>> {
-        let buckconfigs = &BuildContext::from_context(eval)?.buckconfigs;
-        match buckconfigs.current_cell_get(section, key, eval)? {
-            Some(v) => Ok(v.to_value()),
-            None => Ok(default.unwrap_or_else(Value::new_none)),
+        // During `BUCK`/`PACKAGE`/`.bzl` evaluation, read the current cell.
+        let build_err = match BuildContext::from_context(eval) {
+            Ok(build_context) => {
+                let buckconfigs = &build_context.buckconfigs;
+                return match buckconfigs.current_cell_get(section, key, eval)? {
+                    Some(v) => Ok(v.to_value()),
+                    None => Ok(default.unwrap_or_else(Value::new_none)),
+                };
+            }
+            Err(e) => e,
+        };
+
+        // In BXL there is no `BuildContext`; read the `.bxl` file's cell instead.
+        match (BXL_READ_CONFIG.get()?)(eval, section.as_str(), key.as_str())? {
+            BxlConfigValue::Bxl(value) => match value {
+                Some(v) => Ok(eval.heap().alloc_str(&v).to_value()),
+                None => Ok(default.unwrap_or_else(Value::new_none)),
+            },
+            // Not build file evaluation and not BXL: this is analysis, where
+            // `read_config` is unavailable. Report the original error.
+            BxlConfigValue::NotBxl => Err(build_err.into()),
         }
     }
 

--- a/app/buck2_interpreter_for_build/src/interpreter/interpreter_for_dir.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/interpreter_for_dir.rs
@@ -166,6 +166,7 @@ struct InterpreterLoadResolver {
     config: Arc<InterpreterForDir>,
     loader_file_type: StarlarkFileType,
     build_file_cell: BuildFileCell,
+    cell_segmentation: bool,
 }
 
 #[derive(Debug, buck2_error::Error)]
@@ -258,7 +259,11 @@ impl LoadResolver for InterpreterLoadResolver {
                 }
             }
         }
-        let import_path = ImportPath::new_with_build_file_cells(path, self.build_file_cell)?;
+        let import_path = ImportPath::new_with_build_file_cells(
+            path,
+            self.build_file_cell,
+            self.cell_segmentation,
+        )?;
         Ok(match import_path.path().path().extension() {
             Some("json") => OwnedStarlarkModulePath::JsonFile(import_path),
             Some("toml") => OwnedStarlarkModulePath::TomlFile(import_path),
@@ -397,6 +402,7 @@ impl InterpreterForDir {
             config: self.dupe(),
             loader_file_type: current_file_path.file_type(),
             build_file_cell: current_file_path.build_file_cell(),
+            cell_segmentation: self.implicit_import_paths.cell_segmentation,
         }
     }
 

--- a/app/buck2_interpreter_for_build/src/interpreter/testing.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/testing.rs
@@ -33,6 +33,7 @@ use buck2_interpreter::extra::InterpreterHostPlatform;
 use buck2_interpreter::factory::StarlarkEvaluatorProvider;
 use buck2_interpreter::file_loader::LoadedModule;
 use buck2_interpreter::file_loader::LoadedModules;
+use buck2_interpreter::import_paths::GetCellSegmentation;
 use buck2_interpreter::import_paths::ImplicitImportPaths;
 use buck2_interpreter::paths::module::OwnedStarlarkModulePath;
 use buck2_interpreter::paths::module::StarlarkModulePath;
@@ -193,10 +194,12 @@ impl Tester {
 
     fn interpreter(&self) -> buck2_error::Result<Arc<InterpreterForDir>> {
         let build_file_cell = BuildFileCell::new(self.cell_alias_resolver.resolve_self());
+        let cell_segmentation = self.root_config.view().get_cell_segmentation()?;
         let import_paths = ImplicitImportPaths::parse(
-            &self.root_config,
+            self.root_config.view(),
             build_file_cell,
             &self.cell_alias_resolver,
+            cell_segmentation,
         )?;
         let additional_globals = self.additional_globals.clone();
         let cell_info = InterpreterCellInfo::new(

--- a/app/buck2_interpreter_for_build_tests/src/interpreter.rs
+++ b/app/buck2_interpreter_for_build_tests/src/interpreter.rs
@@ -177,25 +177,31 @@ fn test_eval_build_file() {
     assert_eq!(vec!["invoke_some-exported", "java"], target_names);
 }
 
-fn cells() -> CellsData {
-    let BuckConfigBasedCells { cell_resolver, .. } =
-        futures::executor::block_on(BuckConfigBasedCells::testing_parse_with_file_ops(
-            &mut TestConfigParserFileOps::new(&[(
-                ".buckconfig",
-                indoc!(
-                    r#"
+fn cells(cell_segmentation: bool) -> CellsData {
+    let disable_cell_segmentation = !cell_segmentation;
+    let BuckConfigBasedCells {
+        cell_resolver,
+        root_config,
+        ..
+    } = futures::executor::block_on(BuckConfigBasedCells::testing_parse_with_file_ops(
+        &mut TestConfigParserFileOps::new(&[(
+            ".buckconfig",
+            &indoc::formatdoc!(
+                r#"
                     [cells]
                         root = .
                         cell1 = project/cell1
                         cell2 = project/cell2
                         xalias2 = project/cell2
+                    [buck2]
+                        disable_cell_segmentation = {disable_cell_segmentation:?}
                     "#
-                ),
-            )])
-            .unwrap(),
-            &[],
-        ))
-        .unwrap();
+            ),
+        )])
+        .unwrap(),
+        &[],
+    ))
+    .unwrap();
     (
         cell_resolver.root_cell_cell_alias_resolver().dupe(),
         cell_resolver,

--- a/app/buck2_interpreter_for_build_tests/src/interpreter.rs
+++ b/app/buck2_interpreter_for_build_tests/src/interpreter.rs
@@ -11,7 +11,6 @@
 use buck2_build_api::interpreter::rule_defs::provider::registration::register_builtin_providers;
 use buck2_build_api::interpreter::rule_defs::register_rule_defs;
 use buck2_common::legacy_configs::cells::BuckConfigBasedCells;
-use buck2_common::legacy_configs::configs::LegacyBuckConfig;
 use buck2_common::legacy_configs::configs::testing::TestConfigParserFileOps;
 use buck2_common::package_listing::listing::PackageListing;
 use buck2_common::package_listing::listing::testing::PackageListingExt;
@@ -205,7 +204,7 @@ fn cells(cell_segmentation: bool) -> CellsData {
     (
         cell_resolver.root_cell_cell_alias_resolver().dupe(),
         cell_resolver,
-        LegacyBuckConfig::empty(),
+        root_config,
         CellPathWithAllowedRelativeDir::new(
             CellPath::testing_new("cell1//config/foo"),
             Some(CellPath::testing_new("cell1//config")),
@@ -214,8 +213,9 @@ fn cells(cell_segmentation: bool) -> CellsData {
 }
 
 #[test]
-fn test_find_imports() {
-    let tester = Tester::with_cells(cells()).unwrap();
+fn test_find_imports_segmented() {
+    let cell_segmentation = true;
+    let tester = Tester::with_cells(cells(cell_segmentation)).unwrap();
     let path = BuildFilePath::testing_new("cell1//config/foo:BUCK");
     let parse_result = tester.parse(
         StarlarkPath::BuildFile(&path),
@@ -246,11 +246,60 @@ fn test_find_imports() {
         ),
     );
 
+    // cell_segmentation is on, so we have the @cell1 when importing cross-cell
     assert_eq!(
         &[
             "root//imports/one.bzl@cell1",
             "cell1//one.bzl",
             "cell2//two.bzl@cell1",
+            "cell1//config/foo/other.bzl",
+            "cell1//config/bar/three.bzl",
+        ],
+        parse_result.imports().map(|e| e.1.to_string()).as_slice()
+    );
+}
+
+#[test]
+fn test_find_imports_unsegmented() {
+    let cell_segmentation = false;
+    let tester = Tester::with_cells(cells(cell_segmentation)).unwrap();
+    let path = BuildFilePath::testing_new("cell1//config/foo:BUCK");
+    let parse_result = tester.parse(
+        StarlarkPath::BuildFile(&path),
+        indoc!(
+            r#"
+            a = 1
+        "#
+        ),
+    );
+
+    assert!(parse_result.imports().is_empty());
+
+    let parse_result = tester.parse(
+        StarlarkPath::BuildFile(&path),
+        indoc!(
+            r#"
+            # some documentation
+            """ and a string """
+
+            load("//imports:one.bzl", "some_macro")
+            load("@cell1//:one.bzl", "some_macro")
+            load("@xalias2//:two.bzl", "some_macro")
+
+            # some other comments
+            load(":other.bzl", "some_macro")
+            load("../bar/three.bzl", "some_macro")
+        "#
+        ),
+    );
+
+    // cell_segmentation is off, so we don't get the @cell1 cross-cell
+    // indication, just one global canonical import path per cell path.
+    assert_eq!(
+        &[
+            "root//imports/one.bzl",
+            "cell1//one.bzl",
+            "cell2//two.bzl",
             "cell1//config/foo/other.bzl",
             "cell1//config/bar/three.bzl",
         ],

--- a/app/buck2_interpreter_for_build_tests/src/interpreter.rs
+++ b/app/buck2_interpreter_for_build_tests/src/interpreter.rs
@@ -130,7 +130,7 @@ fn test_eval_build_file() {
 
     tester
         .add_import(
-            &ImportPath::testing_new_cross_cell("root", "imports", "one.bzl", "root"),
+            &ImportPath::testing_new("root//imports:one.bzl"),
             indoc!(
                 r#"
                     load("@root//:rules.bzl", "export_file")

--- a/app/buck2_server/src/lsp.rs
+++ b/app/buck2_server/src/lsp.rs
@@ -44,6 +44,7 @@ use buck2_fs::paths::forward_rel_path::ForwardRelativePath;
 use buck2_hash::StdBuckHashMap;
 use buck2_hash::StdBuckHashSet;
 use buck2_interpreter::allow_relative_paths::HasAllowRelativePaths;
+use buck2_interpreter::import_paths::HasImportPaths;
 use buck2_interpreter::load_module::InterpreterCalculation;
 use buck2_interpreter::paths::module::OwnedStarlarkModulePath;
 use buck2_interpreter::paths::path::OwnedStarlarkPath;
@@ -356,26 +357,28 @@ impl<'a> BuckLspContext<'a> {
     async fn import_path(&self, path: &Path) -> buck2_error::Result<OwnedStarlarkModulePath> {
         let abs_path = AbsPath::new(path)?;
         let relative_path = self.fs.relativize_any(abs_path)?;
-        let cell_resolver = self
-            .with_dice_ctx(|dice_ctx| async move { dice_ctx.ctx().get_cell_resolver().await })
-            .await?;
-        let cell_path = cell_resolver.get_cell_path(&relative_path);
+        self.with_dice_ctx(|dice| async move {
+            let cell_resolver = dice.ctx().get_cell_resolver().await?;
+            let cell_path = cell_resolver.get_cell_path(&relative_path);
+            let cell_segmentation = dice.ctx().get_cell_segmentation().await?;
 
-        match path.extension() {
-            Some(e) if e == "bxl" => Ok(OwnedStarlarkModulePath::BxlFile(BxlFilePath::new(
-                cell_path,
-            )?)),
-            _ => {
-                // Instantiating a BuildFileCell off of the path of the file being originally evaluated.
-                // Unlike the build commands and such, there is no meaningful "build file cell" versus
-                // the cell of the file being currently evaluated.
-                let bfc = BuildFileCell::new(cell_path.cell());
+            match path.extension() {
+                Some(e) if e == "bxl" => Ok(OwnedStarlarkModulePath::BxlFile(BxlFilePath::new(
+                    cell_path,
+                )?)),
+                _ => {
+                    // Instantiating a BuildFileCell off of the path of the file being originally evaluated.
+                    // Unlike the build commands and such, there is no meaningful "build file cell" versus
+                    // the cell of the file being currently evaluated.
+                    let bfc = BuildFileCell::new(cell_path.cell());
 
-                Ok(OwnedStarlarkModulePath::LoadFile(
-                    ImportPath::new_hack_for_lsp(cell_path, bfc)?,
-                ))
+                    Ok(OwnedStarlarkModulePath::LoadFile(
+                        ImportPath::new_hack_for_lsp(cell_path, bfc, cell_segmentation)?,
+                    ))
+                }
             }
-        }
+        })
+        .await
     }
 
     async fn starlark_import_path(

--- a/app/buck2_server_commands/src/debug_eval.rs
+++ b/app/buck2_server_commands/src/debug_eval.rs
@@ -7,7 +7,6 @@
  * of this source tree. You may select, at your option, one of the
  * above-listed licenses.
  */
-
 use buck2_cli_proto::new_generic::DebugEvalRequest;
 use buck2_cli_proto::new_generic::DebugEvalResponse;
 use buck2_common::dice::cells::HasCellResolver;
@@ -18,6 +17,7 @@ use buck2_core::cells::cell_path::CellPath;
 use buck2_fs::error::IoResultExt;
 use buck2_fs::fs_util;
 use buck2_fs::paths::abs_path::AbsPathBuf;
+use buck2_interpreter::import_paths::HasImportPaths;
 use buck2_interpreter::load_module::InterpreterCalculation;
 use buck2_interpreter::paths::module::OwnedStarlarkModulePath;
 use buck2_server_ctx::ctx::ServerCommandContextTrait;
@@ -38,6 +38,7 @@ pub(crate) async fn debug_eval_command(
         .with_dice_ctx(|server_ctx, ctx| async move {
             let cell_resolver = ctx.ctx().get_cell_resolver().await?;
             let current_cell_path = cell_resolver.get_cell_path(server_ctx.working_dir());
+            let cell_segmentation = ctx.get_cell_segmentation().await?;
             let mut loads = Vec::new();
 
             let ctx = &ctx;
@@ -51,6 +52,7 @@ pub(crate) async fn debug_eval_command(
                     OwnedStarlarkModulePath::LoadFile(ImportPath::new_with_build_file_cells(
                         path,
                         BuildFileCell::new(current_cell_path.cell()),
+                        cell_segmentation,
                     )?)
                 } else if path.path().as_str().ends_with(".bxl") {
                     OwnedStarlarkModulePath::BxlFile(BxlFilePath::new(path)?)

--- a/prelude/tests/re_utils.bzl
+++ b/prelude/tests/re_utils.bzl
@@ -35,9 +35,11 @@ def _network_access_kwargs(network_access: str | None) -> dict[str, str]:
         return {}
     return {"network_access": network_access}
 
+_FORCE_LOCAL = read_config("fbcode", "disable_re_tests", default = False)
+_FORCE_RUN_AS_BUNDLE = read_config("tpx", "force_run_as_bundle", "False")
+
 def _get_re_arg(ctx: AnalysisContext) -> ReArg:
-    force_local = read_config("fbcode", "disable_re_tests", default = False)
-    if force_local or not hasattr(ctx.attrs, "remote_execution"):
+    if _FORCE_LOCAL or not hasattr(ctx.attrs, "remote_execution"):
         # NOTE: this is kinda weird, we take this path if the attr is missing completely
         # Even if the value is None we still follow. Adding force.local to give users
         # some means of bypassing.
@@ -72,7 +74,7 @@ def maybe_add_run_as_bundle_label(ctx: AnalysisContext, labels: list[str]) -> No
     if "re_ignore_force_run_as_bundle" in labels:
         return
     re_arg = _get_re_arg(ctx)
-    if re_arg.default_run_as_bundle or read_config("tpx", "force_run_as_bundle") == "True":
+    if re_arg.default_run_as_bundle or _FORCE_RUN_AS_BUNDLE == "True":
         labels.extend(["run_as_bundle"])
 
 def get_re_executors_from_props(ctx: AnalysisContext, dynamic_image_override: [dict, None] = None) -> RemoteTestExecutorConfig:
@@ -100,6 +102,7 @@ def get_re_executors_from_props(ctx: AnalysisContext, dynamic_image_override: [d
 
     if re_arg.disabled:
         executor = CommandExecutorConfig(local_enabled = True, remote_enabled = False, **_network_access_kwargs(network_access))
+
         # A `remote_execution = "disabled"` target has always produced an executor
         # and therefore run from the project root; preserve that behavior.
         return RemoteTestExecutorConfig(default_executor = executor, run_from_project_root = True, use_project_relative_paths = True)
@@ -154,7 +157,7 @@ def get_re_executors_from_props(ctx: AnalysisContext, dynamic_image_override: [d
         remote_execution_resource_units = re_resource_units,
         remote_execution_dynamic_image = re_dynamic_image,
         meta_internal_extra_params = meta_internal_extra_params,
-        **_network_access_kwargs(network_access),
+        **_network_access_kwargs(network_access)
     )
 
     listing_executor = default_executor
@@ -168,7 +171,7 @@ def get_re_executors_from_props(ctx: AnalysisContext, dynamic_image_override: [d
             remote_execution_resource_units = re_listing_resource_units,
             remote_execution_dynamic_image = re_dynamic_image,
             meta_internal_extra_params = meta_internal_extra_params,
-            **_network_access_kwargs(network_access),
+            **_network_access_kwargs(network_access)
         )
     return RemoteTestExecutorConfig(
         default_executor = default_executor,

--- a/shim/build_defs/lib/oss.bzl
+++ b/shim/build_defs/lib/oss.bzl
@@ -38,129 +38,145 @@ def _strip_third_party_rust_version(target: str) -> str:
             break
     return "-".join(xs)
 
-# Cell the BUCK file being processed belongs to
-ACTIVE_CELL = native.get_cell_name()
-
-# The root cell of this project, extracted from the "root" alias.
-# Targets that explicitly reference this cell will not be rewritten, and
-# targets that do not end up referencing a cell will be replaced with targets
-# that reference this cell
-ROOT_CELL = read_config("cell_aliases", "root", "root")
-
-# The cell this file and the rest of the shim directory belong to, generally
-# "shim" and does not need to be set.
-SHIM_CELL = read_config("oss", "shim_cell", "shim")
-
-# The internal cell this project originally belonged to.
-#
-# When applying rewrites, the cell of the target is often considered. Targets
-# that do not explicitly specify a cell (eg: "//foo:bar") will be considered
-# to belong to INTERNAL_CELL.
-INTERNAL_CELL = read_config("oss", "internal_cell", "fbcode")
-
-# There can be situations where a target specifies a cell explicitly and the
-# path is part of the local checkout, rather than potentially needing to be
-# shimmed. In this case, we want to rewrite the target to use the root cell.
-#
-# If a target's cell is unspecified or matches the internal cell, and the path
-# starts with an entry in this list, The cell replaced with the ROOT_CELL.
-#
-# Entries are separated by spaces, and evaluated in order. Once a match is
-# found, the rewrite is complete and the following entries will not be
-# evaluated.
-#
-# Examples:
-#     internal_cell//oss_project/foo:bar -> root//oss_project/foo:bar
-PROJECT_DIRS = _filter_empty_strings(read_config("oss", "project_dirs", "").split(" "))
-
-# There are some situations where prefix of the internal directory structure is
-# removed from the public filepaths, such as rewriting "internal/foo/bar/baz"
-# to "oss/baz". When this happens, the BUCK files are not converted to reflect
-# the public directory structure, and targets need to be rewritten to account
-# for the discrepancy.
-#
-# Entries behave similarly to PROJECT_DIRS, except that the root directory will
-# also be removed from the path in the rewritten target. This setting is
-# applied after PROJECT_DIRS.
-#
-# Entries are separated by spaces and evaluated in order. Once a match is
-# found, the rewrite is complete and the following entries will not be
-# evaluated.
-#
-# Examples:
-#     //oss_project/foo:bar -> root//foo:bar
-#     internal_cell//oss_project/foo:bar -> root//foo:bar
-STRIPPED_ROOT_DIRS = _filter_empty_strings(read_config("oss", "stripped_root_dirs", "").split(" "))
-
-# Internally, most code shares the same cell in a monorepo, but public projects
-# only contain a subset, importing dependencies via git submodules or other
-# mechanisms. When this happens, the dependency may end up in a different
-# filepath, or may have it's own buck2 configuration and should be treated as
-# an on disk external cell.
-#
-# If the target's cell is a match (or if unspecified, INTERNAL_CELL is a
-# match),unspecified) matches, and the target's path is within the root
-# directory, both the cell and root directory prefix are replaced with the new
-# values.
-#
-# Entries are in the form of "MATCH->REPLACEMENT". Both MATCH and replacement
-# shall be in the format of "CELL//DIR_PREFIX".
-#
-# Entries are separated by spaces and evaluated in order. Once a match is
-# found, the rewrite is complete and the following entries will not be
-# evaluated.
-#
-# Examples:
-#     internal//foo->foo//foo; internal//foo/bar:baz -> foo//foo/bar:baz
-PREFIX_MAPPINGS = _parse_prefix_mappings(
-    _filter_empty_strings(read_config("oss", "prefix_mappings", "").split(" ")),
+RewriteCells = record(
+    active = field(str),
+    root = field(str),
+    shim = field(str),
+    internal = field(str),
 )
 
-# Hardcoded rewrite rules that apply to many projects and only produce targets
-# within the shim cell. They are applied after the rules from .buckconfig, and
-# will not be applied if any other rules match.
-IMPLICIT_REWRITE_RULES = {
-    "fbcode": struct(
-        exact = {
-            "common/rust/shed/fbinit:fbinit": "third-party/rust:fbinit",
-            "common/rust/shed/sorted_vector_map:sorted_vector_map": "third-party/rust:sorted_vector_map",
-            "watchman/rust/watchman_client:watchman_client": "third-party/rust:watchman_client",
-        },
-        dirs = [
-            ("third-party-buck/platform010/build/supercaml", "third-party/ocaml"),
-            ("third-party-buck/platform010/build", "third-party"),
-        ],
-    ),
-    "fbsource": struct(
-        dirs = [
-            ("third-party", "third-party"),
-        ],
-        dynamic = [
-            ("third-party/rust", _strip_third_party_rust_version),
-        ],
-    ),
-    "third-party": struct(
-        dirs = [
-            ("", "third-party"),
-        ],
-        dynamic = [
-            ("rust", lambda path: "third-party/" + _strip_third_party_rust_version(path)),
-        ],
-    ),
-}
-
-DEFAULT_REWRITE_CTX = struct(
-    cells = struct(
-        active = ACTIVE_CELL,
-        root = ROOT_CELL,
-        shim = SHIM_CELL,
-        internal = INTERNAL_CELL,
-    ),
-    project_dirs = PROJECT_DIRS,
-    stripped_root_dirs = STRIPPED_ROOT_DIRS,
-    prefix_mappings = PREFIX_MAPPINGS,
-    implicit_rewrite_rules = IMPLICIT_REWRITE_RULES,
+RewriteContext = record(
+    cells = field(RewriteCells),
+    project_dirs = field(list[str]),
+    stripped_root_dirs = field(list[str]),
+    prefix_mappings = field(typing.Any),
+    implicit_rewrite_rules = field(typing.Any),
 )
+
+def _get_default_rewrite_ctx():
+    # Cell the BUCK file being processed belongs to
+    ACTIVE_CELL = native.get_cell_name()
+
+    # The root cell of this project, extracted from the "root" alias.
+    # Targets that explicitly reference this cell will not be rewritten, and
+    # targets that do not end up referencing a cell will be replaced with targets
+    # that reference this cell
+    ROOT_CELL = read_config("cell_aliases", "root", "root")
+
+    # The cell this file and the rest of the shim directory belong to, generally
+    # "shim" and does not need to be set.
+    SHIM_CELL = read_config("oss", "shim_cell", "shim")
+
+    # The internal cell this project originally belonged to.
+    #
+    # When applying rewrites, the cell of the target is often considered. Targets
+    # that do not explicitly specify a cell (eg: "//foo:bar") will be considered
+    # to belong to INTERNAL_CELL.
+    INTERNAL_CELL = read_config("oss", "internal_cell", "fbcode")
+
+    # There can be situations where a target specifies a cell explicitly and the
+    # path is part of the local checkout, rather than potentially needing to be
+    # shimmed. In this case, we want to rewrite the target to use the root cell.
+    #
+    # If a target's cell is unspecified or matches the internal cell, and the path
+    # starts with an entry in this list, The cell replaced with the ROOT_CELL.
+    #
+    # Entries are separated by spaces, and evaluated in order. Once a match is
+    # found, the rewrite is complete and the following entries will not be
+    # evaluated.
+    #
+    # Examples:
+    #     internal_cell//oss_project/foo:bar -> root//oss_project/foo:bar
+    PROJECT_DIRS = _filter_empty_strings(read_config("oss", "project_dirs", "").split(" "))
+
+    # There are some situations where prefix of the internal directory structure is
+    # removed from the public filepaths, such as rewriting "internal/foo/bar/baz"
+    # to "oss/baz". When this happens, the BUCK files are not converted to reflect
+    # the public directory structure, and targets need to be rewritten to account
+    # for the discrepancy.
+    #
+    # Entries behave similarly to PROJECT_DIRS, except that the root directory will
+    # also be removed from the path in the rewritten target. This setting is
+    # applied after PROJECT_DIRS.
+    #
+    # Entries are separated by spaces and evaluated in order. Once a match is
+    # found, the rewrite is complete and the following entries will not be
+    # evaluated.
+    #
+    # Examples:
+    #     //oss_project/foo:bar -> root//foo:bar
+    #     internal_cell//oss_project/foo:bar -> root//foo:bar
+    STRIPPED_ROOT_DIRS = _filter_empty_strings(read_config("oss", "stripped_root_dirs", "").split(" "))
+
+    # Internally, most code shares the same cell in a monorepo, but public projects
+    # only contain a subset, importing dependencies via git submodules or other
+    # mechanisms. When this happens, the dependency may end up in a different
+    # filepath, or may have it's own buck2 configuration and should be treated as
+    # an on disk external cell.
+    #
+    # If the target's cell is a match (or if unspecified, INTERNAL_CELL is a
+    # match),unspecified) matches, and the target's path is within the root
+    # directory, both the cell and root directory prefix are replaced with the new
+    # values.
+    #
+    # Entries are in the form of "MATCH->REPLACEMENT". Both MATCH and replacement
+    # shall be in the format of "CELL//DIR_PREFIX".
+    #
+    # Entries are separated by spaces and evaluated in order. Once a match is
+    # found, the rewrite is complete and the following entries will not be
+    # evaluated.
+    #
+    # Examples:
+    #     internal//foo->foo//foo; internal//foo/bar:baz -> foo//foo/bar:baz
+    PREFIX_MAPPINGS = _parse_prefix_mappings(
+        _filter_empty_strings(read_config("oss", "prefix_mappings", "").split(" ")),
+    )
+
+    # Hardcoded rewrite rules that apply to many projects and only produce targets
+    # within the shim cell. They are applied after the rules from .buckconfig, and
+    # will not be applied if any other rules match.
+    IMPLICIT_REWRITE_RULES = {
+        "fbcode": struct(
+            exact = {
+                "common/rust/shed/fbinit:fbinit": "third-party/rust:fbinit",
+                "common/rust/shed/sorted_vector_map:sorted_vector_map": "third-party/rust:sorted_vector_map",
+                "watchman/rust/watchman_client:watchman_client": "third-party/rust:watchman_client",
+            },
+            dirs = [
+                ("third-party-buck/platform010/build/supercaml", "third-party/ocaml"),
+                ("third-party-buck/platform010/build", "third-party"),
+            ],
+        ),
+        "fbsource": struct(
+            dirs = [
+                ("third-party", "third-party"),
+            ],
+            dynamic = [
+                ("third-party/rust", _strip_third_party_rust_version),
+            ],
+        ),
+        "third-party": struct(
+            dirs = [
+                ("", "third-party"),
+            ],
+            dynamic = [
+                ("rust", lambda path: "third-party/" + _strip_third_party_rust_version(path)),
+            ],
+        ),
+    }
+
+    return RewriteContext(
+        cells = RewriteCells(
+            active = ACTIVE_CELL,
+            root = ROOT_CELL,
+            shim = SHIM_CELL,
+            internal = INTERNAL_CELL,
+        ),
+        project_dirs = PROJECT_DIRS,
+        stripped_root_dirs = STRIPPED_ROOT_DIRS,
+        prefix_mappings = PREFIX_MAPPINGS,
+        implicit_rewrite_rules = IMPLICIT_REWRITE_RULES,
+    )
 
 """
 Rewrite an internal target string to one that is compatible with this OSS
@@ -174,7 +190,12 @@ Some example use cases for this:
   (eg: internal/my_library/... and oss-project/my_library/my_library/...)
 """
 
-def translate_target(target: str, ctx = DEFAULT_REWRITE_CTX) -> str:
+def translate_target(
+        target: str,
+        ctx: RewriteContext | None = None) -> str:
+    if not ctx:
+        ctx = _get_default_rewrite_ctx()
+
     if "//" not in target:
         # This is a local target, aka ":foo". Don't touch
         return target

--- a/shim/build_defs/lib/test/oss.bzl
+++ b/shim/build_defs/lib/test/oss.bzl
@@ -6,10 +6,10 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
-load("@shim//build_defs/lib:oss.bzl", "translate_target")
+load("@shim//build_defs/lib:oss.bzl", "RewriteCells", "RewriteContext", "translate_target")
 
-TEST_CTX = struct(
-    cells = struct(
+TEST_CTX = RewriteContext(
+    cells = RewriteCells(
         active = "root",
         root = "root",
         shim = "shim",

--- a/tests/core/interpreter/test_cancellation_data/defs.bzl
+++ b/tests/core/interpreter/test_cancellation_data/defs.bzl
@@ -8,24 +8,38 @@
 
 # @nolint
 
-def loop_long(kind):
-    if read_config("should", "loop", "") != kind:
-        return
-
+def spin():
     for i in range(2147483647):
         for j in range(2147483647):
             for k in range(2147483647):
                 pass
 
-def _noop(ctx):
+def loop_long(kind):
+    # `read_config` is only available while evaluating a `BUCK`/`PACKAGE` file,
+    # so this may only be called from those contexts, not during analysis.
+    if read_config("should", "loop", "") == kind:
+        spin()
+
+def _noop_impl(ctx):
     outs = []
     out = ctx.actions.write("out.txt", ctx.attrs.name, has_content_based_path = False)
     outs.append(out)
-    loop_long("analysis")
+
+    # `read_config` is unavailable during analysis, so whether to loop is decided
+    # during build file evaluation (in the `noop` macro) and threaded in via an
+    # attribute.
+    if ctx.attrs.loop_analysis:
+        spin()
 
     return [DefaultInfo(default_outputs = outs)]
 
-noop = rule(
-    impl = _noop,
-    attrs = {},
+_noop = rule(
+    impl = _noop_impl,
+    attrs = {
+        "loop_analysis": attrs.bool(default = False),
+    },
 )
+
+def noop(**kwargs):
+    kwargs["loop_analysis"] = read_config("should", "loop", "") == "analysis"
+    _noop(**kwargs)

--- a/tests/core/interpreter/test_cell_segmentation.py
+++ b/tests/core/interpreter/test_cell_segmentation.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# pyre-strict
+
+from buck2.tests.e2e_util.api.buck import Buck
+from buck2.tests.e2e_util.asserts import expect_failure
+from buck2.tests.e2e_util.buck_workspace import buck_test
+
+
+@buck_test()
+async def test_baseline_intra_cell(buck: Buck) -> None:
+    await buck.build("//:intra_cell", "-cbuck2.disable_cell_segmentation=false")
+    await buck.build("//:intra_cell", "-cbuck2.disable_cell_segmentation=true")
+
+
+@buck_test()
+async def test_fails_cross_cell_with_segmentation(buck: Buck) -> None:
+    await expect_failure(
+        buck.build("//:cross_cell", "-cbuck2.disable_cell_segmentation=false"),
+        stderr_regex="Transitive set transitive values must be of the same transitive set type",
+    )
+
+
+@buck_test()
+async def test_succeeds_cross_cell_without_segmentation(buck: Buck) -> None:
+    await buck.build("//:cross_cell", "-cbuck2.disable_cell_segmentation=true")

--- a/tests/core/interpreter/test_cell_segmentation_data/.buckconfig
+++ b/tests/core/interpreter/test_cell_segmentation_data/.buckconfig
@@ -1,0 +1,7 @@
+[buildfile]
+name=TARGETS.fixture
+
+[cells]
+root = .
+one = one
+two = two

--- a/tests/core/interpreter/test_cell_segmentation_data/TARGETS.fixture
+++ b/tests/core/interpreter/test_cell_segmentation_data/TARGETS.fixture
@@ -1,0 +1,11 @@
+# @nolint
+
+load("@one//:rules.bzl", "binary", "library")
+
+library(name = "a")
+library(name = "b", deps = [":a"])
+binary(name = "intra_cell", deps = [":a", ":b"])
+
+# these fail though
+binary(name = "cross_cell", deps = ["one//:lib"])
+binary(name = "cross_cell_2", deps = ["two//:lib"])

--- a/tests/core/interpreter/test_cell_segmentation_data/one/.buckconfig
+++ b/tests/core/interpreter/test_cell_segmentation_data/one/.buckconfig
@@ -1,0 +1,2 @@
+[buildfile]
+    name = TARGETS.fixture

--- a/tests/core/interpreter/test_cell_segmentation_data/one/TARGETS.fixture
+++ b/tests/core/interpreter/test_cell_segmentation_data/one/TARGETS.fixture
@@ -1,0 +1,6 @@
+load(":rules.bzl", "library")
+
+library(
+    name = "lib",
+    visibility = ["PUBLIC"],
+)

--- a/tests/core/interpreter/test_cell_segmentation_data/one/rules.bzl
+++ b/tests/core/interpreter/test_cell_segmentation_data/one/rules.bzl
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# @nolint
+
+Info = provider(
+    fields = {
+        "label": provider_field(Label),
+    },
+)
+
+def project_as_json(value: Info | None):
+    if value == None:
+        return struct()
+    return struct(label = str(value.label))
+
+InfoTSet = transitive_set(json_projections = {"json": project_as_json})
+
+InfoGraph = provider(
+    fields = {
+        "tset": provider_field(InfoTSet),
+    },
+)
+
+library = rule(
+    impl = lambda ctx: [
+        DefaultInfo(default_outputs = []),
+        InfoGraph(tset = ctx.actions.tset(
+            InfoTSet,
+            value = Info(label = ctx.label),
+            children = [
+                dep[InfoGraph].tset
+                for dep in ctx.attrs.deps
+            ],
+        )),
+    ],
+    attrs = {
+        "deps": attrs.list(attrs.dep(providers = [InfoGraph]), default = []),
+    },
+)
+
+def __binary(ctx: AnalysisContext) -> list[Provider]:
+    tset = ctx.actions.tset(
+        InfoTSet,
+        children = [
+            dep[InfoGraph].tset
+            for dep in ctx.attrs.deps
+        ],
+    )
+    json = tset.project_as_json("json")
+    json = ctx.actions.write_json("out.json", json)
+    return [DefaultInfo(default_output = json)]
+
+binary = rule(
+    impl = __binary,
+    attrs = {
+        "deps": attrs.list(attrs.dep(providers = [InfoGraph]), default = []),
+    },
+)

--- a/tests/core/interpreter/test_cell_segmentation_data/two/.buckconfig
+++ b/tests/core/interpreter/test_cell_segmentation_data/two/.buckconfig
@@ -1,0 +1,2 @@
+[buildfile]
+    name = TARGETS.fixture

--- a/tests/core/interpreter/test_cell_segmentation_data/two/TARGETS.fixture
+++ b/tests/core/interpreter/test_cell_segmentation_data/two/TARGETS.fixture
@@ -1,0 +1,6 @@
+load("@one//:rules.bzl", "library")
+
+library(
+    name = "lib",
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
Fixes https://github.com/facebook/buck2/issues/683 if you enable the config.

Also fixes https://github.com/facebook/buck2/issues/890.

This is achieved by ignoring the build_file_cell during ImportPath construction. I can confirm this fixes the test case on that issue (https://github.com/cormacrelf/buck2-tset-bug).

This is a big improvement for users outside of Meta because previously it was practically impossible to use transitive sets. I have been writing some rules and have had to emulate the feature with regular starlark sets.

Previous version of this PR had cfg flags; now I made a buckconfig for it. Because it does break some things.

This will break any code that reads `read_config` / `get_cell_name` at the top level of a BZL file outside of the prelude. It will also break code that uses `read_config` / `get_cell_name` during analysis (which should never have worked). It is therefore not activated for anyone by default. However it is not super difficult to migrate. To test it, you can use

```ini
# root .buckconfig
[buck2]
    disable_cell_segmentation = true
```

## Breakage

### Every user, with or without the buckconfig

#### `read_config` during analysis is no longer accepted

Previously this was unofficially and perhaps accidentally supported:

```starlark
def _impl(ctx: AnalysisContext) -> list[Provider]:
    xyz = read_config("abc", "xyz")
    ...

rule = rule(impl = _impl)
```

The reason being that `read_config` was marked as `#[starlark(speculative_exec_safe)]`, so it was actually being inlined when the file was initially parsed. It can no longer be inlined so this no longer works. I recall this working sometimes but not always, to my great puzzlement, which is why I expect people won't have used it that much. There will nevertheless be code that does rely on it. It now fails with

<details>
<summary>
<blockquote>
error: This function is unavailable during analysis (usual solution is to place the information on a toolchain)
</blockquote>
</summary>

```
BUILD FAILED
Error running analysis for `root//rust:test (prelude//platforms:default#7171795d350c5b11)`

Caused by:
    Traceback (most recent call last):
      File <builtin>, in <module>
      * prelude/rust/rust_binary.bzl:519, in rust_test_impl
          re_executor, executor_overrides = get_re_executors_from_props(ctx)
      * prelude/tests/re_utils.bzl:68, in get_re_executors_from_props
          re_arg = _get_re_arg(ctx)
      * prelude/tests/re_utils.bzl:20, in _get_re_arg
          force_local = read_config("fbcode", "disable_re_tests", default = False)

    error: This function is unavailable during analysis (usual solution is to place the information on a toolchain)
      --> prelude/tests/re_utils.bzl:20:19
       |
    20 |     force_local = read_config("fbcode", "disable_re_tests", default = False)
       |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
```

</details>


#### To migrate code that relied on starlark inlining of read_config

Simply lift `read_config` calls to constants outside of analysis impls. I have already done this for a few stragglers in the prelude.


```diff
+_XYZ = read_config("abc", "xyz")
+
def _impl(ctx: AnalysisContext) -> list[Provider]:
-    xyz = read_config("abc", "xyz")
-    if xyz:
+    if XYZ:

abc_library = rule(impl = _impl)
```

### Breaking changes WITH the buckconfig

#### Before (non-prelude cell)

```starlark
# othercell//:defs.bzl

# all calls relate to the build file cell and will agree.
STATIC_CONFIG = read_config(...)
STATIC_CELL = native.get_cell_name()
abc = rule(
    ...
    attrs = { "xyz": attrs.string(default = read_config(...)), },
)
def macro():
    _ = read_config(...)
    _ = native.get_cell_name()
```

```starlark
# BUCK file

load("@othercell//:defs.bzl", "macro")
macro()
```

#### After

There is now a difference between two kinds of calls to get_cell_name/read_config. It matters when you evaluate them.

```starlark
# othercell//:defs.bzl

# These now relate to the .bzl file's cell
STATIC_CONFIG = read_config(...)
STATIC_CELL = native.get_cell_name()
abc = rule(
    ...
    attrs = { "xyz": attrs.string(default = read_config(...)), },
)

def macro():
    # these two relate to build file cell as before
    _ = read_config(...)
    _ = native.get_cell_name()

```

```starlark
# BUCK file

load("@othercell//:defs.bzl", "macro")
macro()
```

#### For the prelude specifically

No change, the "after" is already how it works in the prelude.

#### How to migrate non-prelude cells

Before `buck2.disable_cell_segmentation`, **all** `read_config`/`get_cell_name` calls referred to the importing build file's cell. Achieving this is now a bit more difficult. You must now call `read_config` in a macro such that it is evaluated in the build file context. **This may require wrapping a rule in a macro.**

The ONLY way to achieve 'read the importing build file cell config' is to put it in a macro and call that macro during build file evaluation. Notably, **`attrs.string(default = read_config(...))` is now evaluated in the cell owning the .bzl file** since that is eagerly evaluated and passed to `rule()`.

```diff
def _impl(ctx: AnalysisContext) -> list[Provider]:
-    xyz = read_config("abc", "xyz")
-    if xyz:
+    if ctx.attrs.xyz:

-abc_library = rule(impl = _impl)
+abc_library = rule(impl = _impl, attrs = { "xyz": attrs.string() })
+_abc_library = abc_librneary
+
+def abc_library(**kwargs):
+    kwargs.setdefault("xyz", read_config("abc", "xyz"))
+    _abc_library(**kwargs)
```

I believe this pattern is already necessary to read package values and populate defaults with them.

Alternatively, use a toolchain rule and allow your users to configure things there instead of in buckconfig.

## Review questions

- ~~Is `parser.cell_segmentation` the best buckconfig name? Almost every other config is in the `buck2` section but this is one of those rare occasions that maybe parser is right? Feel free to change it in `app/buck2_interpreter/src/import_paths.rs`. You can call the config whatever you like, just fix the tests, or I am happy to change it. I suppose it doesn't matter since it's a temporary thing anyway.~~ Ok I changed it to `buck2.disable_cell_segmentation`.
- I don't know how to run the integration test that I wrote. Fingers crossed it works.
- There may be a need for disabling this in a more fine-grained way. Especially if people are using a bunch of external cells and they have not been updated to support this new mode.
- Do we maybe want to read the buckconfig not from the root, but rather from the bzl's cell? That way a cell can mark itself safe for single-eval. Which it will do if it contains transitive set definitions, for example. This would slow down a global migration away from cell segmentation by reducing incentive to change code to work without it.

