### PR TITLE
fix OSS cargo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ clap_complete = "4.5.5"
 common-path = "1.0.0"
 compact_str = "0.8"
 console = "0.15.7"
+const-oid = { version = "0.9.6", features = ["db"] }
 const_format = "0.2.32"
 constant_time_eq = "0.2.4"
 convert_case = "0.4.0"
@@ -176,7 +177,7 @@ dashmap = "5.5.3"
 debugserver-types = "0.5.0"
 derivative = "2.2"
 derive_more = { version = "1.0.0", features = ["full"] }
-digest = "0.10"
+digest = { version = "0.10", features = ["oid"] }
 dirs = "3.0.1"
 dunce = "1.0.2"
 either = "1.8"

--- a/app/buck2_execute/src/execute/command_executor.rs
+++ b/app/buck2_execute/src/execute/command_executor.rs
@@ -443,6 +443,7 @@ fn re_create_action(
     #[cfg(not(fbcode_build))]
     {
         let _unused = &mut action;
+        let _unused = re_outputs_required;
     }
 
     let action_and_blobs = action_and_blobs.build(&action);

--- a/pagable/Cargo.toml
+++ b/pagable/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 blake3 = { workspace = true }
 bytemuck = { workspace = true }
+const-oid = { workspace = true }
 dupe = { workspace = true }
 either = { workspace = true }
 gazebo = { workspace = true }

--- a/pagable/src/lib.rs
+++ b/pagable/src/lib.rs
@@ -20,6 +20,9 @@
 
 #![feature(const_type_name)]
 
+pub use pagable_arc::PagableArc;
+pub use pagable_arc::PinnedPagableArc;
+pub use pagable_arc::PinnedPagableArcBorrow;
 pub use pagable_derive::Pagable;
 pub use pagable_derive::PagableDeserialize;
 pub use pagable_derive::PagableSerialize;


### PR DESCRIPTION
Summary:
Fixes:

```
error: unused variable: `re_outputs_required`
   --> app/buck2_execute/src/execute/command_executor.rs:273:5
    |
273 |     re_outputs_required: bool,
    |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_re_outputs_required`
```

```
error[E0433]: failed to resolve: could not find `const_oid` in `digest`
   --> pagable/src/pagable_arc.rs:116:29
    |
116 | use blake3::traits::digest::const_oid::db::rfc4519::O;
    |                             ^^^^^^^^^ could not find `const_oid` in `digest`
```

Differential Revision: D89368680


