### PR TITLE
"Action failed": highlight the action in red, not the command

### DIFF
--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -623,6 +623,7 @@ impl StatefulSuperConsoleImpl {
             StyledContent::new(
                 ContentStyle {
                     attributes: Attribute::Bold.into(),
+                    foreground_color: Some(Color::Red),
                     ..Default::default()
                 },
                 format!("Action failed: {action_id}",),
@@ -902,9 +903,9 @@ fn lines_for_command_details(
                     }
                 };
 
-                lines.push(Line::from_iter([Span::new_styled_lossy(
-                    format!("Reproduce locally: `{command}`").with(Color::DarkRed),
-                )]));
+                lines.push(Line::from_iter([Span::new_unstyled_lossy(format!(
+                    "Reproduce locally: `{command}`"
+                ))]));
             }
             Some(Command::RemoteCommand(remote_command)) => {
                 let help_message = if buck2_core::is_open_source() {
@@ -937,9 +938,9 @@ fn lines_for_command_details(
                     }
                 };
 
-                lines.push(Line::from_iter([Span::new_styled_lossy(
-                    format!("Reproduce locally: `{command}`").with(Color::DarkRed),
-                )]));
+                lines.push(Line::from_iter([Span::new_unstyled_lossy(format!(
+                    "Reproduce locally: `{command}`"
+                ))]));
             }
             Some(Command::WorkerCommand(worker_command)) => {
                 let command = worker_command_as_fallback_to_string(worker_command);
@@ -955,9 +956,9 @@ fn lines_for_command_details(
                     }
                 };
 
-                lines.push(Line::from_iter([Span::new_styled_lossy(
-                    format!("Reproduce locally: `{command}`").with(Color::DarkRed),
-                )]));
+                lines.push(Line::from_iter([Span::new_unstyled_lossy(format!(
+                    "Reproduce locally: `{command}`"
+                ))]));
             }
         };
     }


### PR DESCRIPTION
TL;DR: See the end of the description for before/after screenshots. In "Action failed" errors, render the action ID in bold red (not bold white), and render the "Reproduce locally" in white, not dark red. This makes it clear which action failed, which tends to be more useful than the (truncated) command itself.

We've found that when reading Buck2 error output, users often focus on the description of the action that failed ("Local command returned non-zero exit code 1"), which is the first part of the error message that's rendered in red text. Instead, we would like users to look at the name of the action that failed, which is rendered in bold text and often evades notice.

- At the end of a failing Buck2 command, there's a section which recaps the errors encountered ("BUILD FAILED" "Failed to build 'root//src/Model:Model ...'"). This message is very legible and shows the failing target clearly, but users don't always see this message at first. The command may be long-running and the user may be reading output before it has finished, or the user may simply be reading the output top-to-bottom.

- The description of the action that failed (currently rendered in red text) contains supplementary debugging information such as the failing command's exit code. It also prints the failing command (truncated), which is somewhat misleading; because Buck2 rules often invoke builds through layers of wrapper scripts, the failing command is rarely informative (e.g. a `ghc` failure does not show `ghc`, any wrapper script filename, or any source filenames in the truncated command).

  Although truncating the command is a good tradeoff for brevity, it is not the most informative part of the error message.

Therefore, this change makes small adjustments to the styling of action errors:

- The "Action failed" headline is rendered in bold red text, rather than bold white text. This helps draw the user's attention to the name of the action that failed, rather than the command that failed. This is the most important part of the change.

- The reason ("Local command returned non-zero exit code 1") is still rendered in dark red text, as it provides context for _how_ the action failed.

- The "Reproduce locally" line is rendered in white text, rather than dark red text.

- The "stdout:" and "stderr:" sections are only shown if they are non-empty.


# Before

<img width="1896" height="1290" alt="image" src="https://github.com/user-attachments/assets/7ea13e70-f1ce-469a-8147-cb43e3c205f6" />

# After

<img width="1032" height="707" alt="image" src="https://github.com/user-attachments/assets/ad76cb18-7ea9-420a-a0b8-87e531e44735" />
