### PR TITLE
fix suggestion to include full path

### DIFF
--- a/app/buck2_common/src/file_ops/error.rs
+++ b/app/buck2_common/src/file_ops/error.rs
@@ -132,7 +132,10 @@ pub(super) fn extended_ignore_error<'a>(
                                 return Some(ReadDirError::DirectoryDoesNotExist {
                                     path: path.to_owned(),
                                     suggestion: DirectoryDoesNotExistSuggestion::Typo(
-                                        suggestion.to_owned(),
+                                        match parent.path().join_normalized(suggestion) {
+                                            Ok(p) => p.as_str().to_owned(),
+                                            Err(_) => suggestion.to_owned()
+                                        }
                                     ),
                                 });
                             }

--- a/tests/core/errors/test_errors.py
+++ b/tests/core/errors/test_errors.py
@@ -61,6 +61,8 @@ async def test_package_listing_errors(buck: Buck) -> None:
         "//package_listing/data.file/subdir:target",
         # Missing directory due to typo
         "//package_listings:",
+        # Missing directory due to typo shows full path
+        "//package_listing/data.file:targets",
         # Missing directory due to being in the wrong cell
         "//something:",
     ]:

--- a/tests/core/errors/test_errors_data/package_listing/expected.golden.out
+++ b/tests/core/errors/test_errors_data/package_listing/expected.golden.out
@@ -75,6 +75,18 @@ Caused by:
              ^-----------------------------^
        path `root//package_listing/data.file` is a file, not a directory
 
+Command failed:
+Error evaluating expression:
+    //package_listing/data.file:targets:
+    ^-----------------^
+
+
+Caused by:
+    package `root//package_listing/data.file:targets:` does not exist
+             ^--------------------^
+        dir `root//package_listing/data.file:targets` does not exist. Did you mean `root//package_listing/data.file:target`?
+
+
 
 
 Command failed: 


### PR DESCRIPTION
The current BUCK file suggestion usually returns an invalid path, this change returns a valid suggestion in the case of an invalid path to a BUCK file. 

When you have a missing BUCK file, buck tries to suggest what you meant. Instead of returning the full path, it returns the directory the suggested BUCK file is in, which can be confusing and means the suggestion cannot be copy+pasted

e.g. `root//cat` is not a valid location:
```
dir `root//animals/pets/cats` does not exist. Did you mean `root//cat`?
```

After, we now return the full path to the matched directory allowing copy+paste of the suggestion to fix:
```
dir `root//animals/pets/cats` does not exist. Did you mean `root//animals/pets/cat`?
```

PS: I have no idea if the tests pass, the README says they can only run inside meta so this is just a guess