### PR TITLE
feat(rust): forward exec_compatible_with to proc-macro alias

### DIFF
--- a/prelude/rust/rust_library.bzl
+++ b/prelude/rust/rust_library.bzl
@@ -1129,6 +1129,7 @@ def rust_library_macro_wrapper(rust_library: typing.Callable) -> typing.Callable
                 actual_exec = ":_" + name,
                 actual_plugin = ":_" + name,
                 default_target_platform = kwargs.get("default_target_platform", None),
+                exec_compatible_with = kwargs.get("exec_compatible_with"),
                 visibility = kwargs.pop("visibility", []),
             )
             kwargs["name"] = "_" + name


### PR DESCRIPTION
When `rust_library` creates a proc-macro, the macro_wrapper generates a `rust_proc_macro_alias` that handles the exec-dep semantics. However, if the caller specifies `exec_compatible_with` to constrain which execution platforms can build the proc-macro, this constraint wasn't being forwarded to the alias.

This matters when proc-macros need to be built with a specific toolchain. For example, when using nightly rustc for analysis (like dylint), proc-macros must also be built with nightly for ABI compatibility. Without forwarding `exec_compatible_with`, the alias could resolve to any execution platform, potentially building the proc-macro with the wrong toolchain.

Single line change - forward `exec_compatible_with` from kwargs to `rust_proc_macro_alias`.