### PR TITLE
add network statistics to OSS RE client

### DIFF
--- a/remote_execution/oss/re_grpc/Cargo.toml
+++ b/remote_execution/oss/re_grpc/Cargo.toml
@@ -13,6 +13,8 @@ dupe = { workspace = true }
 futures = { workspace = true }
 gazebo = { workspace = true }
 http = { workspace = true }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }
 prost = { workspace = true }
@@ -23,6 +25,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 zstd = { workspace = true }

--- a/remote_execution/oss/re_grpc/src/lib.rs
+++ b/remote_execution/oss/re_grpc/src/lib.rs
@@ -15,6 +15,13 @@ mod grpc;
 mod metadata;
 mod request;
 mod response;
+mod stats;
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering;
+
 pub use client::*;
 pub use error::*;
 pub use grpc::*;
@@ -22,7 +29,24 @@ pub use metadata::*;
 pub use request::*;
 pub use response::*;
 
+/// The global version of the network stats full of atomics
+#[derive(Default, Debug)]
+struct NetworkStatisticsGlobal {
+    uploaded: AtomicI64,
+    downloaded: AtomicI64,
+}
+
+static NETWORK_STATS: OnceLock<Arc<NetworkStatisticsGlobal>> = OnceLock::new();
+
+fn get_network_stats_global() -> Arc<NetworkStatisticsGlobal> {
+    Arc::clone(NETWORK_STATS.get_or_init(|| Arc::new(NetworkStatisticsGlobal::default())))
+}
+
 pub fn get_network_stats() -> anyhow::Result<NetworkStatisticsResponse> {
-    // TODO: Support this in this client.
-    Ok(NetworkStatisticsResponse::default())
+    let g = get_network_stats_global();
+    Ok(NetworkStatisticsResponse {
+        uploaded: g.uploaded.load(Ordering::Relaxed),
+        downloaded: g.downloaded.load(Ordering::Relaxed),
+        ..Default::default()
+    })
 }

--- a/remote_execution/oss/re_grpc/src/stats.rs
+++ b/remote_execution/oss/re_grpc/src/stats.rs
@@ -1,0 +1,125 @@
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+
+use http::Uri;
+use hyper::rt;
+use hyper_util::rt::TokioIo;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio::io::ReadBuf;
+use tower::Service;
+
+use crate::NetworkStatisticsGlobal;
+use crate::get_network_stats_global;
+
+/// An IO wrapper that implements AsyncRead and AsyncWrite and increments the
+/// global counters
+pub struct CountingIo<T> {
+    inner: T,
+    stats: Arc<NetworkStatisticsGlobal>,
+}
+
+impl<T> CountingIo<T> {
+    pub fn new(inner: T) -> Self {
+        CountingIo {
+            inner,
+            stats: get_network_stats_global(),
+        }
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for CountingIo<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        let before = buf.filled().len();
+        match Pin::new(&mut self.inner).poll_read(cx, buf) {
+            Poll::Ready(Ok(())) => {
+                let after = buf.filled().len();
+                let bytes_read = after - before;
+                if bytes_read > 0 {
+                    self.stats.downloaded.fetch_add(
+                        i64::try_from(bytes_read).unwrap_or_default(),
+                        Ordering::Relaxed,
+                    );
+                }
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for CountingIo<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        match Pin::new(&mut self.inner).poll_write(cx, buf) {
+            Poll::Ready(Ok(bytes_written)) => {
+                if bytes_written > 0 {
+                    self.stats.uploaded.fetch_add(
+                        i64::try_from(bytes_written).unwrap_or_default(),
+                        Ordering::Relaxed,
+                    );
+                }
+                Poll::Ready(Ok(bytes_written))
+            }
+            other => other,
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// A connector that wraps the underlying IO device with a CountingIo wrapper
+pub struct CountingConnector<C: Clone> {
+    inner: C,
+}
+
+impl<C: Clone> CountingConnector<C> {
+    pub fn new(inner: C) -> Self {
+        Self { inner }
+    }
+}
+
+impl<C: Clone> Service<Uri> for CountingConnector<C>
+where
+    C: Service<Uri> + Send + 'static,
+    C::Response: rt::Read + rt::Write + Send + Unpin + 'static,
+    C::Future: Send + 'static,
+{
+    type Response = TokioIo<CountingIo<TokioIo<C::Response>>>;
+    type Error = C::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let io = inner.call(uri).await?;
+            let io = TokioIo::new(CountingIo::new(TokioIo::new(io)));
+            Ok(io)
+        })
+    }
+}


### PR DESCRIPTION
This wraps the transport layer of the OSS RE client channels to count the number of bytes uploaded and downloaded.  This allows the network statistics to show up in the CLI interface.