### PR TITLE
ReActionIdentity: make target and paths optional

### DIFF
--- a/app/buck2_action_impl/src/actions/impls/run.rs
+++ b/app/buck2_action_impl/src/actions/impls/run.rs
@@ -381,6 +381,7 @@ enum ExecuteResult {
         executor_preference: ExecutorPreference,
         action_and_blobs: ActionDigestAndBlobs,
         input_files_bytes: u64,
+        request: CommandExecutionRequest,
     },
 }
 
@@ -1131,6 +1132,7 @@ impl RunAction {
             executor_preference: req.executor_preference,
             action_and_blobs,
             input_files_bytes: req.paths().input_files_bytes(),
+            request: req,
         })
     }
 
@@ -1446,6 +1448,7 @@ impl Action for RunAction {
             executor_preference,
             action_and_blobs,
             input_files_bytes,
+            request,
         ) = match self.execute_inner(ctx).await? {
             ExecuteResult::LocalDepFileHit(outputs, metadata) => {
                 return Ok((outputs, metadata));
@@ -1456,12 +1459,14 @@ impl Action for RunAction {
                 executor_preference,
                 action_and_blobs,
                 input_files_bytes,
+                request,
             } => (
                 result,
                 dep_file_bundle,
                 executor_preference,
                 action_and_blobs,
                 input_files_bytes,
+                request,
             ),
         };
 
@@ -1489,6 +1494,7 @@ impl Action for RunAction {
             let re_result = result.action_result.take();
             let upload_result = ctx
                 .cache_upload(
+                    &request,
                     &action_and_blobs,
                     &result,
                     re_result,

--- a/app/buck2_build_api/src/actions.rs
+++ b/app/buck2_build_api/src/actions.rs
@@ -262,6 +262,7 @@ pub trait ActionExecutionCtx: Send + Sync {
 
     async fn cache_upload(
         &mut self,
+        request: &CommandExecutionRequest,
         action: &ActionDigestAndBlobs,
         execution_result: &CommandExecutionResult,
         re_result: Option<TActionResult2>,

--- a/app/buck2_build_api/src/actions/execute/action_execution_target.rs
+++ b/app/buck2_build_api/src/actions/execute/action_execution_target.rs
@@ -86,4 +86,22 @@ impl CommandExecutionTarget for ActionExecutionTarget<'_> {
             identifier: self.action.identifier().unwrap_or("").to_owned(),
         }
     }
+
+    fn action_mnemonic(&self) -> Option<String> {
+        Some(self.action.category().as_str().to_owned())
+    }
+
+    fn target_label(&self) -> Option<String> {
+        self.action
+            .owner()
+            .unpack_target_label()
+            .map(ToString::to_string)
+    }
+
+    fn configuration_hash(&self) -> Option<String> {
+        self.action
+            .owner()
+            .unpack_target_label()
+            .map(|label| label.cfg().output_hash().as_str().to_owned())
+    }
 }

--- a/app/buck2_build_api/src/actions/execute/action_executor.rs
+++ b/app/buck2_build_api/src/actions/execute/action_executor.rs
@@ -593,6 +593,7 @@ impl ActionExecutionCtx for BuckActionExecutionContext<'_> {
 
     async fn cache_upload(
         &mut self,
+        request: &CommandExecutionRequest,
         action_digest_and_blobs: &ActionDigestAndBlobs,
         execution_result: &CommandExecutionResult,
         re_result: Option<TActionResult2>,
@@ -608,6 +609,7 @@ impl ActionExecutionCtx for BuckActionExecutionContext<'_> {
                     digest_config: self.digest_config(),
                     mergebase: self.mergebase().0.as_ref(),
                     re_platform: self.re_platform(),
+                    paths: request.paths(),
                 },
                 execution_result,
                 re_result,

--- a/app/buck2_build_api/src/materialize.rs
+++ b/app/buck2_build_api/src/materialize.rs
@@ -19,6 +19,7 @@ use buck2_common::legacy_configs::key::BuckconfigKeyRef;
 use buck2_common::legacy_configs::view::LegacyBuckConfigView;
 use buck2_core::execution_types::executor_config::RemoteExecutorUseCase;
 use buck2_core::fs::project_rel_path::ProjectRelativePath;
+use buck2_directory::directory::fingerprinted_directory::FingerprintedDirectory;
 use buck2_error::BuckErrorContext;
 use buck2_execute::artifact::artifact_dyn::ArtifactDyn;
 use buck2_execute::artifact_utils::ArtifactValueBuilder;
@@ -27,6 +28,7 @@ use buck2_execute::digest_config::HasDigestConfig;
 use buck2_execute::directory::ActionDirectoryBuilder;
 use buck2_execute::execute::blobs::ActionBlobs;
 use buck2_execute::materialize::materializer::HasMaterializer;
+use buck2_execute::re::action_identity::ReActionIdentity;
 use dashmap::DashSet;
 use dice::DiceComputations;
 use dice::UserComputationData;
@@ -190,7 +192,10 @@ async fn ensure_uploaded(
             &ActionBlobs::new(digest_config),
             ProjectRelativePath::empty(),
             &dir,
-            None,
+            &ReActionIdentity::minimal(
+                dir.fingerprint().raw_digest().to_string(),
+                Some(dir.fingerprint().raw_digest().to_string()),
+            ),
             digest_config,
             ctx.per_transaction_data()
                 .get_run_action_knobs()

--- a/app/buck2_execute/src/execute/cache_uploader.rs
+++ b/app/buck2_execute/src/execute/cache_uploader.rs
@@ -17,6 +17,7 @@ use remote_execution::TActionResult2;
 use crate::digest_config::DigestConfig;
 use crate::execute::action_digest_and_blobs::ActionDigestAndBlobs;
 use crate::execute::dep_file_digest::DepFileDigest;
+use crate::execute::request::CommandExecutionPaths;
 use crate::execute::result::CommandExecutionResult;
 use crate::execute::target::CommandExecutionTarget;
 use crate::materialize::materializer::Materializer;
@@ -26,6 +27,7 @@ pub struct CacheUploadInfo<'a> {
     pub digest_config: DigestConfig,
     pub mergebase: &'a Option<String>,
     pub re_platform: &'a remote_execution::Platform,
+    pub paths: &'a CommandExecutionPaths,
 }
 
 #[async_trait]

--- a/app/buck2_execute/src/execute/target.rs
+++ b/app/buck2_execute/src/execute/target.rs
@@ -18,4 +18,19 @@ pub trait CommandExecutionTarget: Send + Sync + Debug {
     fn as_proto_action_key(&self) -> buck2_data::ActionKey;
 
     fn as_proto_action_name(&self) -> buck2_data::ActionName;
+
+    /// Optional mnemonic describing the action kind (e.g. `CxxCompile`).
+    fn action_mnemonic(&self) -> Option<String> {
+        None
+    }
+
+    /// Optional configured target label this action belongs to.
+    fn target_label(&self) -> Option<String> {
+        None
+    }
+
+    /// Optional hash identifying the build configuration of the target.
+    fn configuration_hash(&self) -> Option<String> {
+        None
+    }
 }

--- a/app/buck2_execute/src/re/action_identity.rs
+++ b/app/buck2_execute/src/re/action_identity.rs
@@ -28,6 +28,14 @@ pub struct ReActionIdentity<'a> {
     /// Details about the action collected while uploading
     pub paths: &'a CommandExecutionPaths,
 
+    /// Optional action id (usually the action digest hash) used for request metadata.
+    pub action_id: Option<String>,
+
+    /// Optional action mnemonic, target label and configuration hash used for OSS RE metadata.
+    pub action_mnemonic: Option<String>,
+    pub target_label: Option<String>,
+    pub configuration_hash: Option<String>,
+
     //// Trace ID which started the execution of this action, to be added on the RE side
     pub trace_id: TraceId,
 }
@@ -37,6 +45,7 @@ impl<'a> ReActionIdentity<'a> {
         target: &'a dyn CommandExecutionTarget,
         executor_action_key: Option<&str>,
         paths: &'a CommandExecutionPaths,
+        action_id: Option<String>,
     ) -> Self {
         let mut action_key = target.re_action_key();
         if let Some(executor_action_key) = executor_action_key {
@@ -44,12 +53,19 @@ impl<'a> ReActionIdentity<'a> {
         }
 
         let trace_id = get_dispatcher().trace_id().to_owned();
+        let action_mnemonic = target.action_mnemonic();
+        let target_label = target.target_label();
+        let configuration_hash = target.configuration_hash();
 
         Self {
             _target: target,
             action_key,
             affinity_key: target.re_affinity_key(),
             paths,
+            action_id,
+            action_mnemonic,
+            target_label,
+            configuration_hash,
             trace_id,
         }
     }

--- a/app/buck2_execute/src/re/action_identity.rs
+++ b/app/buck2_execute/src/re/action_identity.rs
@@ -17,7 +17,7 @@ use crate::execute::target::CommandExecutionTarget;
 pub struct ReActionIdentity<'a> {
     /// This is currently unused, but historically it has been useful to add logging in the RE
     /// client, so it's worth keeping around.
-    _target: &'a dyn CommandExecutionTarget,
+    _target: Option<&'a dyn CommandExecutionTarget>,
 
     /// Actions with the same action key share e.g. memory requirements learnt by RE.
     pub action_key: String,
@@ -26,7 +26,7 @@ pub struct ReActionIdentity<'a> {
     pub affinity_key: String,
 
     /// Details about the action collected while uploading
-    pub paths: &'a CommandExecutionPaths,
+    pub paths: Option<&'a CommandExecutionPaths>,
 
     /// Optional action id (usually the action digest hash) used for request metadata.
     pub action_id: Option<String>,
@@ -58,15 +58,31 @@ impl<'a> ReActionIdentity<'a> {
         let configuration_hash = target.configuration_hash();
 
         Self {
-            _target: target,
+            _target: Some(target),
             action_key,
             affinity_key: target.re_affinity_key(),
-            paths,
+            paths: Some(paths),
             action_id,
             action_mnemonic,
             target_label,
             configuration_hash,
             trace_id,
+        }
+    }
+
+    /// Create a minimal identity for operations that don't have a full action context,
+    /// such as permission checks.
+    pub fn minimal(action_key: String, action_id: Option<String>) -> Self {
+        Self {
+            _target: None,
+            action_key,
+            affinity_key: String::new(),
+            paths: None,
+            action_id,
+            action_mnemonic: None,
+            target_label: None,
+            configuration_hash: None,
+            trace_id: get_dispatcher().trace_id().to_owned(),
         }
     }
 }

--- a/app/buck2_execute/src/re/manager.rs
+++ b/app/buck2_execute/src/re/manager.rs
@@ -379,7 +379,7 @@ impl ManagedRemoteExecutionClient {
         blobs: &ActionBlobs,
         dir_path: &ProjectRelativePath,
         input_dir: &ActionImmutableDirectory,
-        identity: Option<&ReActionIdentity<'_>>,
+        identity: &ReActionIdentity<'_>,
         digest_config: DigestConfig,
         deduplicate_get_digests_ttl_calls: bool,
     ) -> buck2_error::Result<UploadStats> {
@@ -405,6 +405,7 @@ impl ManagedRemoteExecutionClient {
         files_with_digest: Vec<NamedDigest>,
         directories: Vec<remote_execution::Path>,
         inlined_blobs_with_digest: Vec<InlinedBlobWithDigest>,
+        identity: &ReActionIdentity<'_>,
     ) -> buck2_error::Result<()> {
         self.lock()?
             .get()
@@ -414,6 +415,7 @@ impl ManagedRemoteExecutionClient {
                 directories,
                 inlined_blobs_with_digest,
                 self.use_case,
+                identity,
             )
             .await
     }

--- a/app/buck2_execute/src/re/metadata.rs
+++ b/app/buck2_execute/src/re/metadata.rs
@@ -30,14 +30,18 @@ impl RemoteExecutionMetadataExt for RemoteExecutorUseCase {
         RemoteExecutionMetadata {
             use_case_id: self.as_str().to_owned(),
             buck_info: Some(BuckInfo {
-                build_id: trace_id,
+                build_id: trace_id.clone(),
                 ..Default::default()
             }),
+            correlated_invocations_id: Some(trace_id),
             action_history_info: identity.map(|identity| ActionHistoryInfo {
                 action_key: identity.action_key.clone(),
                 disable_retry_on_oom: false,
                 ..Default::default()
             }),
+            action_mnemonic: identity.and_then(|identity| identity.action_mnemonic.clone()),
+            target_id: identity.and_then(|identity| identity.target_label.clone()),
+            configuration_id: identity.and_then(|identity| identity.configuration_hash.clone()),
             ..Default::default()
         }
     }

--- a/app/buck2_execute/src/re/uploader.rs
+++ b/app/buck2_execute/src/re/uploader.rs
@@ -82,7 +82,7 @@ impl Uploader {
         input_dir: &'a ActionImmutableDirectory,
         blobs: &'a ActionBlobs,
         use_case: &RemoteExecutorUseCase,
-        identity: Option<&ReActionIdentity<'_>>,
+        identity: &ReActionIdentity<'_>,
         digest_config: DigestConfig,
         deduplicate_get_digests_ttl_calls: bool,
     ) -> buck2_error::Result<(
@@ -175,8 +175,8 @@ impl Uploader {
             })
         } else {
             let client = client.clone();
-            let mut metadata = use_case.metadata(identity);
-            if let Some(id) = identity.and_then(|id| id.action_id.clone()) {
+            let mut metadata = use_case.metadata(Some(identity));
+            if let Some(id) = identity.action_id.clone() {
                 metadata.action_id = Some(id);
             }
             let request = GetDigestsTtlRequest {
@@ -236,7 +236,7 @@ impl Uploader {
         input_dir: &ActionImmutableDirectory,
         blobs: &ActionBlobs,
         use_case: RemoteExecutorUseCase,
-        identity: Option<&ReActionIdentity<'_>>,
+        identity: &ReActionIdentity<'_>,
         digest_config: DigestConfig,
         deduplicate_get_digests_ttl_calls: bool,
     ) -> buck2_error::Result<UploadStats> {
@@ -435,8 +435,8 @@ impl Uploader {
 
         // Upload
         if !upload_files.is_empty() || !upload_blobs.is_empty() {
-            let mut metadata = use_case.metadata(identity);
-            if let Some(id) = identity.and_then(|id| id.action_id.clone()) {
+            let mut metadata = use_case.metadata(Some(identity));
+            if let Some(id) = identity.action_id.clone() {
                 metadata.action_id = Some(id);
             }
             with_error_handler(
@@ -597,7 +597,7 @@ impl<'s> GetDigestsTtlDeduper<'s> {
         deduper: &'s Mutex<Self>,
         client: &'a RemoteExecutionClient,
         use_case: RemoteExecutorUseCase,
-        identity: Option<&'a ReActionIdentity<'a>>,
+        identity: &'a ReActionIdentity<'a>,
         digest_config: DigestConfig,
         digests: impl IntoIterator<Item = &'a TrackedFileDigest>,
     ) -> (
@@ -669,13 +669,13 @@ fn query_digest_ttls<'s>(
     request_id: RequestId,
     client: &RemoteExecutionClient,
     use_case: RemoteExecutorUseCase,
-    identity: Option<&ReActionIdentity<'_>>,
+    identity: &ReActionIdentity<'_>,
     digest_config: DigestConfig,
     input_digests: Vec<TrackedFileDigest>,
 ) -> BoxFuture<'s, buck2_error::Result<HashMap<TrackedFileDigest, i64>>> {
     let client = client.dupe();
-    let mut metadata = use_case.metadata(identity);
-    if let Some(id) = identity.and_then(|id| id.action_id.clone()) {
+    let mut metadata = use_case.metadata(Some(identity));
+    if let Some(id) = identity.action_id.clone() {
         metadata.action_id = Some(id);
     }
     let request = GetDigestsTtlRequest {

--- a/app/buck2_execute_impl/src/executors/action_cache.rs
+++ b/app/buck2_execute_impl/src/executors/action_cache.rs
@@ -107,12 +107,12 @@ async fn query_action_cache_and_download_result(
     )
     .await;
 
-    let identity = Some(ReActionIdentity::new(
+    let identity = ReActionIdentity::new(
         command.target,
         re_action_key.as_deref(),
         command.request.paths(),
         Some(action_digest.raw_digest().to_string()),
-    ));
+    );
     if upload_all_actions {
         match re_client
             .upload(
@@ -121,7 +121,7 @@ async fn query_action_cache_and_download_result(
                 action_blobs,
                 ProjectRelativePath::empty(),
                 request.paths().input_directory(),
-                identity.as_ref(),
+                &identity,
                 digest_config,
                 deduplicate_get_digests_ttl_calls,
             )
@@ -167,13 +167,6 @@ async fn query_action_cache_and_download_result(
             Some(dep_file_entry)
         }
     };
-
-    let identity = ReActionIdentity::new(
-        command.target,
-        re_action_key.as_deref(),
-        command.request.paths(),
-        Some(action_digest.raw_digest().to_string()),
-    );
 
     let response = ActionCacheResult(response, cache_type.to_proto());
     let res = download_action_results(

--- a/app/buck2_execute_impl/src/executors/action_cache.rs
+++ b/app/buck2_execute_impl/src/executors/action_cache.rs
@@ -107,7 +107,12 @@ async fn query_action_cache_and_download_result(
     )
     .await;
 
-    let identity = None; // TODO(#503): implement this
+    let identity = Some(ReActionIdentity::new(
+        command.target,
+        re_action_key.as_deref(),
+        command.request.paths(),
+        Some(action_digest.raw_digest().to_string()),
+    ));
     if upload_all_actions {
         match re_client
             .upload(
@@ -116,7 +121,7 @@ async fn query_action_cache_and_download_result(
                 action_blobs,
                 ProjectRelativePath::empty(),
                 request.paths().input_directory(),
-                identity,
+                identity.as_ref(),
                 digest_config,
                 deduplicate_get_digests_ttl_calls,
             )
@@ -167,6 +172,7 @@ async fn query_action_cache_and_download_result(
         command.target,
         re_action_key.as_deref(),
         command.request.paths(),
+        Some(action_digest.raw_digest().to_string()),
     );
 
     let response = ActionCacheResult(response, cache_type.to_proto());

--- a/app/buck2_execute_impl/src/executors/action_cache_upload_permission_checker.rs
+++ b/app/buck2_execute_impl/src/executors/action_cache_upload_permission_checker.rs
@@ -18,6 +18,7 @@ use buck2_error::BuckErrorContext;
 use buck2_execute::digest_config::DigestConfig;
 use buck2_execute::re::client::ActionCacheWriteType;
 use buck2_execute::re::error::RemoteExecutionError;
+use buck2_execute::re::action_identity::ReActionIdentity;
 use buck2_execute::re::manager::ManagedRemoteExecutionClient;
 use dashmap::DashMap;
 use dupe::Dupe;
@@ -58,9 +59,18 @@ impl ActionCacheUploadPermissionChecker {
     ) -> buck2_error::Result<Result<(), String>> {
         let (action, action_result) = empty_action_result(platform, digest_config)?;
 
-        // This is CAS upload, if it fails, something is very broken.
+        // This is CAS upload for permission check with a synthetic empty action.
+        let identity = ReActionIdentity::minimal(
+            "CASPermCheck".to_owned(),
+            Some("CASPermCheck".to_owned()),
+        );
         re_client
-            .upload_files_and_directories(Vec::new(), Vec::new(), action.blobs.to_inlined_blobs())
+            .upload_files_and_directories(
+                Vec::new(),
+                Vec::new(),
+                action.blobs.to_inlined_blobs(),
+                &identity,
+            )
             .await?;
 
         // This operation requires permission to write.

--- a/app/buck2_execute_impl/src/executors/caching.rs
+++ b/app/buck2_execute_impl/src/executors/caching.rs
@@ -22,9 +22,9 @@ use buck2_directory::directory::entry::DirectoryEntry;
 use buck2_error::BuckErrorContext;
 use buck2_events::dispatch::span_async;
 use buck2_execute::digest::CasDigestToReExt;
-use buck2_execute::digest_config::DigestConfig;
 use buck2_execute::directory::ActionDirectoryMember;
 use buck2_execute::directory::directory_to_re_tree;
+use buck2_execute::execute::action_digest::ActionDigest;
 use buck2_execute::execute::action_digest_and_blobs::ActionDigestAndBlobs;
 use buck2_execute::execute::blobs::ActionBlobs;
 use buck2_execute::execute::cache_uploader::CacheUploadInfo;
@@ -33,6 +33,7 @@ use buck2_execute::execute::cache_uploader::IntoRemoteDepFile;
 use buck2_execute::execute::cache_uploader::UploadCache;
 use buck2_execute::execute::result::CommandExecutionResult;
 use buck2_execute::materialize::materializer::Materializer;
+use buck2_execute::re::action_identity::ReActionIdentity;
 use buck2_execute::re::client::ActionCacheWriteType;
 use buck2_execute::re::error::RemoteExecutionError;
 use buck2_execute::re::manager::ManagedRemoteExecutionClient;
@@ -119,7 +120,7 @@ impl CacheUploader {
                 name: Some(info.target.as_proto_action_name()),
                 action_digest: digest_str.clone(),
             },
-            async {
+            async move {
                 let mut file_digests = Vec::new();
                 let mut tree_digests = Vec::new();
 
@@ -150,10 +151,11 @@ impl CacheUploader {
                     // upload ActionResult to ActionCache
                     let result: TActionResult2 = match self
                         .upload_files_and_directories(
+                            info,
                             result,
                             &mut file_digests,
                             &mut tree_digests,
-                            info.digest_config,
+                            &digest,
                         )
                         .await?
                     {
@@ -315,14 +317,19 @@ impl CacheUploader {
 
     async fn upload_files_and_directories(
         &self,
+        info: &CacheUploadInfo<'_>,
         result: &CommandExecutionResult,
         file_digests: &mut Vec<TrackedFileDigest>,
         tree_digests: &mut Vec<TrackedFileDigest>,
-        digest_config: DigestConfig,
+        action_digest: &ActionDigest,
     ) -> buck2_error::Result<Result<TActionResult2, CacheUploadRejectionReason>> {
+        let digest_config = info.digest_config;
         let mut upload_futs = vec![];
         let mut output_files: Vec<TFile> = Vec::new();
         let mut output_directories: Vec<TDirectory2> = Vec::new();
+
+        // Precompute the action_id string once since it's the same for all directory uploads.
+        let action_id = action_digest.raw_digest().to_string();
 
         for output_result in result.resolve_outputs(&self.artifact_fs) {
             let (output, value) = output_result?;
@@ -379,7 +386,16 @@ impl CacheUploader {
                         ..Default::default()
                     });
 
-                    let identity = None; // TODO(#503): implement this
+                    // ReActionIdentity contains references so it cannot be moved into the async
+                    // block. Create it inside the closure instead. The action_id is precomputed
+                    // above to avoid repeated string allocations.
+                    let identity = ReActionIdentity::new(
+                        info.target,
+                        None, // re_action_key not available in cache upload context
+                        info.paths,
+                        Some(action_id.clone()),
+                    );
+
                     let fut = async move {
                         self.re_client
                             .upload(
@@ -388,7 +404,7 @@ impl CacheUploader {
                                 &action_blobs,
                                 output.path(),
                                 &d.dupe().as_immutable(),
-                                identity,
+                                Some(&identity),
                                 digest_config,
                                 self.deduplicate_get_digests_ttl_calls,
                             )

--- a/app/buck2_execute_impl/src/executors/re.rs
+++ b/app/buck2_execute_impl/src/executors/re.rs
@@ -373,8 +373,12 @@ impl PreparedCommandExecutor for ReExecutor {
             )?;
         }
 
-        let identity =
-            ReActionIdentity::new(*target, self.re_action_key.as_deref(), request.paths());
+        let identity = ReActionIdentity::new(
+            *target,
+            self.re_action_key.as_deref(),
+            request.paths(),
+            Some(action_and_blobs.action.raw_digest().to_string()),
+        );
 
         // TODO(bobyf, torozco): remote execution probably needs to explicitly handle cancellations
         let manager = self

--- a/app/buck2_execute_impl/src/executors/re.rs
+++ b/app/buck2_execute_impl/src/executors/re.rs
@@ -110,7 +110,7 @@ impl ReExecutor {
                     blobs,
                     ProjectRelativePath::empty(),
                     paths.input_directory(),
-                    Some(identity),
+                    identity,
                     digest_config,
                     self.deduplicate_get_digests_ttl_calls,
                 )

--- a/app/buck2_test/src/orchestrator.rs
+++ b/app/buck2_test/src/orchestrator.rs
@@ -1091,6 +1091,7 @@ impl BuckTestOrchestrator<'_> {
                         digest_config,
                         mergebase: &None,
                         re_platform: executor.re_platform(),
+                        paths: request.paths(),
                     };
                     let _result = match executor
                         .cache_upload(
@@ -2200,6 +2201,18 @@ impl CommandExecutionTarget for TestTarget<'_> {
             identifier: "".to_owned(),
         }
     }
+
+    fn action_mnemonic(&self) -> Option<String> {
+        Some("test".to_owned())
+    }
+
+    fn target_label(&self) -> Option<String> {
+        Some(self.target.to_string())
+    }
+
+    fn configuration_hash(&self) -> Option<String> {
+        Some(self.target.cfg().output_hash().as_str().to_owned())
+    }
 }
 
 fn create_action_key_suffix(stage: &TestStage) -> String {
@@ -2252,6 +2265,18 @@ impl CommandExecutionTarget for LocalResourceTarget<'_> {
             category: "setup_local_resource".to_owned(),
             identifier: "".to_owned(),
         }
+    }
+
+    fn action_mnemonic(&self) -> Option<String> {
+        Some("setup_local_resource".to_owned())
+    }
+
+    fn target_label(&self) -> Option<String> {
+        Some(self.target.to_string())
+    }
+
+    fn configuration_hash(&self) -> Option<String> {
+        Some(self.target.cfg().output_hash().as_str().to_owned())
     }
 }
 

--- a/remote_execution/oss/re_grpc/src/metadata.rs
+++ b/remote_execution/oss/re_grpc/src/metadata.rs
@@ -42,5 +42,10 @@ pub struct RemoteExecutionMetadata {
     pub do_not_cache: bool,
     pub respect_file_symlinks: Option<bool>,
     pub client_context: Option<TClientContextMetadata>,
+    pub action_id: Option<String>,
+    pub action_mnemonic: Option<String>,
+    pub target_id: Option<String>,
+    pub configuration_id: Option<String>,
+    pub correlated_invocations_id: Option<String>,
     pub _dot_dot: (),
 }


### PR DESCRIPTION
Instead of making 'identity' optional in some of the request paths, make the fields inside ReActionIdentity optional instead.

This enables us to mandate 'identity' for all call RBE client consumer. We simplify the creation of the identity by introducing a minimal constructor to use in different places with insufficient data to build a full one.

This change is based on https://github.com/facebook/buck2/pull/1169