### PR TITLE
Fix deprecation of pkg_resources

### DIFF
--- a/prelude/apple/tools/bundling/action_metadata_test.py
+++ b/prelude/apple/tools/bundling/action_metadata_test.py
@@ -6,20 +6,22 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
+import importlib.resources
 import unittest
 from json import JSONDecodeError
 from pathlib import Path
-
-import pkg_resources
 
 from .action_metadata import parse_action_metadata
 
 
 class TestActionMetadata(unittest.TestCase):
+
+    def _resource_content(self, filename):
+        resources = importlib.resources.files(__package__) / "test_resources"
+        return (resources / filename)
+
     def test_valid_metadata_is_parsed_successfully(self):
-        file_content = pkg_resources.resource_stream(
-            __name__, "test_resources/valid_action_metadata.json"
-        )
+        file_content = self._resource_content("valid_action_metadata.json")
         result = parse_action_metadata(file_content)
         self.assertEqual(
             result,
@@ -30,16 +32,12 @@ class TestActionMetadata(unittest.TestCase):
         )
 
     def test_error_when_invalid_metadata(self):
-        file_content = pkg_resources.resource_stream(
-            __name__, "test_resources/the.broken_json"
-        )
+        file_content = self._resource_content("the.broken_json")
         with self.assertRaises(JSONDecodeError):
             _ = parse_action_metadata(file_content)
 
     def test_user_friendly_error_when_metadata_with_newer_version(self):
-        file_content = pkg_resources.resource_stream(
-            __name__, "test_resources/newer_version_action_metadata.json"
-        )
+        file_content = self._resource_content("newer_version_action_metadata.json")
         with self.assertRaises(Exception) as context:
             _ = parse_action_metadata(file_content)
             self.assertEqual(

--- a/prelude/apple/tools/bundling/incremental_state_test.py
+++ b/prelude/apple/tools/bundling/incremental_state_test.py
@@ -6,12 +6,11 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
+import importlib.resources
 import io
 import json
 import unittest
 from pathlib import Path
-
-import pkg_resources
 
 from .incremental_state import (
     CodesignedOnCopy,
@@ -81,10 +80,12 @@ class TestIncrementalState(unittest.TestCase):
             expected,
         )
 
+    def _resource_content(self, filename):
+        resources = importlib.resources.files(__package__) / "test_resources"
+        return (resources / filename)
+
     def test_valid_state_is_parsed_successfully(self):
-        file_content = pkg_resources.resource_stream(
-            __name__, "test_resources/valid_incremental_state.json"
-        )
+        file_content = self._resource_content("valid_incremental_state.json")
         result = parse_incremental_state(file_content)
         expected = IncrementalState(
             items=[
@@ -149,16 +150,12 @@ class TestIncrementalState(unittest.TestCase):
         )
 
     def test_error_when_invalid_metadata(self):
-        file_content = pkg_resources.resource_stream(
-            __name__, "test_resources/the.broken_json"
-        )
+        file_content = self._resource_content("the.broken_json")
         with self.assertRaises(json.JSONDecodeError):
             _ = parse_incremental_state(file_content)
 
     def test_user_friendly_error_when_metadata_with_newer_version(self):
-        file_content = pkg_resources.resource_stream(
-            __name__, "test_resources/newer_version_incremental_state.json"
-        )
+        file_content = self._resource_content("newer_version_incremental_state.json")
         with self.assertRaises(Exception) as context:
             _ = parse_incremental_state(file_content)
             self.assertEqual(

--- a/prelude/apple/tools/code_signing/app_id_test.py
+++ b/prelude/apple/tools/code_signing/app_id_test.py
@@ -6,10 +6,9 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
+import importlib.resources
 import plistlib
 import unittest
-
-import pkg_resources
 
 from .app_id import AppId
 
@@ -38,8 +37,9 @@ class TestAppId(unittest.TestCase):
             "test_resources/test3.plist",
         ]
 
+        package = importlib.resources.files(__package__)
         for file in test_plist_files:
-            with pkg_resources.resource_stream(__name__, file) as f:
+            with (package / file).open('rb') as f:
                 entitlements = plistlib.load(f)
                 result = AppId.infer_from_entitlements(entitlements)
                 self.assertEqual(expected, result)

--- a/prelude/apple/tools/code_signing/provisioning_profile_metadata_test.py
+++ b/prelude/apple/tools/code_signing/provisioning_profile_metadata_test.py
@@ -7,10 +7,9 @@
 # above-listed licenses.
 
 import datetime
+import importlib.resources
 import unittest
 from pathlib import Path
-
-import pkg_resources
 
 from .app_id import AppId
 from .provisioning_profile_metadata import ProvisioningProfileMetadata
@@ -19,7 +18,7 @@ from .provisioning_profile_metadata import ProvisioningProfileMetadata
 class TestParse(unittest.TestCase):
     def test_canary(self):
         path = Path("test_resources/sample.mobileprovision")
-        file_content = pkg_resources.resource_string(__name__, str(path))
+        file_content = (importlib.resources.files(__package__) / path).read_bytes()
         metadata = ProvisioningProfileMetadata.from_provisioning_profile_file_content(
             path, file_content
         )
@@ -42,7 +41,7 @@ class TestParse(unittest.TestCase):
 
     def test_qualified_entitlements_parsed(self):
         path = Path("test_resources/sample.mobileprovision")
-        file_content = pkg_resources.resource_string(__name__, str(path))
+        file_content = (importlib.resources.files(__package__) / path).read_bytes()
         metadata = ProvisioningProfileMetadata.from_provisioning_profile_file_content(
             path, file_content
         )
@@ -52,7 +51,7 @@ class TestParse(unittest.TestCase):
 
     def test_filtered_entitlements_stripped_out(self):
         path = Path("test_resources/sample.mobileprovision")
-        file_content = pkg_resources.resource_string(__name__, str(path))
+        file_content = (importlib.resources.files(__package__) / path).read_bytes()
         metadata = ProvisioningProfileMetadata.from_provisioning_profile_file_content(
             path, file_content
         )


### PR DESCRIPTION
Replaces deprecated pkg_resources (which is scheduled for removal in 2025-11-30 !) with importlib.resources -- part of python stdlib since like python 3.9. No observable change expected (beyond disappearance of a bunch of warnings)