### PR TITLE
Update the Google protocol definitions

### DIFF
--- a/app/buck2_action_impl/src/actions/impls/run/dep_files.rs
+++ b/app/buck2_action_impl/src/actions/impls/run/dep_files.rs
@@ -324,6 +324,7 @@ impl CommonDigests {
             // Instead of using the digest directly, we could use the constituent digests, or constituent paths
             // which might be useful for debugging.
             arguments: vec![inner_remote_dep_file_key],
+            #[allow(deprecated)]
             platform: Some(re_platform.clone()),
             ..Default::default()
         });

--- a/app/buck2_execute/src/execute/command_executor.rs
+++ b/app/buck2_execute/src/execute/command_executor.rs
@@ -273,6 +273,7 @@ fn re_create_action(
         let mut action_and_blobs = ActionDigestAndBlobsBuilder::new(digest_config);
         let command = RE::Command {
             arguments: worker.init.clone(),
+            #[allow(deprecated)]
             platform: Some(platform.clone()),
             working_directory: working_directory.as_str().to_owned(),
             environment_variables: worker
@@ -305,6 +306,7 @@ fn re_create_action(
 
     let mut command = RE::Command {
         arguments: command_args,
+        #[allow(deprecated)]
         platform: Some(platform),
         working_directory: working_directory.as_str().to_owned(),
         environment_variables: environment
@@ -322,6 +324,7 @@ fn re_create_action(
             for (output, output_type) in outputs {
                 let path = output.as_str().to_owned();
 
+                #[allow(deprecated)]
                 match output_type {
                     OutputType::FileOrDirectory => {
                         command.output_files.push(path.clone());
@@ -336,6 +339,7 @@ fn re_create_action(
             for (output, output_type) in outputs {
                 let path = output.as_str().to_owned();
 
+                #[allow(deprecated)]
                 match output_type {
                     OutputType::FileOrDirectory => {
                         command.output_files.push(path);
@@ -437,6 +441,7 @@ fn re_create_action(
 
     Ok(PreparedAction {
         action_and_blobs,
+        #[allow(deprecated)]
         platform: command
             .platform
             .expect("We did put a platform a few lines up"),

--- a/app/buck2_execute_impl/src/executors/empty_action_result.rs
+++ b/app/buck2_execute_impl/src/executors/empty_action_result.rs
@@ -35,6 +35,7 @@ pub(crate) fn empty_action_result(
             // Random string for xbgs.
             "EMPTY_ACTION_RESULT_fztiucvwawdmarhheqoz".to_owned(),
         ],
+        #[allow(deprecated)]
         platform: Some(platform.to_re_platform()),
         ..Default::default()
     });

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -665,6 +665,7 @@ impl REClient {
                     action_digest: Some(tdigest_to(request.action_digest)),
                     action_result: Some(convert_t_action_result2(request.action_result)?),
                     results_cache_policy: None,
+                    ..Default::default()
                 },
                 metadata,
                 self.runtime_opts.use_fbcode_metadata,
@@ -695,6 +696,7 @@ impl REClient {
             execution_policy: None,
             results_cache_policy: Some(ResultsCachePolicy { priority: 0 }),
             action_digest: Some(action_digest.clone()),
+            ..Default::default()
         };
 
         let stream = client
@@ -953,6 +955,7 @@ impl REClient {
                         FindMissingBlobsRequest {
                             instance_name: self.instance_name.as_str().to_owned(),
                             blob_digests: digests_to_check.map(|b| tdigest_to(b.0.clone())),
+                            ..Default::default()
                         },
                         metadata.clone(),
                         self.runtime_opts.use_fbcode_metadata,
@@ -1227,21 +1230,21 @@ fn convert_t_action_result2(t_action_result: TActionResult2) -> anyhow::Result<A
                 path: output_directory.path,
                 tree_digest: Some(digest.clone()),
                 is_topologically_sorted: false,
+                root_directory_digest: None,
             }
         });
 
     let action_result = ActionResult {
         output_files,
-        output_file_symlinks: Vec::new(),
         output_symlinks,
         output_directories,
-        output_directory_symlinks: Vec::new(),
         exit_code: t_action_result.exit_code,
         stdout_raw: Vec::new(),
         stdout_digest: t_action_result.stdout_digest.map(tdigest_to),
         stderr_raw: Vec::new(),
         stderr_digest: t_action_result.stderr_digest.map(tdigest_to),
         execution_metadata,
+        ..Default::default()
     };
 
     Ok(action_result)
@@ -1303,6 +1306,7 @@ where
                 instance_name: instance_name.as_str().to_owned(),
                 digests: std::mem::take(&mut curr_digests),
                 acceptable_compressors: vec![compressor::Value::Identity as i32],
+                ..Default::default()
             };
             requests.push(read_blob_req);
             curr_size = digest.size_bytes;
@@ -1315,6 +1319,7 @@ where
             instance_name: instance_name.as_str().to_owned(),
             digests: std::mem::take(&mut curr_digests),
             acceptable_compressors: vec![compressor::Value::Identity as i32],
+            ..Default::default()
         };
         requests.push(read_blob_req);
     }
@@ -1549,6 +1554,7 @@ where
             let mut re_request = BatchUpdateBlobsRequest {
                 instance_name: instance_name.as_str().to_owned(),
                 requests: vec![],
+                ..Default::default()
             };
             for blob in batch {
                 match blob {

--- a/remote_execution/oss/re_grpc_proto/build.rs
+++ b/remote_execution/oss/re_grpc_proto/build.rs
@@ -39,6 +39,18 @@ fn main() -> io::Result<()> {
             "#[serde(with = \"::buck2_data::serialize_duration_as_micros\")]",
         )
         .field_attribute(
+            "google.api.MethodSettings.LongRunning.initial_poll_delay",
+            "#[serde(with = \"::buck2_data::serialize_duration_as_micros\")]",
+        )
+        .field_attribute(
+            "google.api.MethodSettings.LongRunning.max_poll_delay",
+            "#[serde(with = \"::buck2_data::serialize_duration_as_micros\")]",
+        )
+        .field_attribute(
+            "google.api.MethodSettings.LongRunning.total_poll_timeout",
+            "#[serde(with = \"::buck2_data::serialize_duration_as_micros\")]",
+        )
+        .field_attribute(
             "build.bazel.remote.execution.v2.NodeProperties.mtime",
             "#[serde(with = \"::buck2_data::serialize_timestamp\")]",
         )

--- a/remote_execution/oss/re_grpc_proto/proto/build/bazel/remote/execution/v2/remote_execution.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/build/bazel/remote/execution/v2/remote_execution.proto
@@ -1,5 +1,5 @@
 // @generated
-// Copied from https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto at 23 Nov 2022
+// Copied from https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto at 25 Sep 2025
 
 // Copyright 2018 The Bazel Authors.
 //
@@ -28,12 +28,12 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "google/rpc/status.proto";
 
-// option csharp_namespace = "Build.Bazel.Remote.Execution.V2";
-// option go_package = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2;remoteexecution";
-// option java_multiple_files = true;
-// option java_outer_classname = "RemoteExecutionProto";
-// option java_package = "build.bazel.remote.execution.v2";
-// option objc_class_prefix = "REX";
+option csharp_namespace = "Build.Bazel.Remote.Execution.V2";
+option go_package = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2;remoteexecution";
+option java_multiple_files = true;
+option java_outer_classname = "RemoteExecutionProto";
+option java_package = "build.bazel.remote.execution.v2";
+option objc_class_prefix = "REX";
 
 
 // The Remote Execution API is used to execute an
@@ -107,7 +107,12 @@ service Execution {
   // send a [PreconditionFailure][google.rpc.PreconditionFailure] error detail
   // where, for each requested blob not present in the CAS, there is a
   // `Violation` with a `type` of `MISSING` and a `subject` of
-  // `"blobs/{hash}/{size}"` indicating the digest of the missing blob.
+  // `"blobs/{digest_function/}{hash}/{size}"` indicating the digest of the
+  // missing blob. The `subject` is formatted the same way as the
+  // `resource_name` provided to
+  // [ByteStream.Read][google.bytestream.ByteStream.Read], with the leading
+  // instance name omitted. `digest_function` MUST thus be omitted if its value
+  // is one of MD5, MURMUR3, SHA1, SHA256, SHA384, SHA512, or VSO.
   //
   // The server does not need to guarantee that a call to this method leads to
   // at most one execution of the action. The server MAY execute the action
@@ -123,6 +128,14 @@ service Execution {
   // operation completes, and then respond with the completed operation. The
   // server MAY choose to stream additional updates as execution progresses,
   // such as to provide an update as to the state of the execution.
+  //
+  // In addition to the cases describe for Execute, the WaitExecution method
+  // may fail as follows:
+  //
+  // * `NOT_FOUND`: The operation no longer exists due to any of a transient
+  //   condition, an unknown operation name, or if the server implements the
+  //   Operations API DeleteOperation method and it was called for the current
+  //   execution. The client should call `Execute` to retry.
   rpc WaitExecution(WaitExecutionRequest) returns (stream google.longrunning.Operation) {
     option (google.api.http) = { post: "/v2/{name=operations/**}:waitExecution" body: "*" };
   }
@@ -165,7 +178,7 @@ service ActionCache {
   //
   // In order to allow the server to perform access control based on the type of
   // action, and to assist with client debugging, the client MUST first upload
-  // the [Action][build.bazel.remote.execution.v2.Execution] that produced the
+  // the [Action][build.bazel.remote.execution.v2.Action] that produced the
   // result, along with its
   // [Command][build.bazel.remote.execution.v2.Command], into the
   // `ContentAddressableStorage`.
@@ -207,20 +220,27 @@ service ActionCache {
 // [Write method][google.bytestream.ByteStream.Write] of the ByteStream API.
 //
 // For uncompressed data, The `WriteRequest.resource_name` is of the following form:
-// `{instance_name}/uploads/{uuid}/blobs/{hash}/{size}{/optional_metadata}`
+// `{instance_name}/uploads/{uuid}/blobs/{digest_function/}{hash}/{size}{/optional_metadata}`
 //
 // Where:
-// * `instance_name` is an identifier, possibly containing multiple path
-//   segments, used to distinguish between the various instances on the server,
-//   in a manner defined by the server. If it is the empty path, the leading
-//   slash is omitted, so that  the `resource_name` becomes
-//   `uploads/{uuid}/blobs/{hash}/{size}{/optional_metadata}`.
+// * `instance_name` is an identifier used to distinguish between the various
+//   instances on the server. Syntax and semantics of this field are defined
+//   by the server; Clients must not make any assumptions about it (e.g.,
+//   whether it spans multiple path segments or not). If it is the empty path,
+//   the leading slash is omitted, so that  the `resource_name` becomes
+//   `uploads/{uuid}/blobs/{digest_function/}{hash}/{size}{/optional_metadata}`.
 //   To simplify parsing, a path segment cannot equal any of the following
 //   keywords: `blobs`, `uploads`, `actions`, `actionResults`, `operations`,
 //   `capabilities` or `compressed-blobs`.
 // * `uuid` is a version 4 UUID generated by the client, used to avoid
 //   collisions between concurrent uploads of the same data. Clients MAY
 //   reuse the same `uuid` for uploading different blobs.
+// * `digest_function` is a lowercase string form of a `DigestFunction.Value`
+//   enum, indicating which digest function was used to compute `hash`. If the
+//   digest function used is one of MD5, MURMUR3, SHA1, SHA256, SHA384, SHA512,
+//   or VSO, this component MUST be omitted. In that case the server SHOULD
+//   infer the digest function using the length of the `hash` and the digest
+//   functions announced in the server's capabilities.
 // * `hash` and `size` refer to the [Digest][build.bazel.remote.execution.v2.Digest]
 //   of the data being uploaded.
 // * `optional_metadata` is implementation specific data, which clients MAY omit.
@@ -228,10 +248,11 @@ service ActionCache {
 //
 // Data can alternatively be uploaded in compressed form, with the following
 // `WriteRequest.resource_name` form:
-// `{instance_name}/uploads/{uuid}/compressed-blobs/{compressor}/{uncompressed_hash}/{uncompressed_size}{/optional_metadata}`
+// `{instance_name}/uploads/{uuid}/compressed-blobs/{compressor}/{digest_function/}{uncompressed_hash}/{uncompressed_size}{/optional_metadata}`
 //
 // Where:
-// * `instance_name`, `uuid` and `optional_metadata` are defined as above.
+// * `instance_name`, `uuid`, `digest_function` and `optional_metadata` are
+//   defined as above.
 // * `compressor` is a lowercase string form of a `Compressor.Value` enum
 //   other than `identity`, which is supported by the server and advertised in
 //   [CacheCapabilities.supported_compressor][build.bazel.remote.execution.v2.CacheCapabilities.supported_compressor].
@@ -274,15 +295,17 @@ service ActionCache {
 // [Read method][google.bytestream.ByteStream.Read] of the ByteStream API.
 //
 // For uncompressed data, The `ReadRequest.resource_name` is of the following form:
-// `{instance_name}/blobs/{hash}/{size}`
-// Where `instance_name`, `hash` and `size` are defined as for uploads.
+// `{instance_name}/blobs/{digest_function/}{hash}/{size}`
+// Where `instance_name`, `digest_function`, `hash` and `size` are defined as
+// for uploads.
 //
 // Data can alternatively be downloaded in compressed form, with the following
 // `ReadRequest.resource_name` form:
-// `{instance_name}/compressed-blobs/{compressor}/{uncompressed_hash}/{uncompressed_size}`
+// `{instance_name}/compressed-blobs/{compressor}/{digest_function/}{uncompressed_hash}/{uncompressed_size}`
 //
 // Where:
-// * `instance_name` and `compressor` are defined as for uploads.
+// * `instance_name`, `compressor` and `digest_function` are defined as for
+//   uploads.
 // * `uncompressed_hash` and `uncompressed_size` refer to the
 //   [Digest][build.bazel.remote.execution.v2.Digest] of the data being
 //   downloaded, once uncompressed. Clients MUST verify that these match
@@ -304,6 +327,15 @@ service ActionCache {
 // Servers MUST be able to provide data for all recently advertised blobs in
 // each of the compression formats that the server supports, as well as in
 // uncompressed form.
+//
+// Additionally, ByteStream requests MAY come with an additional plain text header
+// that indicates the `resource_name` of the blob being sent.  The header, if
+// present, MUST follow the following convention:
+// * name: `build.bazel.remote.execution.v2.resource-name`.
+// * contents: the plain text resource_name of the request message.
+// If set, the contents of the header MUST match the `resource_name` of the request
+// message.  Servers MAY use this header to assist in routing requests to the
+// appropriate backend.
 //
 // The lifetime of entries in the CAS is implementation specific, but it SHOULD
 // be long enough to allow for newly-added and recently looked-up entries to be
@@ -409,6 +441,110 @@ service ContentAddressableStorage {
   // * `NOT_FOUND`: The requested tree root is not present in the CAS.
   rpc GetTree(GetTreeRequest) returns (stream GetTreeResponse) {
     option (google.api.http) = { get: "/v2/{instance_name=**}/blobs/{root_digest.hash}/{root_digest.size_bytes}:getTree" };
+  }
+
+  // Split a blob into chunks.
+  //
+  // This call splits a blob into chunks, stores the chunks in the CAS, and
+  // returns a list of the chunk digests. Using this list, a client can check
+  // which chunks are locally available and just fetch the missing ones. The
+  // desired blob can be assembled by concatenating the fetched chunks in the
+  // order of the digests in the list.
+  //
+  // This rpc can be used to reduce the required data to download a large blob
+  // from CAS if chunks from earlier downloads of a different version of this
+  // blob are locally available. For this procedure to work properly, blobs
+  // SHOULD be split in a content-defined way, rather than with fixed-sized
+  // chunking.
+  //
+  // If a split request is answered successfully, a client can expect the
+  // following guarantees from the server:
+  //  1. The blob chunks are stored in CAS.
+  //  2. Concatenating the blob chunks in the order of the digest list returned
+  //     by the server results in the original blob.
+  //
+  // Servers which implement this functionality MUST declare that they support
+  // it by setting the
+  // [CacheCapabilities.blob_split_support][build.bazel.remote.execution.v2.CacheCapabilities.blob_split_support]
+  // field accordingly.
+  //
+  // Clients MUST check that the server supports this capability, before using
+  // it.
+  //
+  // Clients SHOULD verify that the digest of the blob assembled by the fetched
+  // chunks is equal to the requested blob digest.
+  //
+  // The lifetimes of the generated chunk blobs MAY be independent of the
+  // lifetime of the original blob. In particular:
+  //  * A blob and any chunk derived from it MAY be evicted from the CAS at
+  //    different times.
+  //  * A call to [SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob]
+  //    extends the lifetime of the original blob, and sets the lifetimes of
+  //    the resulting chunks (or extends the lifetimes of already-existing
+  //    chunks).
+  //  * Touching a chunk extends its lifetime, but the server MAY choose not
+  //    to extend the lifetime of the original blob.
+  //  * Touching the original blob extends its lifetime, but the server MAY
+  //    choose not to extend the lifetimes of chunks derived from it.
+  //
+  // When blob splitting and splicing is used at the same time, the clients and
+  // the server SHOULD agree out-of-band upon a chunking algorithm used by both
+  // parties to benefit from each others chunk data and avoid unnecessary data
+  // duplication.
+  //
+  // Errors:
+  //
+  // * `NOT_FOUND`: The requested blob is not present in the CAS.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the blob
+  //   chunks.
+  rpc SplitBlob(SplitBlobRequest) returns (SplitBlobResponse) {
+    option (google.api.http) = { get: "/v2/{instance_name=**}/blobs/{blob_digest.hash}/{blob_digest.size_bytes}:splitBlob" };
+  }
+
+  // Splice a blob from chunks.
+  //
+  // This is the complementary operation to the
+  // [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob]
+  // function to handle the chunked upload of large blobs to save upload
+  // traffic.
+  //
+  // If a client needs to upload a large blob and is able to split a blob into
+  // chunks in such a way that reusable chunks are obtained, e.g., by means of
+  // content-defined chunking, it can first determine which parts of the blob
+  // are already available in the remote CAS and upload the missing chunks, and
+  // then use this API to instruct the server to splice the original blob from
+  // the remotely available blob chunks.
+  //
+  // Servers which implement this functionality MUST declare that they support
+  // it by setting the
+  // [CacheCapabilities.blob_splice_support][build.bazel.remote.execution.v2.CacheCapabilities.blob_splice_support]
+  // field accordingly.
+  //
+  // Clients MUST check that the server supports this capability, before using
+  // it.
+  //
+  // In order to ensure data consistency of the CAS, the server MUST only add
+  // blobs to the CAS after verifying their digests. In particular, servers MUST NOT
+  // trust digests provided by the client. The server MAY accept a request as no-op
+  // if the client-specified blob is already in CAS; the lifetime of that blob SHOULD
+  // be extended as usual. If the client-specified blob is not already in the CAS,
+  // the server SHOULD verify that the digest of the newly created blob matches the
+  // digest specified by the client, and reject the request if they differ.
+  //
+  // When blob splitting and splicing is used at the same time, the clients and
+  // the server SHOULD agree out-of-band upon a chunking algorithm used by both
+  // parties to benefit from each others chunk data and avoid unnecessary data
+  // duplication.
+  //
+  // Errors:
+  //
+  // * `NOT_FOUND`: At least one of the blob chunks is not present in the CAS.
+  // * `RESOURCE_EXHAUSTED`: There is insufficient disk quota to store the
+  //   spliced blob.
+  // * `INVALID_ARGUMENT`: The digest of the spliced blob is different from the
+  //   provided expected digest.
+  rpc SpliceBlob(SpliceBlobRequest) returns (SpliceBlobResponse) {
+    option (google.api.http) = { post: "/v2/{instance_name=**}/blobs:spliceBlob" body: "*" };
   }
 }
 
@@ -593,7 +729,7 @@ message Command {
   // to execution, even if they are not explicitly part of the input root.
   //
   // DEPRECATED since v2.1: Use `output_paths` instead.
-  repeated string output_files = 3;
+  repeated string output_files = 3 [ deprecated = true ];
 
   // A list of the output directories that the client expects to retrieve from
   // the action. Only the listed directories will be returned (an entire
@@ -624,7 +760,7 @@ message Command {
   // if they are not explicitly part of the input root.
   //
   // DEPRECATED since 2.1: Use `output_paths` instead.
-  repeated string output_directories = 4;
+  repeated string output_directories = 4 [ deprecated = true ];
 
   // A list of the output paths that the client expects to retrieve from the
   // action. Only the listed paths will be returned to the client as output.
@@ -664,7 +800,7 @@ message Command {
   // DEPRECATED as of v2.2: platform properties are now specified directly in
   // the action. See documentation note in the
   // [Action][build.bazel.remote.execution.v2.Action] for migration.
-  Platform platform = 5;
+  Platform platform = 5 [ deprecated = true ];
 
   // The working directory, relative to the input root, for the command to run
   // in. It must be a directory which exists in the input tree. If it is left
@@ -683,6 +819,33 @@ message Command {
   // property is not recognized by the server, the server will return an
   // `INVALID_ARGUMENT`.
   repeated string output_node_properties = 8;
+
+  enum OutputDirectoryFormat {
+    // The client is only interested in receiving output directories in
+    // the form of a single Tree object, using the `tree_digest` field.
+    TREE_ONLY = 0;
+
+    // The client is only interested in receiving output directories in
+    // the form of a hierarchy of separately stored Directory objects,
+    // using the `root_directory_digest` field.
+    DIRECTORY_ONLY = 1;
+
+    // The client is interested in receiving output directories both in
+    // the form of a single Tree object and a hierarchy of separately
+    // stored Directory objects, using both the `tree_digest` and
+    // `root_directory_digest` fields.
+    TREE_AND_DIRECTORY = 2;
+  }
+
+  // The format that the worker should use to store the contents of
+  // output directories.
+  //
+  // In case this field is set to a value that is not supported by the
+  // worker, the worker SHOULD interpret this field as TREE_ONLY. The
+  // worker MAY store output directories in formats that are a superset
+  // of what was requested (e.g., interpreting DIRECTORY_ONLY as
+  // TREE_AND_DIRECTORY).
+  OutputDirectoryFormat output_directory_format = 9;
 }
 
 // A `Platform` is a set of requirements, such as hardware, operating system, or
@@ -934,8 +1097,8 @@ message SymlinkNode {
 // serializing, but care should be taken to avoid shortcuts. For instance,
 // concatenating two messages to merge them may produce duplicate fields.
 message Digest {
-  // The hash. In the case of SHA-256, it will always be a lowercase hex string
-  // exactly 64 characters long.
+  // The hash, represented as a lowercase hexadecimal string, padded with
+  // leading zeroes up to the hash function length.
   string hash = 1;
 
   // The size of the blob, in bytes.
@@ -1040,7 +1203,7 @@ message ActionResult {
   //
   // DEPRECATED as of v2.1. Servers that wish to be compatible with v2.0 API
   // should still populate this field in addition to `output_symlinks`.
-  repeated OutputSymlink output_file_symlinks = 10;
+  repeated OutputSymlink output_file_symlinks = 10 [ deprecated = true ];
 
   // New in v2.1: this field will only be populated if the command
   // `output_paths` field was used, and not the pre v2.1 `output_files` or
@@ -1140,7 +1303,7 @@ message ActionResult {
   //
   // DEPRECATED as of v2.1. Servers that wish to be compatible with v2.0 API
   // should still populate this field in addition to `output_symlinks`.
-  repeated OutputSymlink output_directory_symlinks = 11;
+  repeated OutputSymlink output_directory_symlinks = 11 [ deprecated = true ];
 
   // The exit code of the command.
   int32 exit_code = 4;
@@ -1275,6 +1438,15 @@ message OutputDirectory {
   // compute their digests, constructing the Tree object manually avoids
   // redundant marshaling.
   bool is_topologically_sorted = 4;
+
+  // The digest of the encoded
+  // [Directory][build.bazel.remote.execution.v2.Directory] proto
+  // containing the contents the directory's root.
+  //
+  // If both `tree_digest` and `root_directory_digest` are set, this
+  // field MUST match the digest of the root directory contained in the
+  // Tree message.
+  Digest root_directory_digest = 5;
 }
 
 // An `OutputSymlink` is similar to a
@@ -1368,6 +1540,29 @@ message ExecuteRequest {
   // The server will have a default policy if this is not provided.
   // This may be applied to both the ActionResult and the associated blobs.
   ResultsCachePolicy results_cache_policy = 8;
+
+  // The digest function that was used to compute the action digest.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the action digest hash and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 9;
+
+  // A hint to the server to request inlining stdout in the
+  // [ActionResult][build.bazel.remote.execution.v2.ActionResult] message.
+  bool inline_stdout = 10;
+
+  // A hint to the server to request inlining stderr in the
+  // [ActionResult][build.bazel.remote.execution.v2.ActionResult] message.
+  bool inline_stderr = 11;
+
+  // A hint to the server to inline the contents of the listed output files.
+  // Each path needs to exactly match one file path in either `output_paths` or
+  // `output_files` (DEPRECATED since v2.1) in the
+  // [Command][build.bazel.remote.execution.v2.Command] message.
+  repeated string inline_output_files = 12;
 }
 
 // A `LogFile` is a log stored in the CAS.
@@ -1455,7 +1650,7 @@ message ExecutionStage {
 // Metadata about an ongoing
 // [execution][build.bazel.remote.execution.v2.Execution.Execute], which
 // will be contained in the [metadata
-// field][google.longrunning.Operation.response] of the
+// field][google.longrunning.Operation.metadata] of the
 // [Operation][google.longrunning.Operation].
 message ExecuteOperationMetadata {
   // The current stage of execution.
@@ -1474,6 +1669,19 @@ message ExecuteOperationMetadata {
   // [ByteStream.Read][google.bytestream.ByteStream.Read] to stream the
   // standard error from the endpoint hosting streamed responses.
   string stderr_stream_name = 4;
+
+  // The client can read this field to view details about the ongoing
+  // execution.
+  ExecutedActionMetadata partial_execution_metadata = 5;
+
+  // The digest function that was used to compute the action digest.
+  //
+  // If the digest function used is one of BLAKE3, MD5, MURMUR3, SHA1,
+  // SHA256, SHA256TREE, SHA384, SHA512, or VSO, the server MAY leave
+  // this field unset. In that case the client SHOULD infer the digest
+  // function using the length of the action digest hash and the digest
+  // functions announced in the server's capabilities.
+  DigestFunction.Value digest_function = 6;
 }
 
 // A request message for
@@ -1511,6 +1719,15 @@ message GetActionResultRequest {
   // `output_files` (DEPRECATED since v2.1) in the
   // [Command][build.bazel.remote.execution.v2.Command] message.
   repeated string inline_output_files = 5;
+
+  // The digest function that was used to compute the action digest.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the action digest hash and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 6;
 }
 
 // A request message for
@@ -1535,6 +1752,15 @@ message UpdateActionResultRequest {
   // The server will have a default policy if this is not provided.
   // This may be applied to both the ActionResult and the associated blobs.
   ResultsCachePolicy results_cache_policy = 4;
+
+  // The digest function that was used to compute the action digest.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the action digest hash and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 5;
 }
 
 // A request message for
@@ -1547,8 +1773,18 @@ message FindMissingBlobsRequest {
   // omitted.
   string instance_name = 1;
 
-  // A list of the blobs to check.
+  // A list of the blobs to check. All digests MUST use the same digest
+  // function.
   repeated Digest blob_digests = 2;
+
+  // The digest function of the blobs whose existence is checked.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the blob digest hashes and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 3;
 }
 
 // A response message for
@@ -1563,14 +1799,15 @@ message FindMissingBlobsResponse {
 message BatchUpdateBlobsRequest {
   // A request corresponding to a single blob that the client wants to upload.
   message Request {
-    // The digest of the blob. This MUST be the digest of `data`.
+    // The digest of the blob. This MUST be the digest of `data`. All
+    // digests MUST use the same digest function.
     Digest digest = 1;
 
     // The raw binary data.
     bytes data = 2;
 
     // The format of `data`. Must be `IDENTITY`/unspecified, or one of the
-    // compressors advertised by the
+    // compressors advertised by the 
     // [CacheCapabilities.supported_batch_compressors][build.bazel.remote.execution.v2.CacheCapabilities.supported_batch_compressors]
     // field.
     Compressor.Value compressor = 3;
@@ -1585,6 +1822,16 @@ message BatchUpdateBlobsRequest {
 
   // The individual upload requests.
   repeated Request requests = 2;
+
+  // The digest function that was used to compute the digests of the
+  // blobs being uploaded.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the blob digest hashes and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 5;
 }
 
 // A response message for
@@ -1613,12 +1860,22 @@ message BatchReadBlobsRequest {
   // omitted.
   string instance_name = 1;
 
-  // The individual blob digests.
+  // The individual blob digests. All digests MUST use the same digest
+  // function.
   repeated Digest digests = 2;
 
   // A list of acceptable encodings for the returned inlined data, in no
   // particular order. `IDENTITY` is always allowed even if not specified here.
   repeated Compressor.Value acceptable_compressors = 3;
+
+  // The digest function of the blobs being requested.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the blob digest hashes and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 4;
 }
 
 // A response message for
@@ -1671,6 +1928,16 @@ message GetTreeRequest {
   // If present, the server will use that token as an offset, returning only
   // that page and the ones that succeed it.
   string page_token = 4;
+
+  // The digest function that was used to compute the digest of the root
+  // directory.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the root digest hash and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 5;
 }
 
 // A response message for
@@ -1684,6 +1951,86 @@ message GetTreeResponse {
   // [request][build.bazel.remote.execution.v2.GetTreeRequest].
   // If empty, signifies that this is the last page of results.
   string next_page_token = 2;
+}
+
+// A request message for
+// [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob].
+message SplitBlobRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted.
+  string instance_name = 1;
+
+  // The digest of the blob to be split.
+  Digest blob_digest = 2;
+
+  // The digest function of the blob to be split.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256,
+  // SHA384, SHA512, or VSO, the client MAY leave this field unset. In
+  // that case the server SHOULD infer the digest function using the
+  // length of the blob digest hashes and the digest functions announced
+  // in the server's capabilities.
+  DigestFunction.Value digest_function = 3;
+}
+
+// A response message for
+// [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob].
+message SplitBlobResponse {
+  // The ordered list of digests of the chunks into which the blob was split.
+  // The original blob is assembled by concatenating the chunk data according to
+  // the order of the digests given by this list.
+  //
+  // The server MUST use the same digest function as the one explicitly or
+  // implicitly (through hash length) specified in the split request.
+  repeated Digest chunk_digests = 1;
+}
+
+// A request message for
+// [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob].
+message SpliceBlobRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted.
+  string instance_name = 1;
+
+  // Expected digest of the spliced blob. The client SHOULD set this field due
+  // to the following reasons:
+  //  1. It allows the server to perform an early existence check of the blob
+  //     before spending the splicing effort, as described in the
+  //     [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob]
+  //     documentation.
+  //  2. It allows servers with different storage backends to dispatch the
+  //     request to the correct storage backend based on the size and/or the
+  //     hash of the blob.
+  Digest blob_digest = 2;
+
+  // The ordered list of digests of the chunks which need to be concatenated to
+  // assemble the original blob.
+  repeated Digest chunk_digests = 3;
+
+  // The digest function of all chunks to be concatenated and of the blob to be
+  // spliced. The server MUST use the same digest function for both cases.
+  //
+  // If the digest function used is one of MD5, MURMUR3, SHA1, SHA256, SHA384,
+  // SHA512, or VSO, the client MAY leave this field unset. In that case the
+  // server SHOULD infer the digest function using the length of the blob digest
+  // hashes and the digest functions announced in the server's capabilities.
+  DigestFunction.Value digest_function = 4;
+}
+
+// A response message for
+// [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob].
+message SpliceBlobResponse {
+  // Computed digest of the spliced blob.
+  //
+  // The server MUST use the same digest function as the one explicitly or
+  // implicitly (through hash length) specified in the splice request.
+  Digest blob_digest = 1;
 }
 
 // A request message for
@@ -1746,6 +2093,66 @@ message DigestFunction {
     // cryptographic hash function and its collision properties are not strongly guaranteed.
     // See https://github.com/aappleby/smhasher/wiki/MurmurHash3 .
     MURMUR3 = 7;
+
+    // The SHA-256 digest function, modified to use a Merkle tree for
+    // large objects. This permits implementations to store large blobs
+    // as a decomposed sequence of 2^j sized chunks, where j >= 10,
+    // while being able to validate integrity at the chunk level.
+    //
+    // Furthermore, on systems that do not offer dedicated instructions
+    // for computing SHA-256 hashes (e.g., the Intel SHA and ARMv8
+    // cryptographic extensions), SHA256TREE hashes can be computed more
+    // efficiently than plain SHA-256 hashes by using generic SIMD
+    // extensions, such as Intel AVX2 or ARM NEON.
+    //
+    // SHA256TREE hashes are computed as follows:
+    //
+    // - For blobs that are 1024 bytes or smaller, the hash is computed
+    //   using the regular SHA-256 digest function.
+    //
+    // - For blobs that are more than 1024 bytes in size, the hash is
+    //   computed as follows:
+    //
+    //   1. The blob is partitioned into a left (leading) and right
+    //      (trailing) blob. These blobs have lengths m and n
+    //      respectively, where m = 2^k and 0 < n <= m.
+    //
+    //   2. Hashes of the left and right blob, Hash(left) and
+    //      Hash(right) respectively, are computed by recursively
+    //      applying the SHA256TREE algorithm.
+    //
+    //   3. A single invocation is made to the SHA-256 block cipher with
+    //      the following parameters:
+    //
+    //          M = Hash(left) || Hash(right)
+    //          H = {
+    //              0xcbbb9d5d, 0x629a292a, 0x9159015a, 0x152fecd8,
+    //              0x67332667, 0x8eb44a87, 0xdb0c2e0d, 0x47b5481d,
+    //          }
+    //
+    //      The values of H are the leading fractional parts of the
+    //      square roots of the 9th to the 16th prime number (23 to 53).
+    //      This differs from plain SHA-256, where the first eight prime
+    //      numbers (2 to 19) are used, thereby preventing trivial hash
+    //      collisions between small and large objects.
+    //
+    //   4. The hash of the full blob can then be obtained by
+    //      concatenating the outputs of the block cipher:
+    //
+    //          Hash(blob) = a || b || c || d || e || f || g || h
+    //
+    //      Addition of the original values of H, as normally done
+    //      through the use of the Davies-Meyer structure, is not
+    //      performed. This isn't necessary, as the block cipher is only
+    //      invoked once.
+    //
+    // Test vectors of this digest function can be found in the
+    // accompanying sha256tree_test_vectors.txt file.
+    SHA256TREE = 8;
+
+    // The BLAKE3 hash function.
+    // See https://github.com/BLAKE3-team/BLAKE3.
+    BLAKE3 = 9;
   }
 }
 
@@ -1756,7 +2163,7 @@ message ActionCacheUpdateCapabilities {
 
 // Allowed values for priority in
 // [ResultsCachePolicy][build.bazel.remoteexecution.v2.ResultsCachePolicy] and
-// [ExecutionPolicy][build.bazel.remoteexecution.v2.ResultsCachePolicy]
+// [ExecutionPolicy][build.bazel.remoteexecution.v2.ExecutionPolicy]
 // Used for querying both cache and execution valid priority ranges.
 message PriorityCapabilities {
   // Supported range of priorities, including boundaries.
@@ -1806,6 +2213,9 @@ message Compressor {
     // It is advised to use algorithms such as Zstandard instead, as
     // those are faster and/or provide a better compression ratio.
     DEFLATE = 2;
+
+    // Brotli compression.
+    BROTLI = 3;
   }
 }
 
@@ -1842,11 +2252,39 @@ message CacheCapabilities {
   // [BatchUpdateBlobs][build.bazel.remote.execution.v2.ContentAddressableStorage.BatchUpdateBlobs]
   // requests.
   repeated Compressor.Value supported_batch_update_compressors = 7;
+
+  // The maximum blob size that the server will accept for CAS blob uploads.
+  // - If it is 0, it means there is no limit set. A client may assume
+  //   arbitrarily large blobs may be uploaded to and downloaded from the cache.
+  // - If it is larger than 0, implementations SHOULD NOT attempt to upload
+  //   blobs with size larger than the limit. Servers SHOULD reject blob
+  //   uploads over the `max_cas_blob_size_bytes` limit with response code
+  //   `INVALID_ARGUMENT`
+  // - If the cache implementation returns a given limit, it MAY still serve
+  //   blobs larger than this limit.
+  int64 max_cas_blob_size_bytes = 8;
+
+  // Whether blob splitting is supported for the particular server/instance. If
+  // yes, the server/instance implements the specified behavior for blob
+  // splitting and a meaningful result can be expected from the
+  // [ContentAddressableStorage.SplitBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SplitBlob]
+  // operation.
+  bool blob_split_support = 9;
+
+  // Whether blob splicing is supported for the particular server/instance. If
+  // yes, the server/instance implements the specified behavior for blob
+  // splicing and a meaningful result can be expected from the
+  // [ContentAddressableStorage.SpliceBlob][build.bazel.remote.execution.v2.ContentAddressableStorage.SpliceBlob]
+  // operation.
+  bool blob_splice_support = 10;
 }
 
 // Capabilities of the remote execution system.
 message ExecutionCapabilities {
-  // Remote execution may only support a single digest function.
+  // Legacy field for indicating which digest function is supported by the
+  // remote execution system. It MUST be set to a value other than UNKNOWN.
+  // Implementations should consider the repeated digest_functions field
+  // first, falling back to this singular field if digest_functions is unset.
   DigestFunction.Value digest_function = 1;
 
   // Whether remote execution is enabled for the particular server/instance.
@@ -1857,6 +2295,20 @@ message ExecutionCapabilities {
 
   // Supported node properties.
   repeated string supported_node_properties = 4;
+
+  // All the digest functions supported by the remote execution system.
+  // If this field is set, it MUST also contain digest_function.
+  //
+  // Even if the remote execution system announces support for multiple
+  // digest functions, individual execution requests may only reference
+  // CAS objects using a single digest function. For example, it is not
+  // permitted to execute actions having both MD5 and SHA-256 hashed
+  // files in their input root.
+  //
+  // The CAS objects referenced by action results generated by the
+  // remote execution system MUST use the same digest function as the
+  // one used to construct the action.
+  repeated DigestFunction.Value digest_functions = 5;
 }
 
 // Details for the tool used to call the API.
@@ -1875,7 +2327,7 @@ message ToolDetails {
 //
 // * name: `build.bazel.remote.execution.v2.requestmetadata-bin`
 // * contents: the base64 encoded binary `RequestMetadata` message.
-// Note: the gRPC library serializes binary headers encoded in base 64 by
+// Note: the gRPC library serializes binary headers encoded in base64 by
 // default (https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests).
 // Therefore, if the gRPC library is used to pass/retrieve this
 // metadata, the user may ignore the base64 encoding and assume it is simply

--- a/remote_execution/oss/re_grpc_proto/proto/build/bazel/semver/semver.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/build/bazel/semver/semver.proto
@@ -1,5 +1,5 @@
 // @generated
-// Copied from https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/semver/semver.proto at 23 Nov 2022
+// Copied from https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/semver/semver.proto at 25 Sep 2025
 
 // Copyright 2018 The Bazel Authors.
 //

--- a/remote_execution/oss/re_grpc_proto/proto/google/api/annotations.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/api/annotations.proto
@@ -1,7 +1,7 @@
 // @generated
-// Copied from https://github.com/googleapis/googleapis/blob/master/google/api/annotations.proto at 23 Nov 2022
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/api/annotations.proto at 25 Sep 2025
 
-// Copyright 2015 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/remote_execution/oss/re_grpc_proto/proto/google/api/client.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/api/client.proto
@@ -1,7 +1,7 @@
 // @generated
-// Copied from https://github.com/googleapis/googleapis/blob/master/google/api/client.proto at 23 Nov 2022
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/api/client.proto at 25 Sep 2025
 
-// Copyright 2018 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@ syntax = "proto3";
 
 package google.api;
 
+import "google/api/launch_stage.proto";
 import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
@@ -99,4 +101,389 @@ extend google.protobuf.ServiceOptions {
   //     ...
   //   }
   string oauth_scopes = 1050;
+
+  // The API version of this service, which should be sent by version-aware
+  // clients to the service. This allows services to abide by the schema and
+  // behavior of the service at the time this API version was deployed.
+  // The format of the API version must be treated as opaque by clients.
+  // Services may use a format with an apparent structure, but clients must
+  // not rely on this to determine components within an API version, or attempt
+  // to construct other valid API versions. Note that this is for upcoming
+  // functionality and may not be implemented for all services.
+  //
+  // Example:
+  //
+  //   service Foo {
+  //     option (google.api.api_version) = "v1_20230821_preview";
+  //   }
+  string api_version = 525000001;
+}
+
+// Required information for every language.
+message CommonLanguageSettings {
+  // Link to automatically generated reference documentation.  Example:
+  // https://cloud.google.com/nodejs/docs/reference/asset/latest
+  string reference_docs_uri = 1 [deprecated = true];
+
+  // The destination where API teams want this client library to be published.
+  repeated ClientLibraryDestination destinations = 2;
+
+  // Configuration for which RPCs should be generated in the GAPIC client.
+  SelectiveGapicGeneration selective_gapic_generation = 3;
+}
+
+// Details about how and where to publish client libraries.
+message ClientLibrarySettings {
+  // Version of the API to apply these settings to. This is the full protobuf
+  // package for the API, ending in the version element.
+  // Examples: "google.cloud.speech.v1" and "google.spanner.admin.database.v1".
+  string version = 1;
+
+  // Launch stage of this version of the API.
+  LaunchStage launch_stage = 2;
+
+  // When using transport=rest, the client request will encode enums as
+  // numbers rather than strings.
+  bool rest_numeric_enums = 3;
+
+  // Settings for legacy Java features, supported in the Service YAML.
+  JavaSettings java_settings = 21;
+
+  // Settings for C++ client libraries.
+  CppSettings cpp_settings = 22;
+
+  // Settings for PHP client libraries.
+  PhpSettings php_settings = 23;
+
+  // Settings for Python client libraries.
+  PythonSettings python_settings = 24;
+
+  // Settings for Node client libraries.
+  NodeSettings node_settings = 25;
+
+  // Settings for .NET client libraries.
+  DotnetSettings dotnet_settings = 26;
+
+  // Settings for Ruby client libraries.
+  RubySettings ruby_settings = 27;
+
+  // Settings for Go client libraries.
+  GoSettings go_settings = 28;
+}
+
+// This message configures the settings for publishing [Google Cloud Client
+// libraries](https://cloud.google.com/apis/docs/cloud-client-libraries)
+// generated from the service config.
+message Publishing {
+  // A list of API method settings, e.g. the behavior for methods that use the
+  // long-running operation pattern.
+  repeated MethodSettings method_settings = 2;
+
+  // Link to a *public* URI where users can report issues.  Example:
+  // https://issuetracker.google.com/issues/new?component=190865&template=1161103
+  string new_issue_uri = 101;
+
+  // Link to product home page.  Example:
+  // https://cloud.google.com/asset-inventory/docs/overview
+  string documentation_uri = 102;
+
+  // Used as a tracking tag when collecting data about the APIs developer
+  // relations artifacts like docs, packages delivered to package managers,
+  // etc.  Example: "speech".
+  string api_short_name = 103;
+
+  // GitHub label to apply to issues and pull requests opened for this API.
+  string github_label = 104;
+
+  // GitHub teams to be added to CODEOWNERS in the directory in GitHub
+  // containing source code for the client libraries for this API.
+  repeated string codeowner_github_teams = 105;
+
+  // A prefix used in sample code when demarking regions to be included in
+  // documentation.
+  string doc_tag_prefix = 106;
+
+  // For whom the client library is being published.
+  ClientLibraryOrganization organization = 107;
+
+  // Client library settings.  If the same version string appears multiple
+  // times in this list, then the last one wins.  Settings from earlier
+  // settings with the same version string are discarded.
+  repeated ClientLibrarySettings library_settings = 109;
+
+  // Optional link to proto reference documentation.  Example:
+  // https://cloud.google.com/pubsub/lite/docs/reference/rpc
+  string proto_reference_documentation_uri = 110;
+
+  // Optional link to REST reference documentation.  Example:
+  // https://cloud.google.com/pubsub/lite/docs/reference/rest
+  string rest_reference_documentation_uri = 111;
+}
+
+// Settings for Java client libraries.
+message JavaSettings {
+  // The package name to use in Java. Clobbers the java_package option
+  // set in the protobuf. This should be used **only** by APIs
+  // who have already set the language_settings.java.package_name" field
+  // in gapic.yaml. API teams should use the protobuf java_package option
+  // where possible.
+  //
+  // Example of a YAML configuration::
+  //
+  //  publishing:
+  //    java_settings:
+  //      library_package: com.google.cloud.pubsub.v1
+  string library_package = 1;
+
+  // Configure the Java class name to use instead of the service's for its
+  // corresponding generated GAPIC client. Keys are fully-qualified
+  // service names as they appear in the protobuf (including the full
+  // the language_settings.java.interface_names" field in gapic.yaml. API
+  // teams should otherwise use the service name as it appears in the
+  // protobuf.
+  //
+  // Example of a YAML configuration::
+  //
+  //  publishing:
+  //    java_settings:
+  //      service_class_names:
+  //        - google.pubsub.v1.Publisher: TopicAdmin
+  //        - google.pubsub.v1.Subscriber: SubscriptionAdmin
+  map<string, string> service_class_names = 2;
+
+  // Some settings.
+  CommonLanguageSettings common = 3;
+}
+
+// Settings for C++ client libraries.
+message CppSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Php client libraries.
+message PhpSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Python client libraries.
+message PythonSettings {
+  // Experimental features to be included during client library generation.
+  // These fields will be deprecated once the feature graduates and is enabled
+  // by default.
+  message ExperimentalFeatures {
+    // Enables generation of asynchronous REST clients if `rest` transport is
+    // enabled. By default, asynchronous REST clients will not be generated.
+    // This feature will be enabled by default 1 month after launching the
+    // feature in preview packages.
+    bool rest_async_io_enabled = 1;
+
+    // Enables generation of protobuf code using new types that are more
+    // Pythonic which are included in `protobuf>=5.29.x`. This feature will be
+    // enabled by default 1 month after launching the feature in preview
+    // packages.
+    bool protobuf_pythonic_types_enabled = 2;
+
+    // Disables generation of an unversioned Python package for this client
+    // library. This means that the module names will need to be versioned in
+    // import statements. For example `import google.cloud.library_v2` instead
+    // of `import google.cloud.library`.
+    bool unversioned_package_disabled = 3;
+  }
+
+  // Some settings.
+  CommonLanguageSettings common = 1;
+
+  // Experimental features to be included during client library generation.
+  ExperimentalFeatures experimental_features = 2;
+}
+
+// Settings for Node client libraries.
+message NodeSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Dotnet client libraries.
+message DotnetSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+
+  // Map from original service names to renamed versions.
+  // This is used when the default generated types
+  // would cause a naming conflict. (Neither name is
+  // fully-qualified.)
+  // Example: Subscriber to SubscriberServiceApi.
+  map<string, string> renamed_services = 2;
+
+  // Map from full resource types to the effective short name
+  // for the resource. This is used when otherwise resource
+  // named from different services would cause naming collisions.
+  // Example entry:
+  // "datalabeling.googleapis.com/Dataset": "DataLabelingDataset"
+  map<string, string> renamed_resources = 3;
+
+  // List of full resource types to ignore during generation.
+  // This is typically used for API-specific Location resources,
+  // which should be handled by the generator as if they were actually
+  // the common Location resources.
+  // Example entry: "documentai.googleapis.com/Location"
+  repeated string ignored_resources = 4;
+
+  // Namespaces which must be aliased in snippets due to
+  // a known (but non-generator-predictable) naming collision
+  repeated string forced_namespace_aliases = 5;
+
+  // Method signatures (in the form "service.method(signature)")
+  // which are provided separately, so shouldn't be generated.
+  // Snippets *calling* these methods are still generated, however.
+  repeated string handwritten_signatures = 6;
+}
+
+// Settings for Ruby client libraries.
+message RubySettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+}
+
+// Settings for Go client libraries.
+message GoSettings {
+  // Some settings.
+  CommonLanguageSettings common = 1;
+
+  // Map of service names to renamed services. Keys are the package relative
+  // service names and values are the name to be used for the service client
+  // and call options.
+  //
+  // publishing:
+  //   go_settings:
+  //     renamed_services:
+  //       Publisher: TopicAdmin
+  map<string, string> renamed_services = 2;
+}
+
+// Describes the generator configuration for a method.
+message MethodSettings {
+  // Describes settings to use when generating API methods that use the
+  // long-running operation pattern.
+  // All default values below are from those used in the client library
+  // generators (e.g.
+  // [Java](https://github.com/googleapis/gapic-generator-java/blob/04c2faa191a9b5a10b92392fe8482279c4404803/src/main/java/com/google/api/generator/gapic/composer/common/RetrySettingsComposer.java)).
+  message LongRunning {
+    // Initial delay after which the first poll request will be made.
+    // Default value: 5 seconds.
+    google.protobuf.Duration initial_poll_delay = 1;
+
+    // Multiplier to gradually increase delay between subsequent polls until it
+    // reaches max_poll_delay.
+    // Default value: 1.5.
+    float poll_delay_multiplier = 2;
+
+    // Maximum time between two subsequent poll requests.
+    // Default value: 45 seconds.
+    google.protobuf.Duration max_poll_delay = 3;
+
+    // Total polling timeout.
+    // Default value: 5 minutes.
+    google.protobuf.Duration total_poll_timeout = 4;
+  }
+
+  // The fully qualified name of the method, for which the options below apply.
+  // This is used to find the method to apply the options.
+  //
+  // Example:
+  //
+  //    publishing:
+  //      method_settings:
+  //      - selector: google.storage.control.v2.StorageControl.CreateFolder
+  //        # method settings for CreateFolder...
+  string selector = 1;
+
+  // Describes settings to use for long-running operations when generating
+  // API methods for RPCs. Complements RPCs that use the annotations in
+  // google/longrunning/operations.proto.
+  //
+  // Example of a YAML configuration::
+  //
+  //    publishing:
+  //      method_settings:
+  //      - selector: google.cloud.speech.v2.Speech.BatchRecognize
+  //        long_running:
+  //          initial_poll_delay: 60s # 1 minute
+  //          poll_delay_multiplier: 1.5
+  //          max_poll_delay: 360s # 6 minutes
+  //          total_poll_timeout: 54000s # 90 minutes
+  LongRunning long_running = 2;
+
+  // List of top-level fields of the request message, that should be
+  // automatically populated by the client libraries based on their
+  // (google.api.field_info).format. Currently supported format: UUID4.
+  //
+  // Example of a YAML configuration:
+  //
+  //    publishing:
+  //      method_settings:
+  //      - selector: google.example.v1.ExampleService.CreateExample
+  //        auto_populated_fields:
+  //        - request_id
+  repeated string auto_populated_fields = 3;
+}
+
+// The organization for which the client libraries are being published.
+// Affects the url where generated docs are published, etc.
+enum ClientLibraryOrganization {
+  // Not useful.
+  CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED = 0;
+
+  // Google Cloud Platform Org.
+  CLOUD = 1;
+
+  // Ads (Advertising) Org.
+  ADS = 2;
+
+  // Photos Org.
+  PHOTOS = 3;
+
+  // Street View Org.
+  STREET_VIEW = 4;
+
+  // Shopping Org.
+  SHOPPING = 5;
+
+  // Geo Org.
+  GEO = 6;
+
+  // Generative AI - https://developers.generativeai.google
+  GENERATIVE_AI = 7;
+}
+
+// To where should client libraries be published?
+enum ClientLibraryDestination {
+  // Client libraries will neither be generated nor published to package
+  // managers.
+  CLIENT_LIBRARY_DESTINATION_UNSPECIFIED = 0;
+
+  // Generate the client library in a repo under github.com/googleapis,
+  // but don't publish it to package managers.
+  GITHUB = 10;
+
+  // Publish the library to package managers like nuget.org and npmjs.com.
+  PACKAGE_MANAGER = 20;
+}
+
+// This message is used to configure the generation of a subset of the RPCs in
+// a service for client libraries.
+message SelectiveGapicGeneration {
+  // An allowlist of the fully qualified names of RPCs that should be included
+  // on public client surfaces.
+  repeated string methods = 1;
+
+  // Setting this to true indicates to the client generators that methods
+  // that would be excluded from the generation should instead be generated
+  // in a way that indicates these methods should not be consumed by
+  // end users. How this is expressed is up to individual language
+  // implementations to decide. Some examples may be: added annotations,
+  // obfuscated identifiers, or other language idiomatic patterns.
+  bool generate_omitted_as_internal = 2;
 }

--- a/remote_execution/oss/re_grpc_proto/proto/google/api/http.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/api/http.proto
@@ -1,7 +1,7 @@
 // @generated
-// Copied from https://github.com/googleapis/googleapis/blob/master/google/api/http.proto at 23 Nov 2022
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/api/http.proto at 25 Sep 2025
 
-// Copyright 2015 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ syntax = "proto3";
 
 package google.api;
 
-option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
 option java_outer_classname = "HttpProto";
@@ -44,7 +43,7 @@ message Http {
   bool fully_decode_reserved_expansion = 2;
 }
 
-// # gRPC Transcoding
+// gRPC Transcoding
 //
 // gRPC Transcoding is a feature for mapping between a gRPC method and one or
 // more HTTP REST endpoints. It allows developers to build a single API service
@@ -85,9 +84,8 @@ message Http {
 //
 // This enables an HTTP REST to gRPC mapping as below:
 //
-// HTTP | gRPC
-// -----|-----
-// `GET /v1/messages/123456`  | `GetMessage(name: "messages/123456")`
+// - HTTP: `GET /v1/messages/123456`
+// - gRPC: `GetMessage(name: "messages/123456")`
 //
 // Any fields in the request message which are not bound by the path template
 // automatically become HTTP query parameters if there is no HTTP request body.
@@ -111,11 +109,9 @@ message Http {
 //
 // This enables a HTTP JSON to RPC mapping as below:
 //
-// HTTP | gRPC
-// -----|-----
-// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
-// `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
-// "foo"))`
+// - HTTP: `GET /v1/messages/123456?revision=2&sub.subfield=foo`
+// - gRPC: `GetMessage(message_id: "123456" revision: 2 sub:
+// SubMessage(subfield: "foo"))`
 //
 // Note that fields which are mapped to URL query parameters must have a
 // primitive type or a repeated primitive type or a non-repeated message type.
@@ -145,10 +141,8 @@ message Http {
 // representation of the JSON in the request body is determined by
 // protos JSON encoding:
 //
-// HTTP | gRPC
-// -----|-----
-// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
-// "123456" message { text: "Hi!" })`
+// - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+// - gRPC: `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
 //
 // The special name `*` can be used in the body mapping to define that
 // every field not bound by the path template should be mapped to the
@@ -171,10 +165,8 @@ message Http {
 //
 // The following HTTP JSON to RPC mapping is enabled:
 //
-// HTTP | gRPC
-// -----|-----
-// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
-// "123456" text: "Hi!")`
+// - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+// - gRPC: `UpdateMessage(message_id: "123456" text: "Hi!")`
 //
 // Note that when using `*` in the body mapping, it is not possible to
 // have HTTP parameters, as all fields not bound by the path end in
@@ -202,29 +194,32 @@ message Http {
 //
 // This enables the following two alternative HTTP JSON to RPC mappings:
 //
-// HTTP | gRPC
-// -----|-----
-// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
-// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
-// "123456")`
+// - HTTP: `GET /v1/messages/123456`
+// - gRPC: `GetMessage(message_id: "123456")`
 //
-// ## Rules for HTTP mapping
+// - HTTP: `GET /v1/users/me/messages/123456`
+// - gRPC: `GetMessage(user_id: "me" message_id: "123456")`
+//
+// Rules for HTTP mapping
 //
 // 1. Leaf request fields (recursive expansion nested messages in the request
 //    message) are classified into three categories:
 //    - Fields referred by the path template. They are passed via the URL path.
-//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+//    are passed via the HTTP
 //      request body.
 //    - All other fields are passed via the URL query parameters, and the
 //      parameter name is the field path in the request message. A repeated
 //      field can be represented as multiple query parameters under the same
 //      name.
-//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+//  query parameter, all fields
 //     are passed via URL path and HTTP request body.
-//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+//  request body, all
 //     fields are passed via URL path and URL query parameters.
 //
-// ### Path template syntax
+// Path template syntax
 //
 //     Template = "/" Segments [ Verb ] ;
 //     Segments = Segment { "/" Segment } ;
@@ -263,7 +258,7 @@ message Http {
 // Document](https://developers.google.com/discovery/v1/reference/apis) as
 // `{+var}`.
 //
-// ## Using gRPC API Service Configuration
+// Using gRPC API Service Configuration
 //
 // gRPC API Service Configuration (service config) is a configuration language
 // for configuring a gRPC service to become a user-facing product. The
@@ -278,15 +273,14 @@ message Http {
 // specified in the service config will override any matching transcoding
 // configuration in the proto.
 //
-// Example:
+// The following example selects a gRPC method and applies an `HttpRule` to it:
 //
 //     http:
 //       rules:
-//         # Selects a gRPC method and applies HttpRule to it.
 //         - selector: example.v1.Messaging.GetMessage
 //           get: /v1/messages/{message_id}/{sub.subfield}
 //
-// ## Special notes
+// Special notes
 //
 // When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
 // proto to JSON conversion must follow the [proto3
@@ -316,7 +310,8 @@ message Http {
 message HttpRule {
   // Selects a method to which this rule applies.
   //
-  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax
+  // details.
   string selector = 1;
 
   // Determines the URL pattern is matched by this rules. This pattern can be

--- a/remote_execution/oss/re_grpc_proto/proto/google/api/launch_stage.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/api/launch_stage.proto
@@ -1,0 +1,75 @@
+// @generated
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/api/launch_stage.proto at 25 Sep 2025
+
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option go_package = "google.golang.org/genproto/googleapis/api;api";
+option java_multiple_files = true;
+option java_outer_classname = "LaunchStageProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// The launch stage as defined by [Google Cloud Platform
+// Launch Stages](https://cloud.google.com/terms/launch-stages).
+enum LaunchStage {
+  // Do not use this default value.
+  LAUNCH_STAGE_UNSPECIFIED = 0;
+
+  // The feature is not yet implemented. Users can not use it.
+  UNIMPLEMENTED = 6;
+
+  // Prelaunch features are hidden from users and are only visible internally.
+  PRELAUNCH = 7;
+
+  // Early Access features are limited to a closed group of testers. To use
+  // these features, you must sign up in advance and sign a Trusted Tester
+  // agreement (which includes confidentiality provisions). These features may
+  // be unstable, changed in backward-incompatible ways, and are not
+  // guaranteed to be released.
+  EARLY_ACCESS = 1;
+
+  // Alpha is a limited availability test for releases before they are cleared
+  // for widespread use. By Alpha, all significant design issues are resolved
+  // and we are in the process of verifying functionality. Alpha customers
+  // need to apply for access, agree to applicable terms, and have their
+  // projects allowlisted. Alpha releases don't have to be feature complete,
+  // no SLAs are provided, and there are no technical support obligations, but
+  // they will be far enough along that customers can actually use them in
+  // test environments or for limited-use tests -- just like they would in
+  // normal production cases.
+  ALPHA = 2;
+
+  // Beta is the point at which we are ready to open a release for any
+  // customer to use. There are no SLA or technical support obligations in a
+  // Beta release. Products will be complete from a feature perspective, but
+  // may have some open outstanding issues. Beta releases are suitable for
+  // limited production use cases.
+  BETA = 3;
+
+  // GA features are open to all developers and are considered stable and
+  // fully qualified for production use.
+  GA = 4;
+
+  // Deprecated features are scheduled to be shut down and removed. For more
+  // information, see the "Deprecation Policy" section of our [Terms of
+  // Service](https://cloud.google.com/terms/)
+  // and the [Google Cloud Platform Subject to the Deprecation
+  // Policy](https://cloud.google.com/terms/deprecation) documentation.
+  DEPRECATED = 5;
+}

--- a/remote_execution/oss/re_grpc_proto/proto/google/bytestream/bytestream.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/bytestream/bytestream.proto
@@ -1,7 +1,7 @@
 // @generated
-// Copied from https://github.com/googleapis/googleapis/blob/master/google/bytestream/bytestream.proto at 2 May 2023
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/bytestream/bytestream.proto at 25 Sep 2025
 
-// Copyright 2016 Google Inc.
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,6 @@
 syntax = "proto3";
 
 package google.bytestream;
-
-import "google/api/annotations.proto";
-import "google/protobuf/wrappers.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/bytestream;bytestream";
 option java_outer_classname = "ByteStreamProto";

--- a/remote_execution/oss/re_grpc_proto/proto/google/longrunning/operations.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/longrunning/operations.proto
@@ -1,7 +1,7 @@
 // @generated
-// Copied from https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto at 23 Nov 2022
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto at 25 Sep 2025
 
-// Copyright 2020 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,17 +22,18 @@ package google.longrunning;
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/descriptor.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/rpc/status.proto";
-import "google/protobuf/descriptor.proto";
 
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.LongRunning";
-option go_package = "google.golang.org/genproto/googleapis/longrunning;longrunning";
+option go_package = "cloud.google.com/go/longrunning/autogen/longrunningpb;longrunningpb";
 option java_multiple_files = true;
 option java_outer_classname = "OperationsProto";
 option java_package = "com.google.longrunning";
+option objc_class_prefix = "GLRUN";
 option php_namespace = "Google\\LongRunning";
 
 extend google.protobuf.MethodOptions {
@@ -48,25 +49,17 @@ extend google.protobuf.MethodOptions {
 // Manages long-running operations with an API service.
 //
 // When an API method normally takes long time to complete, it can be designed
-// to return [Operation][google.longrunning.Operation] to the client, and the client can use this
-// interface to receive the real response asynchronously by polling the
-// operation resource, or pass the operation resource to another API (such as
-// Google Cloud Pub/Sub API) to receive the response.  Any API service that
-// returns long-running operations should implement the `Operations` interface
-// so developers can have a consistent client experience.
+// to return [Operation][google.longrunning.Operation] to the client, and the
+// client can use this interface to receive the real response asynchronously by
+// polling the operation resource, or pass the operation resource to another API
+// (such as Pub/Sub API) to receive the response.  Any API service that returns
+// long-running operations should implement the `Operations` interface so
+// developers can have a consistent client experience.
 service Operations {
   option (google.api.default_host) = "longrunning.googleapis.com";
 
   // Lists operations that match the specified filter in the request. If the
   // server doesn't support this method, it returns `UNIMPLEMENTED`.
-  //
-  // NOTE: the `name` binding allows API services to override the binding
-  // to use different resource name schemes, such as `users/*/operations`. To
-  // override the binding, API services can add a binding such as
-  // `"/v1/{name=users/*}/operations"` to their service configuration.
-  // For backwards compatibility, the default name includes the operations
-  // collection id, however overriding users must ensure the name binding
-  // is the parent resource, without the operations collection id.
   rpc ListOperations(ListOperationsRequest) returns (ListOperationsResponse) {
     option (google.api.http) = {
       get: "/v1/{name=operations}"
@@ -103,8 +96,9 @@ service Operations {
   // other methods to check whether the cancellation succeeded or whether the
   // operation completed despite cancellation. On successful cancellation,
   // the operation is not deleted; instead, it becomes an operation with
-  // an [Operation.error][google.longrunning.Operation.error] value with a [google.rpc.Status.code][google.rpc.Status.code] of 1,
-  // corresponding to `Code.CANCELLED`.
+  // an [Operation.error][google.longrunning.Operation.error] value with a
+  // [google.rpc.Status.code][google.rpc.Status.code] of `1`, corresponding to
+  // `Code.CANCELLED`.
   rpc CancelOperation(CancelOperationRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/{name=operations/**}:cancel"
@@ -122,8 +116,7 @@ service Operations {
   // Note that this method is on a best-effort basis.  It may return the latest
   // state before the specified timeout (including immediately), meaning even an
   // immediate response is no guarantee that the operation is done.
-  rpc WaitOperation(WaitOperationRequest) returns (Operation) {
-  }
+  rpc WaitOperation(WaitOperationRequest) returns (Operation) {}
 }
 
 // This resource represents a long-running operation that is the result of a
@@ -147,12 +140,13 @@ message Operation {
 
   // The operation result, which can be either an `error` or a valid `response`.
   // If `done` == `false`, neither `error` nor `response` is set.
-  // If `done` == `true`, exactly one of `error` or `response` is set.
+  // If `done` == `true`, exactly one of `error` or `response` can be set.
+  // Some services might not provide the result.
   oneof result {
     // The error result of the operation in case of failure or cancellation.
     google.rpc.Status error = 4;
 
-    // The normal response of the operation in case of success.  If the original
+    // The normal, successful response of the operation.  If the original
     // method returns no data on success, such as `Delete`, the response is
     // `google.protobuf.Empty`.  If the original method is standard
     // `Get`/`Create`/`Update`, the response should be the resource.  For other
@@ -164,13 +158,15 @@ message Operation {
   }
 }
 
-// The request message for [Operations.GetOperation][google.longrunning.Operations.GetOperation].
+// The request message for
+// [Operations.GetOperation][google.longrunning.Operations.GetOperation].
 message GetOperationRequest {
   // The name of the operation resource.
   string name = 1;
 }
 
-// The request message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+// The request message for
+// [Operations.ListOperations][google.longrunning.Operations.ListOperations].
 message ListOperationsRequest {
   // The name of the operation's parent resource.
   string name = 4;
@@ -185,7 +181,8 @@ message ListOperationsRequest {
   string page_token = 3;
 }
 
-// The response message for [Operations.ListOperations][google.longrunning.Operations.ListOperations].
+// The response message for
+// [Operations.ListOperations][google.longrunning.Operations.ListOperations].
 message ListOperationsResponse {
   // A list of operations that matches the specified filter in the request.
   repeated Operation operations = 1;
@@ -194,19 +191,22 @@ message ListOperationsResponse {
   string next_page_token = 2;
 }
 
-// The request message for [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
+// The request message for
+// [Operations.CancelOperation][google.longrunning.Operations.CancelOperation].
 message CancelOperationRequest {
   // The name of the operation resource to be cancelled.
   string name = 1;
 }
 
-// The request message for [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
+// The request message for
+// [Operations.DeleteOperation][google.longrunning.Operations.DeleteOperation].
 message DeleteOperationRequest {
   // The name of the operation resource to be deleted.
   string name = 1;
 }
 
-// The request message for [Operations.WaitOperation][google.longrunning.Operations.WaitOperation].
+// The request message for
+// [Operations.WaitOperation][google.longrunning.Operations.WaitOperation].
 message WaitOperationRequest {
   // The name of the operation resource to wait on.
   string name = 1;
@@ -221,13 +221,12 @@ message WaitOperationRequest {
 //
 // Example:
 //
-//   rpc LongRunningRecognize(LongRunningRecognizeRequest)
-//       returns (google.longrunning.Operation) {
-//     option (google.longrunning.operation_info) = {
-//       response_type: "LongRunningRecognizeResponse"
-//       metadata_type: "LongRunningRecognizeMetadata"
-//     };
-//   }
+//     rpc Export(ExportRequest) returns (google.longrunning.Operation) {
+//       option (google.longrunning.operation_info) = {
+//         response_type: "ExportResponse"
+//         metadata_type: "ExportMetadata"
+//       };
+//     }
 message OperationInfo {
   // Required. The message name of the primary return type for this
   // long-running operation.

--- a/remote_execution/oss/re_grpc_proto/proto/google/rpc/code.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/rpc/code.proto
@@ -1,7 +1,7 @@
 // @generated
-// Copied from https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto at 23 Nov 2022
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto at 25 Sep 2025
 
-// Copyright 2020 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ option objc_class_prefix = "RPC";
 // `OUT_OF_RANGE` over `FAILED_PRECONDITION` if both codes apply.
 // Similarly prefer `NOT_FOUND` or `ALREADY_EXISTS` over `FAILED_PRECONDITION`.
 enum Code {
-  // Not an error; returned on success
+  // Not an error; returned on success.
   //
   // HTTP Mapping: 200 OK
   OK = 0;
@@ -72,7 +72,7 @@ enum Code {
   // Some requested entity (e.g., file or directory) was not found.
   //
   // Note to server developers: if a request is denied for an entire class
-  // of users, such as gradual feature rollout or undocumented whitelist,
+  // of users, such as gradual feature rollout or undocumented allowlist,
   // `NOT_FOUND` may be used. If a request is denied for some users within
   // a class of users, such as user-based access control, `PERMISSION_DENIED`
   // must be used.
@@ -118,11 +118,11 @@ enum Code {
   // Service implementors can use the following guidelines to decide
   // between `FAILED_PRECONDITION`, `ABORTED`, and `UNAVAILABLE`:
   //  (a) Use `UNAVAILABLE` if the client can retry just the failing call.
-  //  (b) Use `ABORTED` if the client should retry at a higher level
-  //      (e.g., when a client-specified test-and-set fails, indicating the
-  //      client should restart a read-modify-write sequence).
+  //  (b) Use `ABORTED` if the client should retry at a higher level. For
+  //      example, when a client-specified test-and-set fails, indicating the
+  //      client should restart a read-modify-write sequence.
   //  (c) Use `FAILED_PRECONDITION` if the client should not retry until
-  //      the system state has been explicitly fixed.  E.g., if an "rmdir"
+  //      the system state has been explicitly fixed. For example, if an "rmdir"
   //      fails because the directory is non-empty, `FAILED_PRECONDITION`
   //      should be returned since the client should not retry unless
   //      the files are deleted from the directory.

--- a/remote_execution/oss/re_grpc_proto/proto/google/rpc/status.proto
+++ b/remote_execution/oss/re_grpc_proto/proto/google/rpc/status.proto
@@ -1,7 +1,7 @@
 // @generated
-// Copied from https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto at 23 Nov 2022
+// Copied from https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto at 25 Sep 2025
 
-// Copyright 2020 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,12 +36,14 @@ option objc_class_prefix = "RPC";
 // You can find out more about this error model and how to work with it in the
 // [API Design Guide](https://cloud.google.com/apis/design/errors).
 message Status {
-  // The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+  // The status code, which should be an enum value of
+  // [google.rpc.Code][google.rpc.Code].
   int32 code = 1;
 
   // A developer-facing error message, which should be in English. Any
   // user-facing error message should be localized and sent in the
-  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+  // [google.rpc.Status.details][google.rpc.Status.details] field, or localized
+  // by the client.
   string message = 2;
 
   // A list of messages that carry the error details.  There is a common set of


### PR DESCRIPTION
Update the proto files to their latest versions.  This allows for some new methods and new compression type (brotli).  But annoyingly, it also causes some fields to become deprecated, even though we still want to set them.  This change only updates the protocol definitions and should not contain any behavior changes at all.