### PR TITLE
fix clippy forkserver break in windows github actions

### DIFF
--- a/app/buck2_forkserver/src/lib.rs
+++ b/app/buck2_forkserver/src/lib.rs
@@ -9,6 +9,7 @@
  */
 
 #![feature(error_generic_member_access)]
+#![cfg(unix)]
 
 pub mod client;
 pub mod command;


### PR DESCRIPTION
Summary:
The oss build runs clippy on the workspace.  Unlike Cargo build dependencies Cargo workspace members can't have conditional inclusions by target os,  so forkserver is covered even on windows, resulting in failures when importing Unix only parts of stdlib.

Fix by making the top level forkserver lib.rs do nothing on windows.

Differential Revision: D87215575


