### PR TITLE
Add support for bytestream compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ anymap3 = "1.0.1"
 arc-swap = "1.6.0"
 argfile = "0.2"
 assert_matches = "1.5"
-async-compression = { version = "0.4.1", features = ["tokio", "gzip", "zstd"] }
+async-compression = { version = "0.4.1", features = ["tokio", "brotli", "deflate", "gzip", "zstd"] }
 async-condvar-fair = { version = "1.0", features = ["parking_lot_0_11", "tokio"] }
 async-recursion = "1.0"
 async-scoped = { version = "0.9", features = ["use-tokio"] }

--- a/remote_execution/oss/re_grpc/Cargo.toml
+++ b/remote_execution/oss/re_grpc/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = { workspace = true }
+async-compression = { workspace = true }
 dupe = { workspace = true }
 futures = { workspace = true }
 gazebo = { workspace = true }
@@ -19,9 +20,12 @@ prost-types = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+zstd = { workspace = true }
 
 buck2_re_configuration = { workspace = true }
 buck2_util = { workspace = true }

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -10,6 +10,8 @@
 
 use std::collections::HashMap;
 use std::env::VarError;
+use std::io;
+use std::io::Cursor;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -18,6 +20,12 @@ use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::Context;
+use async_compression::tokio::bufread::BrotliDecoder;
+use async_compression::tokio::bufread::BrotliEncoder;
+use async_compression::tokio::bufread::DeflateDecoder;
+use async_compression::tokio::bufread::DeflateEncoder;
+use async_compression::tokio::bufread::ZstdDecoder;
+use async_compression::tokio::bufread::ZstdEncoder;
 use buck2_re_configuration::Buck2OssReConfiguration;
 use buck2_re_configuration::HttpHeader;
 use dupe::Dupe;
@@ -69,9 +77,13 @@ use re_grpc_proto::google::rpc::Code;
 use re_grpc_proto::google::rpc::Status;
 use regex::Regex;
 use tokio::fs::OpenOptions;
+use tokio::io::AsyncBufRead;
+use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
 use tokio::sync::broadcast;
+use tokio_util::io::StreamReader;
 use tonic::codegen::InterceptedService;
 use tonic::metadata;
 use tonic::metadata::MetadataKey;
@@ -222,6 +234,8 @@ pub struct RECapabilities {
     max_total_batch_size: usize,
     /// Does the remote server support execution.
     exec_enabled: bool,
+    /// Compressors supported by the "compressed-blobs" bytestream resources.
+    supported_compressors: Vec<Compressor>,
 }
 
 /// Contains runtime options for the remote execution client as set under `buck2_re_client`
@@ -248,6 +262,35 @@ impl InstanceName {
         match &self.0 {
             Some(instance_name) => format!("{instance_name}/"),
             None => "".to_owned(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum Compressor {
+    Zstd,
+    Deflate,
+    Brotli,
+}
+
+impl Compressor {
+    fn from_grpc(val: i32) -> Option<Self> {
+        // TODO: brotli cannot be supported until google proto definitions are updated
+        if val == compressor::Value::Zstd as i32 {
+            Some(Self::Zstd)
+        } else if val == compressor::Value::Deflate as i32 {
+            Some(Self::Deflate)
+        } else {
+            None
+        }
+    }
+
+    /// The compressor name used in compressed-blob resource paths
+    fn name(&self) -> &str {
+        match self {
+            Self::Zstd => "zstd",
+            Self::Deflate => "deflate",
+            Self::Brotli => "brotli",
         }
     }
 }
@@ -328,6 +371,7 @@ impl REClientBuilder {
             RECapabilities {
                 exec_enabled: true,
                 max_total_batch_size: DEFAULT_MAX_TOTAL_BATCH_SIZE,
+                supported_compressors: Vec::new(),
             }
         };
 
@@ -344,6 +388,22 @@ impl REClientBuilder {
                 "Attribute `max_decoding_message_size` must always be equal or higher to `max_total_batch_size`"
             ));
         }
+
+        // Choose a ByteStream compressor
+        // TODO: brotli cannot be supported until google proto definitions are updated
+        let bystream_compressor = if capabilities
+            .supported_compressors
+            .contains(&Compressor::Zstd)
+        {
+            Some(Compressor::Zstd)
+        } else if capabilities
+            .supported_compressors
+            .contains(&Compressor::Deflate)
+        {
+            Some(Compressor::Deflate)
+        } else {
+            None
+        };
 
         let grpc_clients = GRPCClients {
             cas_client: ContentAddressableStorageClient::with_interceptor(
@@ -377,6 +437,7 @@ impl REClientBuilder {
             grpc_clients,
             capabilities,
             instance_name,
+            bystream_compressor,
         ))
     }
 
@@ -396,6 +457,17 @@ impl REClientBuilder {
             .into_inner();
 
         let mut exec_enabled = true;
+
+        let supported_compressors = if let Some(cache_cap) = &resp.cache_capabilities {
+            cache_cap
+                .supported_compressors
+                .iter()
+                .cloned()
+                .filter_map(Compressor::from_grpc)
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         let max_total_batch_size_from_capabilities: Option<usize> =
             if let Some(cache_cap) = resp.cache_capabilities {
@@ -421,6 +493,7 @@ impl REClientBuilder {
         Ok(RECapabilities {
             max_total_batch_size,
             exec_enabled,
+            supported_compressors,
         })
     }
 }
@@ -549,6 +622,7 @@ pub struct REClient {
     instance_name: InstanceName,
     // buck2 calls find_missing for same blobs
     find_missing_cache: Mutex<FindMissingCache>,
+    bystream_compressor: Option<Compressor>,
 }
 
 impl Drop for REClient {
@@ -589,6 +663,12 @@ impl BatchUploadReqAggregator {
             BatchUploadRequest::Blob(blob) => blob.digest.size_in_bytes,
             BatchUploadRequest::File(file) => file.digest.size_in_bytes,
         };
+
+        // As an optimization, we can silently skip uploading empty blobs
+        if size_in_bytes == 0 {
+            return;
+        }
+
         self.curr_request_size += size_in_bytes;
 
         if self.curr_request_size >= self.max_msg_size {
@@ -612,6 +692,7 @@ impl REClient {
         grpc_clients: GRPCClients,
         capabilities: RECapabilities,
         instance_name: InstanceName,
+        bystream_compressor: Option<Compressor>,
     ) -> Self {
         REClient {
             runtime_opts,
@@ -623,6 +704,7 @@ impl REClient {
                 ttl: Duration::from_secs(12 * 60 * 60), // 12 hours TODO: Tune this parameter
                 last_check: Instant::now(),
             }),
+            bystream_compressor,
         }
     }
 
@@ -808,6 +890,7 @@ impl REClient {
         upload_impl(
             &self.instance_name,
             request,
+            self.bystream_compressor,
             self.capabilities.max_total_batch_size,
             self.runtime_opts.max_concurrent_uploads_per_action,
             |re_request| async {
@@ -873,6 +956,7 @@ impl REClient {
         download_impl(
             &self.instance_name,
             request,
+            self.bystream_compressor,
             self.capabilities.max_total_batch_size,
             |re_request| async {
                 let metadata = metadata.clone();
@@ -1250,25 +1334,41 @@ fn convert_t_action_result2(t_action_result: TActionResult2) -> anyhow::Result<A
 async fn download_impl<Byt, BytRet, Cas>(
     instance_name: &InstanceName,
     request: DownloadRequest,
+    bystream_compressor: Option<Compressor>,
     max_total_batch_size: usize,
     cas_f: impl Fn(BatchReadBlobsRequest) -> Cas,
     bystream_fut: impl Fn(ReadRequest) -> Byt + Sync + Send + Copy,
 ) -> anyhow::Result<DownloadResponse>
 where
     Byt: Future<Output = anyhow::Result<Pin<Box<BytRet>>>>,
-    BytRet: Stream<Item = Result<ReadResponse, tonic::Status>>,
+    BytRet: Stream<Item = Result<ReadResponse, tonic::Status>> + Send,
     Cas: Future<Output = anyhow::Result<BatchReadBlobsResponse>>,
 {
-    let bystream_fut = |digest: TDigest| async move {
-        let hash = digest.hash;
-        let size_in_bytes = digest.size_in_bytes;
+    fn resource_name(
+        instance_name: &InstanceName,
+        compressor: Option<Compressor>,
+        digest: &TDigest,
+    ) -> String {
+        if let Some(compressor) = compressor {
+            format!(
+                "{}compressed-blobs/{}/{}/{}",
+                instance_name.as_resource_prefix(),
+                compressor.name(),
+                digest.hash,
+                digest.size_in_bytes,
+            )
+        } else {
+            format!(
+                "{}blobs/{}/{}",
+                instance_name.as_resource_prefix(),
+                digest.hash,
+                digest.size_in_bytes,
+            )
+        }
+    }
 
-        let resource_name = format!(
-            "{}blobs/{}/{}",
-            instance_name.as_resource_prefix(),
-            hash,
-            size_in_bytes
-        );
+    let bystream_fut = |digest: TDigest| async move {
+        let resource_name = resource_name(&instance_name, bystream_compressor, &digest);
 
         bystream_fut(ReadRequest {
             resource_name: resource_name.clone(),
@@ -1276,6 +1376,21 @@ where
             read_limit: 0,
         })
         .await
+        // adapt the tokio Stream of ReadResponse into a StreamReader
+        .map(|p| {
+            let blob_reader = StreamReader::new(
+                p.map(|r| r.map(|rr| Cursor::new(rr.data)).map_err(io::Error::other)),
+            );
+            // Wrap the blob reader in a compression reader
+            let reader: Pin<Box<dyn AsyncRead + Unpin + Send>> = match bystream_compressor {
+                None => Pin::new(Box::new(blob_reader)),
+                Some(Compressor::Zstd) => Pin::new(Box::new(ZstdDecoder::new(blob_reader))),
+                Some(Compressor::Deflate) => Pin::new(Box::new(DeflateDecoder::new(blob_reader))),
+                Some(Compressor::Brotli) => Pin::new(Box::new(BrotliDecoder::new(blob_reader))),
+            };
+
+            reader
+        })
         .with_context(|| format!("Failed to read {resource_name} from Bytestream service"))
     };
 
@@ -1346,13 +1461,8 @@ where
     for digest in inlined_digests {
         let data = if digest.size_in_bytes as usize >= max_total_batch_size {
             let mut accum = vec![];
-            let mut responses = bystream_fut(digest.clone()).await?;
-            while let Some(resp) = responses.next().await {
-                let data = resp
-                    .with_context(|| format!("Failed to fetch inline digest: {digest}"))?
-                    .data;
-                accum.extend_from_slice(&data);
-            }
+            let mut reader = bystream_fut(digest.clone()).await?;
+            tokio::io::copy(&mut reader, &mut accum).await?;
             accum
         } else {
             get(&digest)?
@@ -1391,15 +1501,12 @@ where
                     .await
                     .with_context(|| format!("Error writing: {}", req.named_digest.digest))?;
             } else {
-                let mut responses = bystream_fut(req.named_digest.digest.clone()).await?;
-                while let Some(resp) = responses.next().await {
-                    let data = resp
-                        .with_context(|| format!("Failed to fetch file: {file:?}"))?
-                        .data;
-                    file.write_all(&data).await.with_context(|| {
+                let mut reader = bystream_fut(req.named_digest.digest.clone()).await?;
+                tokio::io::copy(&mut reader, &mut file)
+                    .await
+                    .with_context(|| {
                         format!("Error writing chunk of: {}", req.named_digest.digest)
                     })?;
-                }
             }
             file.flush().await.context("Error flushing")?;
             anyhow::Ok(())
@@ -1424,6 +1531,7 @@ where
 async fn upload_impl<Byt, Cas>(
     instance_name: &InstanceName,
     request: UploadRequest,
+    bystream_compressor: Option<Compressor>,
     max_total_batch_size: usize,
     max_concurrent_uploads: Option<usize>,
     cas_f: impl Fn(BatchUpdateBlobsRequest) -> Cas + Sync + Send + Copy,
@@ -1433,12 +1541,82 @@ where
     Cas: Future<Output = anyhow::Result<BatchUpdateBlobsResponse>> + Send,
     Byt: Future<Output = anyhow::Result<WriteResponse>> + Send,
 {
+    fn resource_name(
+        instance_name: &InstanceName,
+        client_uuid: &str,
+        compressor: Option<Compressor>,
+        digest: &TDigest,
+    ) -> String {
+        if let Some(compressor) = compressor {
+            format!(
+                "{}uploads/{}/compressed-blobs/{}/{}/{}",
+                instance_name.as_resource_prefix(),
+                client_uuid,
+                compressor.name(),
+                digest.hash,
+                digest.size_in_bytes,
+            )
+        } else {
+            format!(
+                "{}uploads/{}/blobs/{}/{}",
+                instance_name.as_resource_prefix(),
+                client_uuid,
+                digest.hash,
+                digest.size_in_bytes,
+            )
+        }
+    }
+
     // NOTE if we stop recording blob_hashes, we can drop out a lot of allocations.
     let mut upload_futures: Vec<BoxFuture<anyhow::Result<Vec<String>>>> = vec![];
 
     // For small file uploads the client should group them together and call `BatchUpdateBlobs`
     // https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L205
     let mut batched_blob_updates = BatchUploadReqAggregator::new(max_total_batch_size);
+
+    // Adapt the given bystream_fut to take in an AsyncBufRead
+    let bystream_fut = |resource_name: String, reader: Box<dyn AsyncBufRead + Unpin + Send>| async move {
+        let mut reader: Pin<Box<dyn AsyncRead + Unpin + Send>> = match bystream_compressor {
+            None => Pin::new(Box::new(reader)),
+            Some(Compressor::Zstd) => Pin::new(Box::new(ZstdEncoder::new(reader))),
+            Some(Compressor::Deflate) => Pin::new(Box::new(DeflateEncoder::new(reader))),
+            Some(Compressor::Brotli) => Pin::new(Box::new(BrotliEncoder::new(reader))),
+        };
+
+        let mut current_offset = 0;
+        let mut upload_segments = Vec::new();
+        let mut buf = vec![0; max_total_batch_size];
+        loop {
+            let n_read = reader.read(&mut buf).await.unwrap();
+            if n_read == 0 {
+                break;
+            }
+            upload_segments.push(WriteRequest {
+                resource_name: resource_name.clone(),
+                write_offset: current_offset,
+                finish_write: false,
+                data: buf[0..n_read].to_vec(),
+            });
+            current_offset += n_read as i64;
+        }
+        if let Some(last_segment) = upload_segments.last_mut() {
+            last_segment.finish_write = true;
+        }
+
+        if upload_segments.is_empty() {
+            // As an optimization, we can silently skip uploading empty blobs
+            return Ok(());
+        }
+
+        let response = bystream_fut(upload_segments).await?;
+        if response.committed_size != current_offset && response.committed_size != -1 {
+            anyhow::bail!(
+                "Failed to upload `{resource_name}`: invalid committed_size from WriteResponse"
+            );
+        }
+
+        Ok(())
+    };
 
     // Create futures for any blobs that need uploading.
     for blob in request.inlined_blobs_with_digest.unwrap_or_default() {
@@ -1452,32 +1630,14 @@ where
 
         let data = blob.blob;
         let client_uuid = uuid::Uuid::new_v4().to_string();
-        let resource_name = format!(
-            "{}uploads/{}/blobs/{}/{}",
-            instance_name.as_resource_prefix(),
-            client_uuid,
-            hash,
-            size
+        let resource_name = resource_name(
+            &instance_name,
+            &client_uuid,
+            bystream_compressor,
+            &blob.digest,
         );
         let fut = async move {
-            // Number of complete (non-partial) messages
-            let mut upload_segments = vec![];
-            for (i, chunk) in data.chunks(max_total_batch_size).enumerate() {
-                upload_segments.push(WriteRequest {
-                    resource_name: resource_name.to_owned(),
-                    write_offset: (i * max_total_batch_size) as i64,
-                    finish_write: false,
-                    data: chunk.to_owned(),
-                });
-            }
-            upload_segments.last_mut().unwrap().finish_write = true;
-
-            let resp = bystream_fut(upload_segments).await?;
-            if resp.committed_size != size {
-                return Err(anyhow::anyhow!(
-                    "Failed to upload inline blob: invalid committed_size from WriteResponse"
-                ));
-            }
+            bystream_fut(resource_name, Box::new(Cursor::new(data))).await?;
 
             Ok(vec![hash])
         };
@@ -1494,48 +1654,19 @@ where
             continue;
         }
         let client_uuid = uuid::Uuid::new_v4().to_string();
-        let resource_name = format!(
-            "{}uploads/{}/blobs/{}/{}",
-            instance_name.as_resource_prefix(),
-            client_uuid,
-            hash.clone(),
-            size
+        let resource_name = resource_name(
+            &instance_name,
+            &client_uuid,
+            bystream_compressor,
+            &file.digest,
         );
+
         let fut = async move {
-            let mut file = tokio::fs::File::open(&name)
+            let file = tokio::fs::File::open(&name)
                 .await
                 .with_context(|| format!("Opening `{name}` for reading failed"))?;
-            let mut data = vec![0; max_total_batch_size];
 
-            let mut write_offset = 0;
-            let mut upload_segments = Vec::new();
-            loop {
-                let length = file
-                    .read(&mut data)
-                    .await
-                    .with_context(|| format!("Error reading from {name}"))?;
-                if length == 0 {
-                    break;
-                }
-                upload_segments.push(WriteRequest {
-                    resource_name: resource_name.to_owned(),
-                    write_offset,
-                    finish_write: false,
-                    data: data[..length].to_owned(),
-                });
-                write_offset += length as i64;
-            }
-            upload_segments
-                .last_mut()
-                .with_context(|| format!("Read no segments from `{name} "))?
-                .finish_write = true;
-
-            let resp = bystream_fut(upload_segments).await?;
-            if resp.committed_size != size {
-                return Err(anyhow::anyhow!(
-                    "Failed to upload `{name}`: invalid committed_size from WriteResponse"
-                ));
-            }
+            bystream_fut(resource_name, Box::new(BufReader::new(file))).await?;
             Ok(vec![hash])
         };
         upload_futures.push(Box::pin(fut));
@@ -1806,6 +1937,7 @@ mod tests {
         download_impl(
             &InstanceName(None),
             req,
+            None,
             10000,
             |req| {
                 let res = res.clone();
@@ -1912,6 +2044,7 @@ mod tests {
         download_impl(
             &InstanceName(None),
             req,
+            None,
             10, // kept small to simulate a large file download
             |req| {
                 let res = res.clone();
@@ -1993,6 +2126,7 @@ mod tests {
         let res = download_impl(
             &InstanceName(None),
             req,
+            None,
             100000,
             |req| {
                 let res = res.clone();
@@ -2079,6 +2213,7 @@ mod tests {
         let res = download_impl(
             &InstanceName(None),
             req,
+            None,
             7,
             |req| {
                 counter.fetch_add(1, Ordering::Relaxed);
@@ -2147,6 +2282,7 @@ mod tests {
         let res = download_impl(
             &InstanceName(None),
             req,
+            None,
             10, // intentionally small value to keep data in the test blobs small
             |req| {
                 let res = res.clone();
@@ -2202,6 +2338,7 @@ mod tests {
         let res = download_impl(
             &InstanceName(None),
             req,
+            None,
             100000,
             |req| {
                 let res = res.clone();
@@ -2240,6 +2377,7 @@ mod tests {
         download_impl(
             &InstanceName(Some("instance".to_owned())),
             req,
+            None,
             0,
             |_req| async { panic!("not called") },
             |req| async move {
@@ -2309,6 +2447,7 @@ mod tests {
         upload_impl(
             &InstanceName(None),
             req,
+            None,
             10000,
             None,
             |req| {
@@ -2392,6 +2531,7 @@ mod tests {
         upload_impl(
             &InstanceName(None),
             req,
+            None,
             10, // kept small to simulate a large file upload
             None,
             |req| {
@@ -2466,6 +2606,7 @@ mod tests {
         upload_impl(
             &InstanceName(None),
             req,
+            None,
             10, // kept small to simulate a large inlined upload
             None,
             |req| {
@@ -2527,6 +2668,7 @@ mod tests {
         let resp: Result<UploadResponse, anyhow::Error> = upload_impl(
             &InstanceName(None), // TODO
             req,
+            None,
             10,
             None,
             |_req| async move {
@@ -2588,6 +2730,7 @@ mod tests {
         upload_impl(
             &InstanceName(None),
             req,
+            None,
             3,
             None,
             |_req| async move {
@@ -2617,31 +2760,62 @@ mod tests {
             ..Default::default()
         };
 
-        let req = UploadRequest {
-            files_with_digest: Some(vec![NamedDigest {
-                name: path1.to_owned(),
-                digest: digest1.clone(),
-                ..Default::default()
-            }]),
-            ..Default::default()
-        };
-
-        let res = upload_impl(
-            &InstanceName(None),
-            req,
-            0,
+        for compressor in [
             None,
-            |_req| async move {
-                panic!("Not called");
-            },
-            |_write_reqs| async move {
-                panic!("Not called");
-            },
-        )
-        .await;
+            Some(Compressor::Deflate),
+            Some(Compressor::Brotli),
+            Some(Compressor::Zstd),
+        ] {
+            assert!(
+                upload_impl(
+                    &InstanceName(None),
+                    UploadRequest {
+                        files_with_digest: Some(vec![NamedDigest {
+                            name: path1.to_owned(),
+                            digest: digest1.clone(),
+                            ..Default::default()
+                        }]),
+                        ..Default::default()
+                    },
+                    compressor,
+                    0, // max_total_batch_size=0 forces bytestream API
+                    None,
+                    |_req| async move {
+                        panic!("Not called");
+                    },
+                    |_write_reqs| async move {
+                        panic!("Not called");
+                    },
+                )
+                .await
+                .is_ok()
+            );
 
-        assert!(res.is_err()); // Should not panic.
-
+            assert!(
+                upload_impl(
+                    &InstanceName(None),
+                    UploadRequest {
+                        files_with_digest: Some(vec![NamedDigest {
+                            name: path1.to_owned(),
+                            digest: digest1.clone(),
+                            ..Default::default()
+                        }]),
+                        ..Default::default()
+                    },
+                    compressor,
+                    1024, // forces the batch API
+                    None,
+                    |_req| async move {
+                        panic!("Not called");
+                    },
+                    |_write_reqs| async move {
+                        panic!("Not called");
+                    },
+                )
+                .await
+                .is_ok()
+            );
+        }
         Ok(())
     }
 
@@ -2675,6 +2849,7 @@ mod tests {
         upload_impl(
             &InstanceName(Some("instance".to_owned())),
             req,
+            None,
             1,
             None,
             |_req| async move {
@@ -2684,6 +2859,57 @@ mod tests {
                 assert!(write_reqs[0].resource_name.starts_with("instance/uploads/"));
                 assert!(write_reqs[0].resource_name.ends_with("/blobs/aa/3"));
                 anyhow::Ok(WriteResponse { committed_size: 3 })
+            },
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_upload_resource_name_compressed() -> anyhow::Result<()> {
+        let digest1 = TDigest {
+            hash: "aa".to_owned(),
+            size_in_bytes: 3,
+            ..Default::default()
+        };
+        let work = tempfile::tempdir()?;
+
+        let path1 = work.path().join("path1");
+        let path1 = path1.to_str().context("tempdir is not utf8")?;
+        tokio::fs::write(path1, "aaa").await?;
+
+        let req = UploadRequest {
+            inlined_blobs_with_digest: Some(vec![InlinedBlobWithDigest {
+                digest: digest1.clone(),
+                blob: b"aaa".to_vec(),
+                ..Default::default()
+            }]),
+            files_with_digest: Some(vec![NamedDigest {
+                name: path1.to_owned(),
+                digest: digest1.clone(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+
+        upload_impl(
+            &InstanceName(Some("instance".to_owned())),
+            req,
+            Some(Compressor::Zstd),
+            1,
+            None,
+            |_req| async move {
+                panic!("Not called");
+            },
+            |write_reqs| async move {
+                assert!(write_reqs[0].resource_name.starts_with("instance/uploads/"));
+                assert!(
+                    write_reqs[0]
+                        .resource_name
+                        .ends_with("/compressed-blobs/zstd/aa/3")
+                );
+                anyhow::Ok(WriteResponse { committed_size: -1 })
             },
         )
         .await?;
@@ -2716,4 +2942,94 @@ mod tests {
         assert_eq!(substitute_env_vars_impl("FOO", getter).unwrap(), "FOO");
         assert!(substitute_env_vars_impl("$FOO$BAZ", getter).is_err());
     }
+}
+
+#[tokio::test]
+async fn test_upload_compressed() -> anyhow::Result<()> {
+    let blob_data = vec![1; 10 * 1024 * 1024];
+    let digest1 = TDigest {
+        hash: "aa".to_owned(),
+        size_in_bytes: blob_data.len() as i64,
+        ..Default::default()
+    };
+
+    let req = UploadRequest {
+        inlined_blobs_with_digest: Some(vec![InlinedBlobWithDigest {
+            digest: digest1.clone(),
+            blob: blob_data.clone(),
+            ..Default::default()
+        }]),
+        ..Default::default()
+    };
+
+    let blob_data_ref = &blob_data;
+    upload_impl(
+        &InstanceName(Some("instance".to_owned())),
+        req,
+        Some(Compressor::Zstd),
+        1,
+        None,
+        |_req| async move {
+            panic!("Not called");
+        },
+        {
+            |write_reqs| async move {
+                let compressed_data: Vec<u8> =
+                    write_reqs.iter().flat_map(|wr| wr.data.clone()).collect();
+                let mut data = vec![];
+                ZstdDecoder::new(Cursor::new(compressed_data))
+                    .read_to_end(&mut data)
+                    .await
+                    .unwrap();
+                assert_eq!(&data, blob_data_ref);
+                anyhow::Ok(WriteResponse { committed_size: -1 })
+            }
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_download_compressed() -> anyhow::Result<()> {
+    let blob_data = vec![1; 1024];
+
+    let mut compressed_data = vec![];
+    ZstdEncoder::new(Cursor::new(blob_data.clone()))
+        .read_to_end(&mut compressed_data)
+        .await
+        .unwrap();
+    let compressed_data_ref = &compressed_data;
+
+    let d_resp = download_impl(
+        &InstanceName(None),
+        DownloadRequest {
+            inlined_digests: Some(vec![TDigest {
+                hash: "aa".to_owned(),
+                size_in_bytes: blob_data.len() as i64,
+                ..Default::default()
+            }]),
+            file_digests: None,
+            ..Default::default()
+        },
+        Some(Compressor::Zstd),
+        10,
+        |_req| async { panic!("not called") },
+        |_req| async move {
+            Ok(Box::pin(futures::stream::iter(
+                compressed_data_ref
+                    .chunks(10)
+                    .map(|d| Result::Ok(ReadResponse { data: d.to_vec() })),
+            )))
+        },
+    )
+    .await?;
+
+    assert_eq!(
+        d_resp.inlined_blobs.as_ref().unwrap()[0].blob.len(),
+        blob_data.len()
+    );
+    assert_eq!(d_resp.inlined_blobs.unwrap()[0].blob, blob_data);
+    Ok(())
 }


### PR DESCRIPTION
- If capabilities allow, use compression for bytestream API uploads and downloads.

- Uploading zero sized blobs now succeeds silently without uploading anything, when previously it would fail with an error.  This is allowed by the specification of the bazel remote execution API.

- If an upload returns with a committed_size of -1, which indicates the blob has already been uploaded, it is no longer an error.  Previously, it would have been reported as an error.