### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ jobs:
   linux-build-and-test:
     runs-on: 4-core-ubuntu
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup_linux_env
     - uses: ./.github/actions/build_debug
     - uses: ./.github/actions/run_test_py
@@ -17,14 +17,14 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup_macos_env
     - uses: ./.github/actions/build_debug
     - uses: ./.github/actions/run_test_py
   windows-build-and-test:
     runs-on: windows-8-core
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup_windows_env
     - uses: ./.github/actions/build_debug
     - uses: ./.github/actions/run_test_py
@@ -34,7 +34,7 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
         xcode-version: 16.4.0
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup_macos_env
     - uses: ./.github/actions/init_opam
     - uses: ./.github/actions/build_release
@@ -64,7 +64,7 @@ jobs:
   linux-build-examples:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4.1.0
+    - uses: actions/checkout@v6
     - uses: ./.github/actions/setup_linux_env
     - uses: ./.github/actions/init_opam
     - uses: ./.github/actions/build_release
@@ -101,7 +101,7 @@ jobs:
   windows-build-examples:
     runs-on: windows-8-core
     steps:
-      - uses: actions/checkout@v4.1.0
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_windows_env
       - uses: ./.github/actions/build_release
       - name: Build example/prelude directory

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -38,7 +38,7 @@ jobs:
           git rev-parse HEAD > ../artifacts/prelude_hash
           echo "prelude_hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Upload prelude_hash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: artifacts/prelude_hash
           name: prelude_hash
@@ -79,7 +79,7 @@ jobs:
     runs-on: ${{ matrix.target.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: SebRollen/toml-action@v1.0.2
@@ -160,7 +160,7 @@ jobs:
           zstd -z ${{ steps.set_variables.outputs.buck2_out }} -o ${{ steps.set_variables.outputs.buck2_zst }}
           zstd -z ${{ steps.set_variables.outputs.buck2_rust_project_out }} -o ${{ steps.set_variables.outputs.buck2_rust_project_zst }}
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: buck2-${{ matrix.target.triple }}
           path: artifacts/
@@ -172,7 +172,7 @@ jobs:
       - get_prelude_hash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       # Publish a new tag and upload all aritfacts from `build` and `get_prelude_hash`
@@ -233,7 +233,7 @@ jobs:
     # Only perform this action if check_for_bi_monthly_release set a tag output
     if: ${{ needs.check_for_bi_monthly_release.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       # Publish a new tag and upload all aritfacts from `build` and `get_prelude_hash`
@@ -255,9 +255,9 @@ jobs:
       - build
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Download Buck2
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: buck2-x86_64-unknown-linux-gnu
         path: artifacts


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/download-artifact` | [``](https://github.com/actions/download-artifact/releases/tag/) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
