### PR TITLE
Support for explicit Git object formats in .buckconfig

### DIFF
--- a/app/buck2_common/src/legacy_configs/cells.rs
+++ b/app/buck2_common/src/legacy_configs/cells.rs
@@ -9,6 +9,7 @@
  */
 
 use std::collections::HashSet;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use allocative::Allocative;
@@ -20,6 +21,7 @@ use buck2_core::cells::cell_root_path::CellRootPath;
 use buck2_core::cells::cell_root_path::CellRootPathBuf;
 use buck2_core::cells::external::ExternalCellOrigin;
 use buck2_core::cells::external::GitCellSetup;
+use buck2_core::cells::external::GitObjectFormat;
 use buck2_core::cells::name::CellName;
 use buck2_core::fs::project::ProjectRoot;
 use buck2_core::fs::project_rel_path::ProjectRelativePath;
@@ -30,7 +32,6 @@ use buck2_fs::paths::forward_rel_path::ForwardRelativePath;
 use dice::DiceComputations;
 use dupe::Dupe;
 
-use crate::cas_digest::RawDigest;
 use crate::dice::cells::HasCellResolver;
 use crate::dice::data::HasIoProvider;
 use crate::external_cells::EXTERNAL_CELLS_IMPL;
@@ -515,12 +516,23 @@ impl BuckConfigBasedCells {
         } else if value == "git" {
             let section = &format!("external_cell_{}", cell.as_str());
             let commit: Arc<str> = get_config(section, "commit_hash")?.into();
-            // No use in storing the commit hash as a byte array, but let's reuse existing code to
-            // check for validity
-            let _ = RawDigest::parse_sha1(commit.as_bytes())?;
+            let object_format = match get_config(section, "object_format") {
+                Ok(s) => {
+                    let object_format = GitObjectFormat::from_str(s)?;
+                    drop(object_format.check(commit.as_ref()));
+                    Option::Some(GitObjectFormat::from_str(s)?)
+                }
+                Err(_) => {
+                    // We pretend that the object format is SHA1 for this check only;
+                    // We do not use it when interacting with Git.
+                    drop(GitObjectFormat::Sha1.check(commit.as_ref()));
+                    Option::None
+                }
+            };
             Ok(ExternalCellOrigin::Git(GitCellSetup {
                 git_origin: get_config(section, "git_origin")?.into(),
                 commit,
+                object_format,
             }))
         } else {
             Err(ExternalCellOriginParseError::Unknown(value.to_owned()).into())

--- a/app/buck2_external_cells/src/git.rs
+++ b/app/buck2_external_cells/src/git.rs
@@ -108,7 +108,13 @@ impl IoRequest for GitFetchIoRequest {
         }
 
         run_git(&path, |c| {
-            c.arg("init");
+            match &self.setup.object_format {
+                None => c.arg("init"),
+                Some(object_format) => c
+                    .arg("init")
+                    .arg("--object-format")
+                    .arg(object_format.to_string()),
+            };
         })?;
 
         run_git(&path, |c| {


### PR DESCRIPTION
This PR adds a new optional config option for external cells retrieved via Git:
```
[external_cell_foo]
git_origin = ...
commit_hash = ...
object_format = sha1

[external_cell_bar]
git_origin = ...
commit_hash = ...
object_format = sha256
```
If specified, we pass `--object-format sha1` or `--object-format sha256` as arguments to the `git init` invocation.
In both cases we validate that the commit_hash is a valid digest for the respective algorithm. If no object_format is given, we check that the commit_hash is a valid SHA1 digest, but we do not pass the --object-format option when initializing the Git repository.