### PR TITLE
Fix oss-enable in apple_test.bzl

### DIFF
--- a/prelude/apple/apple_test.bzl
+++ b/prelude/apple/apple_test.bzl
@@ -256,10 +256,10 @@ def _get_test_info(ctx: AnalysisContext, xctest_bundle: Artifact, test_host_app_
         test_device_type = get_default_test_device(sdk = sdk_name, platform = ctx.attrs.default_target_platform.name)
     labels.append(tpx_label_for_test_device_type(test_device_type))
 
-    # @oss-enable local_enabled = True
-    # @oss-enable remote_enabled = False
-    # @oss-enable remote_execution_properties = None
-    # @oss-enable remote_execution_use_case = None
+    local_enabled = True # @oss-enable
+    remote_enabled = False # @oss-enable
+    remote_execution_properties = None # @oss-enable
+    remote_execution_use_case = None # @oss-enable
 
     # @oss-disable[end= ]: if ctx.attrs.test_re_capabilities:
         # @oss-disable[end= ]: remote_execution_properties = ctx.attrs.test_re_capabilities


### PR DESCRIPTION
Summary:
The `oss-enable` from {D87842176} are not getting enabled in open-source as intended.

https://github.com/facebook/buck2/blob/fde440f6f4ad8504486d2a2e1d153c4f45549db8/prelude/apple/apple_test.bzl#L259-L262

```lang=log,counterexample
From load at implicit location

Caused by:
    0: From load at prelude/prelude.bzl:9
    1: From load at prelude/native.bzl:17
    2: From load at prelude/rules.bzl:12
    3: From load at prelude/rules_impl.bzl:22
    4: From load at prelude/apple/apple_rules_decls.bzl:83
    5: Error evaluating module: `prelude//apple/apple_test.bzl`
    6: error: Variable `local_enabled` not found
          --> prelude/apple/apple_test.bzl:285:8
           |
       285 |     if local_enabled and tpx_needs_local_simulator(test_device_type):
           |        ^^^^^^^^^^^^^
           |
```

Differential Revision: D87990886


