### PR TITLE
allow for setting priority on remote executions

### DIFF
--- a/app/buck2_build_api/src/interpreter/rule_defs/command_executor_config.rs
+++ b/app/buck2_build_api/src/interpreter/rule_defs/command_executor_config.rs
@@ -104,6 +104,7 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
     /// * `remote_execution_gang_workers`: Gang workers for gang scheduling in remote execution
     /// * `remote_execution_custom_image`: Custom Tupperware image for remote execution for this platform
     /// * `meta_internal_extra_params`: Json dict of extra params to pass to RE related to Meta internal infra.
+    /// * `priority`: The priority for remote execution requests.
     #[starlark(as_type = StarlarkCommandExecutorConfig)]
     fn CommandExecutorConfig<'v>(
         #[starlark(require = named)] local_enabled: bool,
@@ -139,6 +140,7 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
         #[starlark(default = NoneOr::None, require = named)] meta_internal_extra_params: NoneOr<
             DictRef<'v>,
         >,
+        #[starlark(default = NoneOr::None, require = named)] priority: NoneOr<i32>,
     ) -> starlark::Result<StarlarkCommandExecutorConfig> {
         let command_executor_config = {
             let remote_execution_max_input_files_mebibytes: Option<i32> =
@@ -189,6 +191,8 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
 
             let extra_params =
                 parse_meta_internal_extra_params(meta_internal_extra_params.into_option())?;
+
+            let priority = priority.into_option();
 
             let re_use_case = if remote_execution_use_case.is_none() {
                 None
@@ -303,6 +307,7 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
                         gang_workers: re_gang_workers,
                         custom_image: re_dynamic_image,
                         meta_internal_extra_params: extra_params,
+                        priority,
                     })
                 }
                 (Some(local), None, true) => {
@@ -321,6 +326,7 @@ pub fn register_command_executor_config(builder: &mut GlobalsBuilder) {
                         gang_workers: re_gang_workers,
                         custom_image: re_dynamic_image,
                         meta_internal_extra_params: extra_params,
+                        priority,
                     })
                 }
                 // If remote cache is disabled, also disable the remote dep file cache as well

--- a/app/buck2_core/src/execution_types/executor_config.rs
+++ b/app/buck2_core/src/execution_types/executor_config.rs
@@ -53,6 +53,7 @@ pub struct RemoteEnabledExecutorOptions {
     pub gang_workers: Vec<ReGangWorker>,
     pub custom_image: Option<Box<RemoteExecutorCustomImage>>,
     pub meta_internal_extra_params: MetaInternalExtraParams,
+    pub priority: Option<i32>,
 }
 
 #[derive(Debug, buck2_error::Error)]

--- a/app/buck2_execute/src/re/client.rs
+++ b/app/buck2_execute/src/re/client.rs
@@ -302,6 +302,7 @@ impl RemoteExecutionClient {
         knobs: &ExecutorGlobalKnobs,
         meta_internal_extra_params: &MetaInternalExtraParams,
         worker_tool_action_digest: Option<ActionDigest>,
+        priority: Option<i32>,
     ) -> buck2_error::Result<ExecuteResponseOrCancelled> {
         self.data
             .executes
@@ -320,6 +321,7 @@ impl RemoteExecutionClient {
                 knobs,
                 meta_internal_extra_params,
                 worker_tool_action_digest,
+                priority,
             ))
             .await
     }
@@ -1351,6 +1353,7 @@ impl RemoteExecutionClientImpl {
         knobs: &ExecutorGlobalKnobs,
         meta_internal_extra_params: &MetaInternalExtraParams,
         worker_tool_action_digest: Option<ActionDigest>,
+        priority: Option<i32>,
     ) -> buck2_error::Result<ExecuteResponseOrCancelled> {
         #[cfg(not(fbcode_build))]
         let _unused = worker_tool_action_digest;
@@ -1388,9 +1391,8 @@ impl RemoteExecutionClientImpl {
                 || induced_cache_miss.is_some(),
             execution_policy: Some(TExecutionPolicy {
                 affinity_keys: vec![identity.affinity_key.clone()],
-                priority: meta_internal_extra_params
-                    .remote_execution_policy
-                    .priority
+                priority: priority
+                    .or(meta_internal_extra_params.remote_execution_policy.priority)
                     .unwrap_or_default(),
                 region_preference: meta_internal_extra_params
                     .remote_execution_policy

--- a/app/buck2_execute/src/re/manager.rs
+++ b/app/buck2_execute/src/re/manager.rs
@@ -434,6 +434,7 @@ impl ManagedRemoteExecutionClient {
         knobs: &ExecutorGlobalKnobs,
         meta_internal_extra_params: &MetaInternalExtraParams,
         worker_tool_action_digest: Option<ActionDigest>,
+        priority: Option<i32>,
     ) -> buck2_error::Result<ExecuteResponseOrCancelled> {
         self.lock()?
             .get()
@@ -453,6 +454,7 @@ impl ManagedRemoteExecutionClient {
                 knobs,
                 meta_internal_extra_params,
                 worker_tool_action_digest,
+                priority,
             )
             .await
     }

--- a/app/buck2_execute_impl/src/executors/re.rs
+++ b/app/buck2_execute_impl/src/executors/re.rs
@@ -92,6 +92,7 @@ pub struct ReExecutor {
     pub gang_workers: Vec<ReGangWorker>,
     pub deduplicate_get_digests_ttl_calls: bool,
     pub output_trees_download_config: OutputTreesDownloadConfig,
+    pub priority: Option<i32>,
 }
 
 impl ReExecutor {
@@ -193,6 +194,7 @@ impl ReExecutor {
             &self.knobs,
             meta_internal_extra_params,
             worker_tool_action_digest,
+            self.priority,
         );
 
         let execute_response =

--- a/app/buck2_server/src/daemon/common.rs
+++ b/app/buck2_server/src/daemon/common.rs
@@ -224,7 +224,8 @@ impl HasCommandExecutor for CommandExecutorFactory {
              re_action_key: &Option<String>,
              remote_cache_enabled: bool,
              dependencies: &[RemoteExecutorDependency],
-             gang_workers: &[ReGangWorker]| {
+             gang_workers: &[ReGangWorker],
+             priority: Option<i32>| {
                 ReExecutor {
                     artifact_fs: artifact_fs.clone(),
                     project_fs: self.project_root.clone(),
@@ -244,6 +245,7 @@ impl HasCommandExecutor for CommandExecutorFactory {
                     gang_workers: gang_workers.to_vec(),
                     deduplicate_get_digests_ttl_calls: self.deduplicate_get_digests_ttl_calls,
                     output_trees_download_config: self.output_trees_download_config.dupe(),
+                    priority,
                 }
             };
 
@@ -343,6 +345,7 @@ impl HasCommandExecutor for CommandExecutorFactory {
                                 remote_options.remote_cache_enabled,
                                 &remote_options.dependencies,
                                 &remote_options.gang_workers,
+                                remote_options.priority,
                             )))
                         }
                         RemoteEnabledExecutor::Hybrid {
@@ -361,6 +364,7 @@ impl HasCommandExecutor for CommandExecutorFactory {
                                 remote_options.remote_cache_enabled,
                                 &remote_options.dependencies,
                                 &remote_options.gang_workers,
+                                remote_options.priority,
                             );
                             let executor_preference = self.strategy.hybrid_preference();
                             let low_pass_filter = self.low_pass_filter.dupe();
@@ -520,6 +524,7 @@ pub fn get_default_executor_config(host_platform: HostPlatformOverride) -> Comma
             gang_workers: vec![],
             custom_image: None,
             meta_internal_extra_params: MetaInternalExtraParams::default(),
+            priority: None,
         })
     };
 

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -50,6 +50,7 @@ use re_grpc_proto::build::bazel::remote::execution::v2::ExecuteOperationMetadata
 use re_grpc_proto::build::bazel::remote::execution::v2::ExecuteRequest as GExecuteRequest;
 use re_grpc_proto::build::bazel::remote::execution::v2::ExecuteResponse as GExecuteResponse;
 use re_grpc_proto::build::bazel::remote::execution::v2::ExecutedActionMetadata;
+use re_grpc_proto::build::bazel::remote::execution::v2::ExecutionPolicy;
 use re_grpc_proto::build::bazel::remote::execution::v2::FindMissingBlobsRequest;
 use re_grpc_proto::build::bazel::remote::execution::v2::FindMissingBlobsResponse;
 use re_grpc_proto::build::bazel::remote::execution::v2::GetActionResultRequest;
@@ -744,7 +745,12 @@ impl REClient {
         let request = GExecuteRequest {
             instance_name: self.instance_name.as_str().to_owned(),
             skip_cache_lookup: false,
-            execution_policy: None,
+            execution_policy: Some(ExecutionPolicy {
+                priority: execute_request
+                    .execution_policy
+                    .map(|ep| ep.priority)
+                    .unwrap_or_default(),
+            }),
             results_cache_policy: Some(ResultsCachePolicy { priority: 0 }),
             action_digest: Some(action_digest.clone()),
             ..Default::default()


### PR DESCRIPTION
Add a priority field under `CommandExecutorConfig` that allows for giving a priority to remote executions.

I hope this can start a conversation about where to expose the "priority" field in the bazel remote execution protocol.

I'm not sure if this is the best place to add a priority field, but it seems pretty natural since a priority field already exists under `CommandExecutorConfig.meta_internal_extra_params`.

https://github.com/bazelbuild/remote-apis/blob/main/build/bazel/remote/execution/v2/remote_execution.proto#L1484

Unfortunately, the bazel protocol just gives a recommended meaning of the priority number is, and it is ultimately up to the server for how it gets interpreted.  So in buck, it would not have a specific meaning and be ultimately up to the server.