### PR TITLE
Ignore set_cfg_constructor() in external cells

### DIFF
--- a/tests/core/configurations/cfg_constructor/BUCK
+++ b/tests/core/configurations/cfg_constructor/BUCK
@@ -1,0 +1,5 @@
+load("@fbcode//buck2/tests:buck_e2e.bzl", "buck2_core_tests")
+
+oncall("build_infra")
+
+buck2_core_tests()

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor.py
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# pyre-strict
+
+
+from buck2.tests.e2e_util.api.buck import Buck
+from buck2.tests.e2e_util.buck_workspace import buck_test
+
+
+@buck_test()
+async def test_external_cell_set_cfg_constructor_silently_ignored(buck: Buck) -> None:
+    """Test that set_cfg_constructor called from an external cell's PACKAGE is silently ignored.
+
+    The external cell has its own set_cfg_constructor call in its PACKAGE file.
+    This should be silently ignored, and the root cell's cfg_constructor
+    should be used instead.
+    """
+    # Query a target in the root cell - should succeed
+    result = await buck.cquery("root//:test")
+    assert "root//:test" in result.stdout
+
+
+@buck_test()
+async def test_external_cell_target_succeeds_with_cfg_constructor(buck: Buck) -> None:
+    """Test that targets in external cells work when the external cell has set_cfg_constructor.
+
+    Even though the external cell has its own set_cfg_constructor in its PACKAGE,
+    querying targets in that cell should succeed because the call is silently ignored.
+    """
+    # Query a target in the external cell - should succeed
+    # The external cell's set_cfg_constructor should be silently ignored
+    result = await buck.cquery("external_cell//:external_test")
+    assert "external_cell//:external_test" in result.stdout
+    # Make sure the external cell's constructor wasn't used
+    assert "SHOULD_NOT_BE_USED" not in result.stdout

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/.buckconfig
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/.buckconfig
@@ -1,0 +1,7 @@
+[buildfile]
+name = TARGETS.fixture
+
+[cells]
+root = .
+prelude = prelude
+external_cell = external_cell

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/PACKAGE
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/PACKAGE
@@ -1,0 +1,3 @@
+load("//:defs.bzl", "init_cfg_constructor")
+
+init_cfg_constructor()

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/TARGETS.fixture
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/TARGETS.fixture
@@ -1,0 +1,10 @@
+load(":rules.bzl", "test_platform", "test_rule")
+
+test_platform(
+    name = "platform",
+)
+
+test_rule(
+    name = "test",
+    default_target_platform = ":platform",
+)

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/defs.bzl
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/defs.bzl
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+KEY = "buck.cfg_modifiers"
+
+def _cfg_constructor_pre_constraint_analysis(
+        legacy_platform,
+        package_modifiers: dict[str, typing.Any] | None,
+        target_modifiers: dict[str, typing.Any] | None,
+        cli_modifiers: list[str],
+        rule_name: str,
+        aliases: struct | None,
+        extra_data: dict[str, typing.Any] | None):
+    _unused = package_modifiers  # buildifier: disable=unused-variable
+    _unused = target_modifiers  # buildifier: disable=unused-variable
+    _unused = cli_modifiers  # buildifier: disable=unused-variable
+    _unused = extra_data  # buildifier: disable=unused-variable
+    _unused = aliases  # buildifier: disable=unused-variable
+    _unused = rule_name  # buildifier: disable=unused-variable
+
+    platform = legacy_platform or PlatformInfo(label = "root_cfg_constructor", configuration = ConfigurationInfo(
+        constraints = {},
+        values = {},
+    ))
+    return ([], platform)
+
+def _cfg_constructor_post_constraint_analysis(refs: dict[str, ProviderCollection], params):
+    _unused = refs  # buildifier: disable=unused-variable
+    _unused = params  # buildifier: disable=unused-variable
+    return PlatformInfo(label = "root_post_constraint_analysis", configuration = ConfigurationInfo(
+        constraints = params.configuration.constraints,
+        values = {},
+    ))
+
+def init_cfg_constructor():
+    set_cfg_constructor(
+        key = KEY,
+        stage0 = _cfg_constructor_pre_constraint_analysis,
+        stage1 = _cfg_constructor_post_constraint_analysis,
+    )

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/.buckconfig
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/.buckconfig
@@ -1,0 +1,2 @@
+[buildfile]
+name = TARGETS.fixture

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/PACKAGE
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/PACKAGE
@@ -1,0 +1,5 @@
+load("//:defs.bzl", "init_cfg_constructor")
+
+# This call to set_cfg_constructor should be silently ignored
+# because this is an external cell, not the root cell.
+init_cfg_constructor()

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/TARGETS.fixture
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/TARGETS.fixture
@@ -1,0 +1,6 @@
+load(":rules.bzl", "test_rule")
+
+test_rule(
+    name = "external_test",
+    default_target_platform = "root//:platform",
+)

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/defs.bzl
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/defs.bzl
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# This file defines a cfg_constructor for the external cell.
+# The set_cfg_constructor call should be silently ignored since this is not the root cell.
+
+KEY = "buck.cfg_modifiers"
+
+def _cfg_constructor_pre_constraint_analysis(
+        legacy_platform,
+        package_modifiers: dict[str, typing.Any] | None,
+        target_modifiers: dict[str, typing.Any] | None,
+        cli_modifiers: list[str],
+        rule_name: str,
+        aliases: struct | None,
+        extra_data: dict[str, typing.Any] | None):
+    _unused = package_modifiers  # buildifier: disable=unused-variable
+    _unused = target_modifiers  # buildifier: disable=unused-variable
+    _unused = cli_modifiers  # buildifier: disable=unused-variable
+    _unused = extra_data  # buildifier: disable=unused-variable
+    _unused = aliases  # buildifier: disable=unused-variable
+    _unused = rule_name  # buildifier: disable=unused-variable
+
+    # Use a distinct label so we can detect if this constructor was used
+    platform = legacy_platform or PlatformInfo(label = "external_cfg_constructor_SHOULD_NOT_BE_USED", configuration = ConfigurationInfo(
+        constraints = {},
+        values = {},
+    ))
+    return ([], platform)
+
+def _cfg_constructor_post_constraint_analysis(refs: dict[str, ProviderCollection], params):
+    _unused = refs  # buildifier: disable=unused-variable
+    _unused = params  # buildifier: disable=unused-variable
+    # Use a distinct label so we can detect if this constructor was used
+    return PlatformInfo(label = "external_post_constraint_analysis_SHOULD_NOT_BE_USED", configuration = ConfigurationInfo(
+        constraints = params.configuration.constraints,
+        values = {},
+    ))
+
+def init_cfg_constructor():
+    # This call should be silently ignored since this PACKAGE is in an external cell
+    set_cfg_constructor(
+        key = KEY,
+        stage0 = _cfg_constructor_pre_constraint_analysis,
+        stage1 = _cfg_constructor_post_constraint_analysis,
+    )

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/rules.bzl
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/external_cell/rules.bzl
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+def _test_rule(ctx):
+    _unused = ctx  # buildifier: disable=unused-variable
+    return [
+        DefaultInfo(),
+    ]
+
+test_rule = rule(
+    impl = _test_rule,
+    attrs = {},
+)

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/prelude/prelude.bzl
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/prelude/prelude.bzl
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# Minimal prelude for testing

--- a/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/rules.bzl
+++ b/tests/core/configurations/cfg_constructor/test_external_cell_cfg_constructor_data/rules.bzl
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+def _test_platform_impl(ctx):
+    _unused = ctx  # buildifier: disable=unused-variable
+    return [
+        DefaultInfo(),
+        PlatformInfo(
+            label = str(ctx.label.raw_target()),
+            configuration = ConfigurationInfo(
+                constraints = {},
+                values = {},
+            ),
+        ),
+    ]
+
+test_platform = rule(
+    impl = _test_platform_impl,
+    attrs = {},
+)
+
+def _test_rule(ctx):
+    _unused = ctx  # buildifier: disable=unused-variable
+    return [
+        DefaultInfo(),
+    ]
+
+test_rule = rule(
+    impl = _test_rule,
+    attrs = {},
+)


### PR DESCRIPTION
When a repository is used as an external cell by another repository, its PACKAGE/BUCK_TREE file's `set_cfg_constructor()` call would previously error because it's not the root cell.