### PR TITLE
fix cargo build on windows

### DIFF
--- a/app/buck2_resource_control/src/lib.rs
+++ b/app/buck2_resource_control/src/lib.rs
@@ -112,8 +112,6 @@ pub struct RetryFuture(
 pub mod action_cgroups {
     use std::time::Duration;
 
-    use buck2_events::dispatch::EventDispatcher;
-
     use crate::CommandType;
     use crate::RetryFuture;
     use crate::memory_tracker::MemoryTrackerHandle;


### PR DESCRIPTION
Summary:
Fixes:
```
error: unused import: `buck2_events::dispatch::EventDispatcher`
   --> app\buck2_resource_control\src\lib.rs:115:9
    |
115 |     use buck2_events::dispatch::EventDispatcher;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: requested on the command line with `-D unused-imports`
```

Differential Revision: D89460111


