### PR TITLE
remote_execution: remove check for exec_enabled on ExecutionCapabilities

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -383,10 +383,6 @@ impl REClientBuilder {
             }
         };
 
-        if !capabilities.exec_enabled {
-            return Err(anyhow::anyhow!("Server has remote execution disabled."));
-        }
-
         let max_decoding_msg_size = opts
             .max_decoding_message_size
             .unwrap_or(capabilities.max_total_batch_size * 2);


### PR DESCRIPTION
I have no idea why this exists. It's completely fine if a server has `exec_enabled = false`, as long as the selected platform used by Buck does not try to perform remote execution; this is the case when you're only using caching and not RE -- the server will correctly specify its capabilities, but this check will cause Buck to not use it at all. Remove it.