### PR TITLE
Bytestream decompression with async-compression requires multiple_members(true)

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -1315,9 +1315,21 @@ where
             // Wrap the blob reader in a compression reader
             let reader: Pin<Box<dyn AsyncRead + Unpin + Send>> = match bystream_compressor {
                 None => Pin::new(Box::new(blob_reader)),
-                Some(Compressor::Zstd) => Pin::new(Box::new(ZstdDecoder::new(blob_reader))),
-                Some(Compressor::Deflate) => Pin::new(Box::new(DeflateDecoder::new(blob_reader))),
-                Some(Compressor::Brotli) => Pin::new(Box::new(BrotliDecoder::new(blob_reader))),
+                Some(Compressor::Zstd) => {
+                    let mut decoder = ZstdDecoder::new(blob_reader);
+                    decoder.multiple_members(true);
+                    Pin::new(Box::new(decoder))
+                }
+                Some(Compressor::Deflate) => {
+                    let mut decoder = DeflateDecoder::new(blob_reader);
+                    decoder.multiple_members(true);
+                    Pin::new(Box::new(decoder))
+                }
+                Some(Compressor::Brotli) => {
+                    let mut decoder = BrotliDecoder::new(blob_reader);
+                    decoder.multiple_members(true);
+                    Pin::new(Box::new(decoder))
+                }
             };
 
             reader


### PR DESCRIPTION
Summary:
This fixes the truncated materializations when using Remote Execution with BuildBuddy described in <https://github.com/facebook/buck2/pull/1103#issuecomment-3413866377>.

The fix was discovered by @cormacrelf and @NobodyXu in <https://github.com/Nullus157/async-compression/pull/400>.

Differential Revision: D88011967


