### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -25,7 +25,7 @@ The latest set of `buck2` executables can be found under the
 [`latest` release page](https://github.com/facebook/buck2/releases/tag/latest).
 
 Additionally, for each bi-monthly release there is a
-[dotslash](https://dotslash-cli.com/) file that is appropriate for checkin to a
+[dotslash](https://dotslash-cli.com) file that is appropriate for committing to a
 repository. This will automatically fetch the correct version and architecture
 for each user, and ensures a consistent build environment for each commit in the
 repo.


### PR DESCRIPTION
I went with "committing" rather than "check-in" or "check in".