### PR TITLE
git_fetch: Optional initialization/update of Git submodules

### DIFF
--- a/prelude/decls/git_rules.bzl
+++ b/prelude/decls/git_rules.bzl
@@ -59,6 +59,12 @@ git_fetch = prelude_rule(
                 Commit hash. 40 hex digits for sha1, 64 hex digits for sha256.
             """
             ),
+            "update_submodules": attrs.bool(
+                default = False,
+                doc = """
+                Whether to initialize and update Git submodules after the worktree checkout.
+            """
+            ),
             "sub_targets": attrs.list(
                 attrs.string(),
                 default = [],

--- a/prelude/git/git_fetch.bzl
+++ b/prelude/git/git_fetch.bzl
@@ -38,12 +38,18 @@ def git_fetch_impl(ctx: AnalysisContext) -> list[Provider]:
         short_path = "work-tree"
     work_tree = ctx.actions.declare_output(short_path, dir = True, has_content_based_path = False)
 
+    if ctx.attrs.update_submodules:
+        update_submodules = cmd_args("--update-submodules")
+    else:
+        update_submodules = cmd_args()
+
     cmd = [
         ctx.attrs._git_fetch_tool[RunInfo],
         cmd_args("--git-dir=", git_dir.as_output(), delimiter = ""),
         cmd_args("--work-tree=", work_tree.as_output(), delimiter = ""),
         cmd_args("--repo=", ctx.attrs.repo, delimiter = ""),
         cmd_args("--rev=", rev, delimiter = ""),
+        update_submodules,
     ]
     if ctx.attrs.git != None:
         cmd.append(cmd_args("--git=", ctx.attrs.git, delimiter = ""))

--- a/prelude/git/tools/git_fetch.py
+++ b/prelude/git/tools/git_fetch.py
@@ -7,6 +7,7 @@
 # above-listed licenses.
 
 import argparse
+import os
 import shutil
 import subprocess
 import sys
@@ -70,6 +71,7 @@ class Args(NamedTuple):
     object_format: ObjectFormat
     repo: str
     rev: str
+    update_submodules: bool
 
 
 def arg_parse() -> Args:
@@ -78,6 +80,7 @@ def arg_parse() -> Args:
     parser.add_argument("--git-dir", type=Path, required=True)
     parser.add_argument("--work-tree", type=Path, required=True)
     parser.add_argument("--object-format", type=ObjectFormat, required=False)
+    parser.add_argument("--update-submodules", action='store_true', required=False)
     parser.add_argument("--repo", type=str, required=True)
     parser.add_argument("--rev", type=str, required=True)
     return Args(**vars(parser.parse_args()))
@@ -97,7 +100,7 @@ def main() -> None:
     args.work_tree.mkdir(exist_ok=True)
 
     git_bin = _find_git(args.git)
-    git = [git_bin, f"--git-dir={args.git_dir}", f"--work-tree={args.work_tree}"]
+    git = [git_bin, "--git-dir", args.git_dir, "--work-tree", args.work_tree]
     if args.object_format is None:
         object_format_args = []
     else:
@@ -117,6 +120,10 @@ def main() -> None:
         )
 
     run([*git, "checkout", "FETCH_HEAD"], check=True)
+
+    if args.update_submodules:
+        git_in_worktree = [git_bin, "--git-dir", os.path.abspath(args.git_dir), "-C", args.work_tree]
+        run([*git_in_worktree, "submodule", "update", "--init"], check=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a new (optional) attribute `update_submodules` to the git_fetch rule. If set to `True`, `git submodule update --init` is run after the checkout of the worktree.