### PR TITLE
Index string at chars boundaries

### DIFF
--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -1003,8 +1003,9 @@ fn truncate(contents: &str) -> Option<String> {
     if contents.len() > MAX_LENGTH + BUFFER {
         Some(format!(
             "{} ...<omitted>... {}",
-            &contents[0..MAX_LENGTH / 2],
-            &contents[contents.len() - MAX_LENGTH / 2..contents.len()]
+            &contents[0..contents.ceil_char_boundary(MAX_LENGTH / 2)],
+            &contents
+                [contents.floor_char_boundary(contents.len() - MAX_LENGTH / 2)..contents.len()]
         ))
     } else {
         None


### PR DESCRIPTION
This function would panic when the truncated message contained non-ASCII characters, and the truncation happened between within char boundaries.

I've not been able to test this because I can't seem to easily build Buck2 from source these days, but this should be trivial enough.