### PR TITLE
fix: nix flake lock outdated

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748399823,
-        "narHash": "sha256-kahD8D5hOXOsGbNdoLLnqCL887cjHkx98Izc37nDjlA=",
+        "lastModified": 1766198367,
+        "narHash": "sha256-f1L1rCEu2Zew6zdiZ38jJDZd65ktE7UN+Gqn2LHPiFI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d68a69dc71bc19beb3479800392112c2f6218159",
+        "rev": "66bb33fdfb50b1ee724381c3f5d6012dac6c89b3",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -9,6 +9,7 @@
 #   * NOTE: You may have to change this ocaml file in a follow up commit as ocamlrep
 #     has a dependency on buck2 git trunk.
 # * Update `../monarch/rust-toolchain` (one instance)
+# * Update flake.lock via `nix flake update rust-overlay`
 
 # @rustc_version: rustc 1.91.0-nightly (02c7b1a7a 2025-09-13)
 channel = "nightly-2025-09-14"


### PR DESCRIPTION
The flake lock is using an older version of https://github.com/oxalica/rust-overlay

which at the time only supported rust version `2025-05-28`
https://github.com/oxalica/rust-overlay/blob/d68a69dc71bc19beb3479800392112c2f6218159/manifests/nightly/default.nix#L508

This updates the lock and then adds a documentation to future bumpers to also update the lock when they change the version again.