### PR TITLE
OSS: Fix the build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,10 +273,11 @@ quote = "1.0.3"
 rand = { version = "0.9", features = ["small_rng"] }
 rand_08 = { package = "rand", version = "0.8.4", features = ["small_rng"] }
 rand_chacha = "0.3"
-rand_distr = "0.4"
+rand_distr = "0.5"
+rand_distr_04 = { package = "rand_distr", version = "0.4" }
 rand_xoshiro = "0.7"
 ref-cast = "1.0.0"
-regex = "1.5.4"
+regex = "1.12.2"
 relative-path = { version = "1.7.0", features = ["serde"] }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 rustc-hash = { version = "2.1" }

--- a/app/buck2_action_impl/Cargo.toml
+++ b/app/buck2_action_impl/Cargo.toml
@@ -24,6 +24,7 @@ parking_lot = { workspace = true }
 relative-path = { workspace = true }
 serde_json = { workspace = true }
 sha1 = { workspace = true }
+smallvec = { workspace = true }
 static_assertions = { workspace = true }
 tracing = { workspace = true }
 
@@ -35,6 +36,7 @@ starlark = { workspace = true }
 starlark_map = { workspace = true }
 
 buck2_action_metadata_proto = { workspace = true }
+buck2_analysis = { workspace = true }
 buck2_artifact = { workspace = true }
 buck2_build_api = { workspace = true }
 buck2_build_signals = { workspace = true }

--- a/app/buck2_analysis/Cargo.toml
+++ b/app/buck2_analysis/Cargo.toml
@@ -22,6 +22,7 @@ starlark_map = { workspace = true }
 
 buck2_artifact = { workspace = true }
 buck2_build_api = { workspace = true }
+buck2_build_signals = { workspace = true }
 buck2_core = { workspace = true }
 buck2_data = { workspace = true }
 buck2_error = { workspace = true }

--- a/app/buck2_build_api/Cargo.toml
+++ b/app/buck2_build_api/Cargo.toml
@@ -41,8 +41,10 @@ dice = { workspace = true }
 display_container = { workspace = true }
 dupe = { workspace = true }
 gazebo = { workspace = true }
+pagable = { workspace = true }
 remote_execution = { workspace = true }
 rustls = { workspace = true }
+setsketch = { workspace = true }
 sorted_vector_map = { workspace = true }
 starlark = { workspace = true }
 starlark_map = { workspace = true }

--- a/app/buck2_build_api_tests/Cargo.toml
+++ b/app/buck2_build_api_tests/Cargo.toml
@@ -33,6 +33,7 @@ buck2_analysis = { workspace = true }
 buck2_anon_target = { workspace = true }
 buck2_artifact = { workspace = true }
 buck2_build_api = { workspace = true }
+buck2_build_signals = { workspace = true }
 buck2_certs = { workspace = true }
 buck2_common = { workspace = true }
 buck2_configured = { workspace = true }

--- a/app/buck2_common/Cargo.toml
+++ b/app/buck2_common/Cargo.toml
@@ -49,6 +49,7 @@ cmp_any = { workspace = true }
 dice = { workspace = true }
 dupe = { workspace = true }
 gazebo = { workspace = true }
+pagable = { workspace = true }
 starlark_map = { workspace = true }
 
 buck2_cli_proto = { workspace = true }

--- a/app/buck2_critical_path/Cargo.toml
+++ b/app/buck2_critical_path/Cargo.toml
@@ -15,6 +15,8 @@ starlark_map = { workspace = true }
 buck2_error = { workspace = true }
 
 [dev-dependencies]
-rand = { workspace = true }
-rand_chacha = { workspace = true }
-rand_distr = { workspace = true }
+# Can't use workspace dependencies here because rand = { package = "rand_08", workspace = true } is
+# not valid syntax.
+rand = { package = "rand", version = "0.8.4", features = ["small_rng"] }
+rand_chacha = "0.3"
+rand_distr = { package = "rand_distr", version = "0.4" }

--- a/app/buck2_execute_impl/Cargo.toml
+++ b/app/buck2_execute_impl/Cargo.toml
@@ -36,6 +36,7 @@ zstd = { workspace = true }
 allocative = { workspace = true }
 
 buck2_action_metadata_proto = { workspace = true }
+buck2_build_signals = { workspace = true }
 buck2_cli_proto = { workspace = true }
 buck2_common = { workspace = true }
 buck2_core = { workspace = true }

--- a/app/buck2_interpreter/Cargo.toml
+++ b/app/buck2_interpreter/Cargo.toml
@@ -24,6 +24,7 @@ allocative = { workspace = true }
 dice = { workspace = true }
 dupe = { workspace = true }
 gazebo = { workspace = true }
+pagable = { workspace = true }
 starlark = { workspace = true }
 starlark_map = { workspace = true }
 

--- a/app/buck2_node/Cargo.toml
+++ b/app/buck2_node/Cargo.toml
@@ -29,6 +29,7 @@ dice = { workspace = true }
 display_container = { workspace = true }
 dupe = { workspace = true }
 gazebo = { workspace = true }
+pagable = { workspace = true }
 starlark_map = { workspace = true }
 strong_hash = { workspace = true }
 

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -191,7 +191,7 @@ rand_distr = "0.5"
 rand_distr_04 = { package = "rand_distr", version = "0.4" }
 rand_xoshiro = "0.7"
 ref-cast = "1.0.0"
-regex = "1.5.4"
+regex = "1.12.2"
 relative-path = { version = "1.7.0", features = ["serde"] }
 ring = "=0.17.5" # Upgrading this is possible, but a pain, so we don't want to pick up every new minor version
 rusqlite = { version = "0.33", features = ["bundled"] }


### PR DESCRIPTION
It appears that the Meta-internal build was using much newer versions of rand_distr and regex crates and due to lack of automation, Cargo.toml got several years out of date.

To paraphrase a Meta employee's commit message in
49b8b1b0e41f1aa4e59e30c91a78f3c46a7dc46e (2023-04-10):
> Perhaps we should set up CI to verify fbcode//third-party/rust/Cargo.toml, fbcode//buck2/shim/third-party/rust/Cargo.toml, and fbcode//buck2/Cargo.toml are in sync.