### PR TITLE
Added supports_content_based_paths attribute to cxx_tools_info_toolchain

### DIFF
--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -281,6 +281,7 @@ cxx_tools_info_toolchain = rule(
         ),
         "post_link_flags": attrs.list(attrs.arg(), default = []),
         "rc_flags": attrs.list(attrs.arg(), default = []),
+        "supports_content_based_paths": attrs.bool(default = False),
         "_target_os_type": buck.target_os_type_arg(),
     },
     is_toolchain_rule = True,


### PR DESCRIPTION
This was added to system_cxx_toolchain but not to cxx_tools_info_toolchain.

I think the CI failures are unrelated to my changes.