### PR TITLE
Enable brotli support for bytestream compression

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -276,11 +276,12 @@ pub enum Compressor {
 
 impl Compressor {
     fn from_grpc(val: i32) -> Option<Self> {
-        // TODO: brotli cannot be supported until google proto definitions are updated
         if val == compressor::Value::Zstd as i32 {
             Some(Self::Zstd)
         } else if val == compressor::Value::Deflate as i32 {
             Some(Self::Deflate)
+        } else if val == compressor::Value::Brotli as i32 {
+            Some(Self::Brotli)
         } else {
             None
         }
@@ -394,12 +395,16 @@ impl REClientBuilder {
         }
 
         // Choose a ByteStream compressor
-        // TODO: brotli cannot be supported until google proto definitions are updated
         let bystream_compressor = if capabilities
             .supported_compressors
             .contains(&Compressor::Zstd)
         {
             Some(Compressor::Zstd)
+        } else if capabilities
+            .supported_compressors
+            .contains(&Compressor::Brotli)
+        {
+            Some(Compressor::Brotli)
         } else if capabilities
             .supported_compressors
             .contains(&Compressor::Deflate)


### PR DESCRIPTION
Summary:
The Compressor enum value for Brotli is available in build/bazel/remote/execution/v2/remote_execution.proto since https://github.com/facebook/buck2/pull/1108.

https://github.com/facebook/buck2/blob/248ba5953cb8bb242dc759959948275d1b01d610/remote_execution/oss/re_grpc_proto/proto/build/bazel/remote/execution/v2/remote_execution.proto#L2217-L2218

Differential Revision: D88012152


