### PR TITLE
[tiny] docs: fix markdown link to XAR blog post

### DIFF
--- a/docs/developers/architecture/buck1_vs_buck2.md
+++ b/docs/developers/architecture/buck1_vs_buck2.md
@@ -123,8 +123,8 @@ codegen step, driven by a Python binary.
 
 In certain configurations/modes, Python binaries are non-deterministic, because
 they are XARs
-([https://engineering.fb.com/2018/07/13/data-infrastructure/xars-a-more-efficient-open-source-system-for-self-contained-executables/](eXecutable
-ARchives)) and that is always non-deterministic, which is bad!
+([eXecutable
+ARchives](https://engineering.fb.com/2018/07/13/data-infrastructure/xars-a-more-efficient-open-source-system-for-self-contained-executables/)) and that is always non-deterministic, which is bad!
 
 - In Buck1, that doesn’t really matter, because you can get a cache hit on the
   codegen output without ever visiting the XAR (as long as the input files


### PR DESCRIPTION
Broken on the docs site: https://buck2.build/docs/developers/architecture/buck1_vs_buck2/#non-determinism