### PR TITLE
enables 'buck2 killall' to work when the binary has been deleted

### DIFF
--- a/app/buck2_wrapper_common/src/is_buck2.rs
+++ b/app/buck2_wrapper_common/src/is_buck2.rs
@@ -32,7 +32,9 @@ pub(crate) fn is_buck2_exe(path: &Path, who_is_asking: WhoIsAsking) -> bool {
         OsStr::new("buck2 (deleted)"),
         OsStr::new("buck2-daemon"),
         OsStr::new("buck2-daemon (deleted)"),
-    ].contains(&file_stem) {
+    ]
+    .contains(&file_stem)
+    {
         true
     } else {
         match who_is_asking {


### PR DESCRIPTION
This change makes `buck2 killall` work on linux when the underlying binary has been deleted.

Currently on linux if the buck2 binary has been deleted, `buck2 killall` returns "No buck2 processes found" and fails to kill the buck2 process. This is because we check the symlinked path in `/proc/<pid>/exec` for the string 'buck2'. Linux appends the string ` (deleted)` to the symlinked path in the case the binary was deleted, causing the `is_buck2_exe` check to fail