### PR TITLE
feat(rust): enable incoming_transition on rust_library

### DIFF
--- a/prelude/decls/rust_rules.bzl
+++ b/prelude/decls/rust_rules.bzl
@@ -207,6 +207,7 @@ rust_library = prelude_rule(
         third_party_common.create_third_party_build_root_attrs()
     ),
     uses_plugins = [RustProcMacroPlugin],
+    supports_incoming_transition = True,
 )
 
 rust_test = prelude_rule(


### PR DESCRIPTION
When first-party code uses constraints to enable specific behavior (test-only APIs, nightly features, etc.), those constraints propagate through the entire dependency graph. Third-party crates can't use these constraints - they're meaningless to them - but the different configuration still causes them to compile separately for each constraint value.

`rust_binary` already has `supports_incoming_transition = True`, which lets you specify a transition that modifies the configuration before it reaches the target. This PR adds the same capability to `rust_library`.

With this change, third-party BUCK files can define an incoming transition that strips irrelevant constraints, allowing third-party crates to share builds across constraint variations.

Single line change - just adding `supports_incoming_transition = True` to the `rust_library` rule definition.