### PR TITLE
Drop all DICE nodes when FS events missed

### DIFF
--- a/dice/dice/src/impls/core/internals.rs
+++ b/dice/dice/src/impls/core/internals.rs
@@ -142,6 +142,7 @@ impl CoreState {
     }
 
     pub(super) fn unstable_drop_everything(&mut self) {
+        debug!("Dropping all DICE nodes");
         self.version_tracker.clear();
 
         // Do the actual drop on a different thread because we may have to drop a lot of stuff


### PR DESCRIPTION
Handle the case where the notify crate tells us that events were missed.  In this case, when sync is called at the beginning of a new build, the entire DICE graph gets dropped.  This should fix the bug where caches can become out of sync with the file system due to missed events.