### PR TITLE
rust-project: populate `sysroot_src`

### DIFF
--- a/integrations/rust-project/src/main.rs
+++ b/integrations/rust-project/src/main.rs
@@ -89,10 +89,17 @@ enum Command {
         #[clap(long, conflicts_with = "sysroot")]
         prefer_rustup_managed_toolchain: bool,
 
-        /// The directory containing the Rust source code, including std.
+        /// The directory containing the Rust standard library and the rust-analyzer proc macro
+        /// server.
         /// Default value is determined based on platform.
         #[clap(short = 's', long)]
         sysroot: Option<PathBuf>,
+
+        /// The directory containing the Rust standard library source code.
+        /// Defaults to the value of the `RUST_SRC_PATH` environment variable, if set, or the
+        /// `--sysroot` flag otherwise.
+        #[clap(long)]
+        sysroot_src: Option<PathBuf>,
 
         /// Pretty-print generated `rust-project.json` file.
         #[clap(short, long)]

--- a/integrations/rust-project/src/sysroot.rs
+++ b/integrations/rust-project/src/sysroot.rs
@@ -25,7 +25,10 @@ use crate::target::Target;
 
 #[derive(Debug)]
 pub(crate) enum SysrootConfig {
-    Sysroot(PathBuf),
+    Sysroot {
+        sysroot: PathBuf,
+        sysroot_src: PathBuf,
+    },
     BuckConfig,
     Rustup,
 }


### PR DESCRIPTION
According to
https://rust-analyzer.github.io/book/non_cargo_based_projects.html, rust-analyzer should compute `sysroot_src` from `sysroot` if it is absent.

According to my testing, this is not the case, and rust-analyzer is broken if `sysroot_src` is not populated.

To fix this, we populate it from a new `--sysroot-src` flag, or the de facto standard `RUST_SRC_PATH`, which fixes the issue.

Ideally, rust-analyzer should be fixed but:
1. I haven't gotten to the bottom of that bug.
2. This commit remains correct in the meantime.
3. This commit allows setups where the binary sysroot and source sysroots are different (as is the case in Nixpks, where they come from different packages).