### PR TITLE
compilation_database.bxl: take configured targets as inputs

### DIFF
--- a/prelude/cxx/tools/compilation_database.bxl
+++ b/prelude/cxx/tools/compilation_database.bxl
@@ -67,7 +67,7 @@ generate = bxl_main(
             doc = "Automatically include all dependent targets in the generated compilation db",
         ),
         "targets": cli_args.list(
-            cli_args.target_expr(),
+            cli_args.configured_target_expr(),
             doc = "Targets to generate the database for",
         ),
     },


### PR DESCRIPTION
This makes this script more flexible.

The only reason this was not done from the beginning is that cli_args.configured_target_expr() was not available when this script was first written.