### PR TITLE
git_fetch: Allow specification of the used object format

### DIFF
--- a/prelude/decls/git_rules.bzl
+++ b/prelude/decls/git_rules.bzl
@@ -29,11 +29,19 @@ git_fetch = prelude_rule(
             "allow_cache_upload": attrs.bool(doc = """
                 Whether the results of the fetch can be written to the action cache and CAS.
             """, default = True),
+            "object_format": attrs.option(
+                attrs.enum(["sha1", "sha256"]),
+                default = None,
+                doc = """
+                The object format to use for the underlying Git repository.
+                Must be one off `sha1` or `sha256`.
+                """,
+            ),
             "repo": attrs.string(doc = """
                 Url suitable as a git remote.
             """),
             "rev": attrs.string(doc = """
-                40-digit hex SHA-1 of the git commit.
+                The hex digest of the git commit.
             """),
             "sub_targets": attrs.list(
                 attrs.string(),

--- a/prelude/git/git_fetch.bzl
+++ b/prelude/git/git_fetch.bzl
@@ -16,10 +16,28 @@ def _is_40_hex(rev: str) -> bool:
             return False
     return True
 
+def _is_64_hex(rev: str) -> bool:
+    if len(rev) != 64:
+        return False
+    for digit in rev.elems():
+        if digit not in _HEX_DIGITS:
+            return False
+    return True
+
 def git_fetch_impl(ctx: AnalysisContext) -> list[Provider]:
+    object_format = ctx.attrs.object_format
     rev = ctx.attrs.rev
-    if not _is_40_hex(rev):
-        fail("git_fetch's `rev` must be a 40-hex-digit commit hash: {}".format(rev))
+    if object_format == None:
+        if not _is_40_hex(rev):
+            fail("git_fetch's `rev` must be a 40-hex-digit commit hash: {}".format(rev))
+    elif object_format == "sha1":
+        if not _is_40_hex(rev):
+            fail("git_fetch's `rev` must be a 40-hex-digit commit hash when the chosen object format is sha1: {}".format(rev))
+    elif object_format == "sha256":
+        if not _is_64_hex(rev):
+            fail("git_fetch's `rev` must be a 64-hex-digit commit hash when the chosen object format is sha256: {}".format(rev))
+    else:
+        fail("Invalid git_fetch `object_format`: Must be one of sha1 or sha256: {}".format(object_format))
 
     git_dir = ctx.actions.declare_output(".git", dir = True)
 
@@ -35,6 +53,8 @@ def git_fetch_impl(ctx: AnalysisContext) -> list[Provider]:
         cmd_args("--repo=", ctx.attrs.repo, delimiter = ""),
         cmd_args("--rev=", rev, delimiter = ""),
     ]
+    if object_format != None:
+        cmd.append(cmd_args("--object-format=", object_format, delimiter = ""))
 
     ctx.actions.run(
         cmd,

--- a/prelude/git/tools/git_fetch.py
+++ b/prelude/git/tools/git_fetch.py
@@ -10,6 +10,7 @@ import argparse
 import subprocess
 import sys
 import time
+from enum import Enum
 from pathlib import Path
 from typing import List, NamedTuple
 
@@ -39,9 +40,14 @@ def run(cmd: List[str], check: bool, retries: int = MAX_RETRIES) -> str:
     return proc.stdout
 
 
+class ObjectFormat(str, Enum):
+    Sha1 = "sha1"
+    Sha256 = "sha256"
+
 class Args(NamedTuple):
     git_dir: Path
     work_tree: Path
+    object_format: ObjectFormat
     repo: str
     rev: str
 
@@ -50,6 +56,7 @@ def arg_parse() -> Args:
     parser = argparse.ArgumentParser()
     parser.add_argument("--git-dir", type=Path, required=True)
     parser.add_argument("--work-tree", type=Path, required=True)
+    parser.add_argument("--object-format", type=ObjectFormat, required=False)
     parser.add_argument("--repo", type=str, required=True)
     parser.add_argument("--rev", type=str, required=True)
     return Args(**vars(parser.parse_args()))
@@ -69,8 +76,12 @@ def main() -> None:
     args.work_tree.mkdir(exist_ok=True)
 
     git = ["git", f"--git-dir={args.git_dir}", f"--work-tree={args.work_tree}"]
+    if args.object_format == None:
+        object_format_args = []
+    else:
+        object_format_args = ["--object-format", args.object_format]
 
-    run([*git, "init"], check=True)
+    run([*git, "init"] + object_format_args, check=True)
     git_configure(git)
     run([*git, "remote", "remove", "origin"], check=False)
     run([*git, "remote", "add", "origin", args.repo], check=True)


### PR DESCRIPTION
This PR adds a new (optional) attribute `object_format` to the git_fetch rule. If given, the values of the attribute must be one of `sha1` or `sha256`, and its value is used for the initialization of the underlying Git repository (e.g. `git init --object-format sha1`).

The given `rev` is validated according to the chosen object format; If none is provided we still check if the `rev` is a valid SHA1 digest, but we do not pass the `--object-format` option to Git.