### PR TITLE
Add buck2 rules that implement CMake's configure_file() behavior.

### DIFF
--- a/prelude/cxx/cctest.bzl
+++ b/prelude/cxx/cctest.bzl
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+CcTestValueInfo = provider(
+    fields = {
+        "value": provider_field(typing.Any)
+    }
+)
+
+CcTestTypeSizeInfo = provider(
+    fields = {
+        "type": provider_field(str),
+        "size": provider_field(int)
+    }
+)
+
+def cctest_value_impl(ctx: AnalysisContext) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        CcTestValueInfo(value = ctx.attrs.value)
+    ]
+
+def cctest_type_exists_impl(ctx: AnalysisContext) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        CcTestValueInfo(value = ctx.attrs.exists)
+    ]
+
+
+def cctest_type_size_impl(ctx: AnalysisContext) -> list[Provider]:
+    type_exists = ctx.attrs.size != None
+    return [
+        DefaultInfo(),
+        CcTestTypeSizeInfo(type = ctx.attrs.type, size = ctx.attrs.size),
+        CcTestValueInfo(value = type_exists)
+    ]
+
+def cctest_map_value_impl(ctx: AnalysisContext) -> list[Provider]:
+    original = ctx.attrs.original[CcTestValueInfo].value
+
+    if original not in ctx.attrs.actual:
+        fail(f"Value {original} does not contain a mapping.")
+
+    new = ctx.attrs.actual[original]
+    return [
+        DefaultInfo(),
+        CcTestValueInfo(value = new)
+    ]

--- a/prelude/cxx/cmake.bzl
+++ b/prelude/cxx/cmake.bzl
@@ -1,0 +1,135 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+load(":cctest.bzl", "CcTestValueInfo", "CcTestTypeSizeInfo")
+load("@prelude//python:toolchain.bzl", "PythonToolchainInfo")
+
+# Provider used by embedded_file rule, which allows replacing a cmake
+# substitution variable with content from another file.
+CMakeEmbeddedFileInfo = provider(
+    fields = {
+        "files": provider_field(typing.Any, default = None),
+        "prefix": provider_field(typing.Any, default = None),
+        "suffix": provider_field(typing.Any, default = None),
+        "item_prefix": provider_field(typing.Any, default = None),
+        "item_suffix": provider_field(typing.Any, default = None),
+        "delimiter": provider_field(typing.Any, default = None),
+        "trailing_delimiter": provider_field(typing.Any, default = None),
+    }
+)
+
+# Stores a variable which will be searched for in the cmake configure file
+# template as well as a value to replace that variable with during substitution.
+CMakeSubstitutionInfo = provider(
+    fields = {
+        "variable": provider_field(str),
+        "value": provider_field(typing.Any)
+    }
+)
+
+def _cmake_substitution_impl_internal(name:str, value) -> list[Provider]:
+    if isinstance(value, Dependency):
+        value = value[CcTestValueInfo].value
+
+    return [
+        DefaultInfo(default_outputs = []),
+        CMakeSubstitutionInfo(
+            variable = name,
+            value = value
+        )
+    ]
+
+def cmake_configure_file_impl(ctx: AnalysisContext) -> list[Provider]:
+    output_dir = ctx.actions.declare_output("out", dir = True)
+    output_file = output_dir.project(ctx.attrs.output if ctx.attrs.output else ctx.label.name)
+
+    script_run_info = ctx.attrs.script[RunInfo]
+    args = [
+        script_run_info,
+        "--input", ctx.attrs.template,
+        "--output", output_file.as_output(),
+    ]
+    hidden = []
+    print(ctx.attrs.strict)
+    if ctx.attrs.strict:
+        args.append("--strict")
+    if ctx.attrs.at_sub:
+        args.append("--enable-at-replacements")
+    if ctx.attrs.var_sub:
+        args.append("--enable-var-replacements")
+    if ctx.attrs.escape_quotes:
+        args.append("--escape-quotes")
+    if ctx.attrs.copy_only:
+        args.append("--copy-only")
+
+    substitution_dictionary = {}
+
+    for sub in ctx.attrs.substitutions:
+        info = sub[CMakeSubstitutionInfo]
+        substitution_dictionary[info.variable] = info.value
+
+    config_json = ctx.actions.write_json("config.json", substitution_dictionary, pretty=True)
+    args.extend([
+        "--substitution-file",
+        config_json
+    ])
+
+    for key, value in ctx.attrs.embeddings.items():
+        value = value[CMakeEmbeddedFileInfo]
+        action = {
+            "label": key,
+            "files": value.files,
+            "prefix": value.prefix,
+            "suffix": value.suffix,
+            "item_prefix": value.item_prefix,
+            "item_suffix": value.item_suffix,
+            "delimiter": value.delimiter,
+            "trailing_delimiter": value.trailing_delimiter,
+        }
+        embedding_json_name = "{}.embedding.json".format(key)
+        embedding_json = ctx.actions.write_json(embedding_json_name, action, pretty=True)
+        args.append("--embeddings")
+        args.append(embedding_json)
+        hidden.extend(value.files)
+
+    ctx.actions.run(
+        cmd_args(args, hidden=hidden),
+        category = "cmake_configure_file",
+        identifier = ctx.attrs.template.short_path(),
+    )
+
+    sub_targets = {"outdir": [DefaultInfo(default_outputs=[output_dir])]}
+    return [
+        DefaultInfo(
+            default_outputs = [output_file],
+            sub_targets = sub_targets
+        )
+    ]
+
+def cmake_embedding_impl(ctx: AnalysisContext) -> list[Provider]:
+    return [
+        DefaultInfo(),
+        CMakeEmbeddedFileInfo(
+            files = ctx.attrs.files,
+            prefix = ctx.attrs.prefix,
+            suffix = ctx.attrs.suffix,
+            item_prefix = ctx.attrs.item_prefix,
+            item_suffix = ctx.attrs.item_suffix,
+            delimiter = ctx.attrs.delimiter,
+            trailing_delimiter = ctx.attrs.trailing_delimiter
+        )
+    ]
+
+def cmake_substitution_impl(ctx: AnalysisContext) -> list[Provider]:
+    return _cmake_substitution_impl_internal(ctx.attrs.name, ctx.attrs.value)
+
+def cmake_type_size_substitution_impl(ctx: AnalysisContext) -> list[Provider]:
+    name = ctx.attrs.name
+    size = ctx.attrs.value[CcTestTypeSizeInfo].size
+    return _cmake_substitution_impl_internal(f"{name}_CODE", f"#define {name} {size}")
+

--- a/prelude/cxx/tools/BUCK
+++ b/prelude/cxx/tools/BUCK
@@ -19,6 +19,12 @@ prelude.python_bootstrap_binary(
 )
 
 prelude.python_bootstrap_binary(
+    name = "expand_cmake_template",
+    main = "expand_cmake_template.py",
+    visibility = ["PUBLIC"],
+)
+
+prelude.python_bootstrap_binary(
     name = "hmap_wrapper.py",
     main = "hmap_wrapper.py",
 )

--- a/prelude/cxx/tools/expand_cmake_template.py
+++ b/prelude/cxx/tools/expand_cmake_template.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+"""
+A compatibility layer for cmake to buck2 migration that expands a template file with substitutions
+Supports the following expansions:
+ - @substitution@ -> value
+ - #cmakedefine substitution -> #define substitution
+ - #cmakedefine01 substitution -> #define substitution 1 or #define substitution 0
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+import json
+import re
+import logging
+import sys
+from typing import Union
+
+at_replace = re.compile(r"(@\w+@)")
+variable_replace = re.compile(r"(\${\w+})")
+regex_cmakedefine = re.compile(r"#cmakedefine (\w+)(?:\s+(.+))?")
+cmakedefine01 = re.compile(r"#cmakedefine01 (\w+)")
+
+substitutions_encountered_in_template = set()
+
+
+def load_file(path:str) -> str:
+    with open(path) as fp:
+        return fp.read()
+    
+def resolve_one_embedding(json_spec:dict) -> str:
+    result = ""
+    result += json_spec["prefix"]
+    file_contents = [
+        json_spec["item_prefix"] + load_file(file) + json_spec["item_suffix"] for file in json_spec["files"]
+    ]
+    concatenated_contents = json_spec["delimiter"].join(file_contents)
+    if json_spec["trailing_delimiter"]:
+            concatenated_contents += json_spec["delimiter"]
+    result += concatenated_contents
+
+    result += json_spec["suffix"]
+    return result
+
+def resolve_all_embeddings(substitutions:list[str]) -> dict[str, str]:
+    embedding_specs = {}
+    for spec_file in substitutions:
+        with open(spec_file) as fp:
+            spec = json.load(fp)
+        label = spec["label"]
+        embedding = resolve_one_embedding(spec)
+        embedding_specs[label] = embedding
+
+    return embedding_specs
+
+
+
+def read_substitutions(substitution_file: str) -> dict[str, Union[int,str,bool,None]]:
+    substitutions = []
+    with open(substitution_file) as f:
+        return json.load(f)
+
+def prepare_substitutions(key_value_pairs: list[str], escape_quotes: bool) -> dict[str, Union[int,str,bool,None]]:
+    substitutions = {}
+    for s in key_value_pairs:
+        k, v = s.split("=")
+        if escape_quotes:
+            v = v.replace('"', '\\"')
+        substitutions[k] = v
+    return substitutions
+
+def perform_substitutions(
+        input: list[str],
+        substitutions: dict[str, Union[int,bool,str,None]],
+        copy_only: bool,
+        at_replacements: bool,
+        var_replacements: bool,
+        embeddings: list[str]) -> list[str]:
+    
+    resolved_embeddings = resolve_all_embeddings(embeddings)
+
+    formatted = []
+    substitutions.update(resolved_embeddings)
+    for line in input:
+        line = line.rstrip("\r\n")
+
+        if not copy_only:
+            if at_replacements:
+                line = substitute_at_replace(line, substitutions)
+
+            if var_replacements:
+                line = substitute_variable_replace(line, substitutions)
+
+            line = substitute_cmakedefine(line, substitutions)
+            line = substitute_cmakedefine01(line, substitutions)
+            
+        formatted.append(line + "\n")
+    return formatted
+
+def get_substitution_value(key:str, substitutions: dict[str, Union[int, str, bool, None]], default=None):
+    substitutions_encountered_in_template.add(key)
+    return substitutions.get(key, default)
+
+def substitute_at_replace(line: str, substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    return re.sub(at_replace, lambda m: __at_replace_impl(m, substitutions), line)
+
+def __at_replace_impl(match: re.Match[str], substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    key = match.group(1).strip("@")
+
+    value = get_substitution_value(key, substitutions, "")
+    if value:
+        return str(value)
+    return ""
+
+ 
+def substitute_variable_replace(line: str, substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    return re.sub(variable_replace, lambda m: __variable_replace_impl(m, substitutions), line)
+
+def __variable_replace_impl(match: re.Match[str], substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    key = match.group(1)
+    key = key[2:-1]
+
+    value = get_substitution_value(key, substitutions)
+    if value:
+        return str(value)
+    return ""
+
+def substitute_cmakedefine(line: str, substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    return re.sub(regex_cmakedefine, lambda m: __cmakedefine_impl(m, substitutions), line).rstrip()
+
+def _is_value_false_like(value:Union[str,int,bool,None]) -> bool:
+    if not value:
+        return True
+    if isinstance(value, str) and value.lower() in ['0', 'false', 'off', '']:
+        return True
+    return False
+
+def __cmakedefine_impl(match: re.Match[str], substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    groups = match.groups()
+
+    # Support both of the following forms:
+    #    #cmakedefine KEY
+    #    #cmakedefine KEY VALUE
+    key = groups[0]
+    substitute_value = None
+    if len(groups) >= 2:
+        substitute_value = groups[1]
+
+    template_value = get_substitution_value(key, substitutions)
+    
+    if _is_value_false_like(template_value):
+        return f"/* #undef {key} */"
+    
+    result = f"#define {key}"
+    if substitute_value:
+        result += f" {substitute_value}"
+    return result
+
+def substitute_cmakedefine01(line: str, substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    return re.sub(cmakedefine01, lambda m: __cmakedefine01_impl(m, substitutions), line)
+
+def __cmakedefine01_impl(match: re.Match[str], substitutions: dict[str, Union[int, str, bool, None]]) -> str:
+    key = match.group(1)
+    value = get_substitution_value(key, substitutions)
+    if _is_value_false_like(value):
+        return f"#define {key} 0"
+    else:
+        return f"#define {key} 1"
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", required=True)
+    parser.add_argument("-o", "--output", required=True)
+    parser.add_argument(
+        "--strict",
+        action='store_true',
+        required=False,
+        default=False,
+        help="Fail on missing & unused substitutions",
+    )
+    parser.add_argument(
+        "-s",
+        "--substitutions",
+        required=False,
+        default=[],
+        help="Substitutions as key=value pairs to make in the template file",
+        nargs="*",
+    )
+    parser.add_argument(
+        "-e",
+        "--embeddings",
+        required=False,
+        default=[],
+        help="File substitutions as json",
+        nargs="*"
+    )
+
+    parser.add_argument(
+        "--substitution-file",
+        required=False,
+        default=None,
+        help="File containing key=value pairs to make in the template file",
+    )
+    parser.add_argument(
+        "--enable-at-replacements",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Perform @var@ substitution",
+    )
+    parser.add_argument(
+        "--enable-var-replacements",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Perform ${var} substitution",
+    )
+    parser.add_argument(
+        "--escape-quotes",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Escape any substituted quotes with backslashes (C-style).",
+    )
+    parser.add_argument(
+        "--copy-only",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Only copy the input file to the output file",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Configure the logging level.",
+    )
+    
+    args = parser.parse_args()
+    logging.getLogger().setLevel(args.log_level)
+
+    with open(args.input) as f:
+        template = f.readlines()
+
+    if args.substitution_file:
+        substitutions = read_substitutions(args.substitution_file)
+    else:
+        substitutions = prepare_substitutions(args.substitutions, escape_quotes=args.escape_quotes)
+
+    formatted = perform_substitutions(
+        template, 
+        substitutions=substitutions,
+        at_replacements=args.enable_at_replacements,
+        var_replacements=args.enable_var_replacements,
+        embeddings=args.embeddings,
+        copy_only=args.copy_only)
+    
+    if args.strict:
+        unused_substitutions = set(substitutions.keys()).difference(substitutions_encountered_in_template)
+        missing_substitutions = substitutions_encountered_in_template.difference(substitutions.keys())
+
+        fail = False
+        if unused_substitutions:
+            fail = True
+            print(f"Found {len(unused_substitutions)} unused substitutions:")
+            for s in unused_substitutions:
+                print(f"    * {s}")
+
+        if missing_substitutions:
+            fail = True
+            print(f"Encountered {len(missing_substitutions)} substitutions in the template file with no corresponding replacement given:")
+            for s in missing_substitutions:
+                print(f"    * {s}")
+
+        if fail:
+            sys.exit(1)
+
+    if args.output is not None:
+        output = Path(args.output)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with open(output, "w") as f:
+            f.writelines(formatted)

--- a/prelude/rules_impl.bzl
+++ b/prelude/rules_impl.bzl
@@ -25,6 +25,8 @@ load("@prelude//configurations:rules.bzl", _config_extra_attributes = "extra_att
 load("@prelude//csharp:csharp.bzl", "csharp_library_impl", "prebuilt_dotnet_library_impl")
 load("@prelude//cxx:bitcode.bzl", "llvm_link_bitcode_impl")
 load("@prelude//cxx:cuda.bzl", "CudaCompileStyle")
+load("@prelude//cxx:cctest.bzl", "cctest_map_value_impl", "cctest_type_exists_impl", "cctest_type_size_impl", "cctest_value_impl")
+load("@prelude//cxx:cmake.bzl", "cmake_configure_file_impl", "cmake_embedding_impl", "cmake_substitution_impl", "cmake_type_size_substitution_impl")
 load("@prelude//cxx:cxx.bzl", "cxx_binary_impl", "cxx_library_impl", "cxx_precompiled_header_impl", "cxx_test_impl", "prebuilt_cxx_library_impl")
 load("@prelude//cxx:cxx_toolchain.bzl", "cxx_toolchain_extra_attributes", "cxx_toolchain_impl")
 load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxPlatformInfo", "CxxToolchainInfo")
@@ -184,6 +186,14 @@ extra_implemented_rules = struct(
     prebuilt_dotnet_library = prebuilt_dotnet_library_impl,
 
     #c++
+    cctest_map_value = cctest_map_value_impl,
+    cctest_value = cctest_value_impl,
+    cctest_type_exists = cctest_type_exists_impl,
+    cctest_type_size = cctest_type_size_impl,
+    cmake_configure_file = cmake_configure_file_impl,
+    cmake_embedding = cmake_embedding_impl,
+    cmake_substitution = cmake_substitution_impl,
+    cmake_type_size_substitution = cmake_type_size_substitution_impl,
     cxx_binary = cxx_binary_impl,
     cxx_test = cxx_test_impl,
     cxx_toolchain = cxx_toolchain_impl,


### PR DESCRIPTION
This adds a set of rules that implement CMake `configure_file()` semantics, significantly easing the burden of integrating libraries that use CMake (or other configure-like systems) into buck builds.

Typically, such build systems will run a step before the build begins that determines values for all of the things it considers important.  Then it will output a header file (or otherwise modify the build in some way, for example by adding preprocessor defines) that contains preprocessor defines, typedefs etc that contain definitions based on the values that were determined earlier.

There are two basic categories of meta-rules implemented in this PR, and then one "real" rule that does the actual work.

**cctest rules** hardcode values about your toolchain that would otherwise be computed by something like autoconf, configure, or CMake itself.  For example, these systems may try to detect whether or not your toolchain has `ssize_t` defined, or the size of an integer.  These systems do this by compiling small little programs and examining the output to determine what happened.  This approach is flexible, but it is non-hermetic and necessarily requires a configure step.   Hermetic build systems -- by definition -- know everything about the build environment.  These rules do not have any outputs, and simply provide a way to encode the known values into build targets that can be used by the next category of rules: **substitution rules**.

**substitution rules** define mappings between variable names that might appear in the substitution file, and values that were previously encoded in the form of **cctest rules**.  To explain why this distinction is needed, consider two libraries, both of whom need to detect whether `ssize_t` exists on your system.  One library expect its configured header file to have a line of the form:

```
#define HAVE_SSIZE_T
```

while the other may expect to have a line of the form:

```
#define HAVE_BUILTIN_TYPE_SSIZE_T
```

Whether or not `ssize_t` exists is a universal truth, but the libraries expect to consume that information through different ways.  So we need one set of rules (**cctest rules**) to encode the universally known values, and another set of rules (**substitution rules**) to define the library-specific mappings.

Finally, we have the `cmake_configure_file` rule which accepts a list of substitutions and will perform the generation.