### PR TITLE
Fix SortedSet: new_unchecked debug assertion and sorted union

### DIFF
--- a/starlark-rust/starlark_map/src/sorted_set.rs
+++ b/starlark-rust/starlark_map/src/sorted_set.rs
@@ -46,8 +46,15 @@ where
     }
 
     /// Construct without checking that the elements are sorted.
+    ///
+    /// # Safety
+    /// Caller must guarantee that `inner` is already sorted.
     #[inline]
     pub fn new_unchecked(inner: OrderedSet<T>) -> Self {
+        debug_assert!(
+            inner.is_sorted(),
+            "SortedSet::new_unchecked called with unsorted OrderedSet"
+        );
         Self { inner }
     }
 
@@ -93,11 +100,19 @@ where
         self.inner.get_index(index)
     }
 
-    /// Iterate over the union of two sets.
+    /// Return a sorted union of two `SortedSet`s.
     #[inline]
-    pub fn union<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = &'a T> {
-        // TODO(nga): return sorted.
-        self.inner.union(&other.inner)
+    pub fn union(&self, other: &Self) -> SortedSet<T>
+    where
+        T: Clone,
+    {
+        let mut inner = OrderedSet::new();
+
+        inner.extend(self.inner.iter().cloned());
+        inner.extend(other.inner.iter().cloned());
+
+        inner.sort();
+        SortedSet { inner }
     }
 }
 


### PR DESCRIPTION
- Added a debug assertion in `SortedSet::new_unchecked` to ensure the inner OrderedSet is already sorted.
- Updated `SortedSet::union` to return a properly sorted `SortedSet` instead of an unsorted iterator.
- Ensures that all SortedSet instances maintain the invariant that elements are sorted, improving safety and correctness.

This fixes potential issues where unsorted elements could be introduced and guarantees that union operations produce a valid SortedSet.