### PR TITLE
fix unused import error in windows build

### DIFF
--- a/app/buck2_execute_local/src/win/process_group.rs
+++ b/app/buck2_execute_local/src/win/process_group.rs
@@ -14,7 +14,6 @@ use std::os::windows::process::CommandExt;
 use std::process::Child;
 use std::process::Command;
 use std::process::ExitStatus;
-use std::process::Stdio;
 use std::time::Duration;
 
 use buck2_error::BuckErrorContext;


### PR DESCRIPTION
Summary: Remove unused import that is breaking oss build on windows

Differential Revision: D87057605


