### PR TITLE
fix(cxx_zig_toolchain): resolve wrapper paths and expand nested argsfiles

### DIFF
--- a/prelude/rust/tools/rustc_action.py
+++ b/prelude/rust/tools/rustc_action.py
@@ -39,6 +39,8 @@ INHERITED_ENV = [
     "HOME",
     "RUSTUP_HOME",
     "TMPDIR",
+    # Required for linker wrappers that expand nested argsfiles
+    "BUCK_SCRATCH_PATH",
     # Required on Windows
     "LOCALAPPDATA",
     "PROGRAMDATA",


### PR DESCRIPTION
CGO builds with zig toolchain fail because go_go_wrapper changes to a temp directory before invoking the C compiler. The generated wrapper scripts use relative paths that break once we're no longer in the project root:

```
# runtime/cgo
zig_cc.sh: line 2: buck-out/v2/gen/mise/.../zig: No such file or directory
```

After fixing that, zig also doesn't support nested argsfiles which the Go prelude generates:

```
error: unable to parse command line parameters: NestedResponseFile
```

This PR uses `BASH_SOURCE` to resolve paths from the script's location and adds recursive argsfile expansion before invoking zig.

The Windows path has the same issues but I don't have a way to test batch scripts. Would need `%~dp0` for path resolution and similar expansion logic - happy to add it if someone can validate.