### PR TITLE
Make python_wheel produce PEP-427 compliant wheels with PEP-425 compliant tags

### DIFF
--- a/prelude/python/python_wheel.bzl
+++ b/prelude/python/python_wheel.bzl
@@ -77,6 +77,23 @@ def _link_deps(
 
     return depth_first_traversal_by(link_infos, deps, find_deps)
 
+def _python_version_from_tag(tag):
+    """Extract Python version from a wheel tag: "py3.12" -> "3.12", "cp312" -> "3.12"."""
+    version = tag
+    for prefix in ("cp", "py"):
+        if tag.startswith(prefix):
+            version = tag[len(prefix):]
+            break
+    if "." in version:
+        return version
+    if len(version) >= 2:
+        return version[0] + "." + version[1:]
+    return version
+
+def _cpython_tag(python_version):
+    """Convert Python version to CPython tag: "3.12" -> "cp312"."""
+    return "cp" + python_version.replace(".", "")
+
 def _whl_cmd(
         ctx: AnalysisContext,
         output: Artifact,
@@ -84,7 +101,8 @@ def _whl_cmd(
         abi: str,
         python: str,
         manifests: list[ManifestInfo] = [],
-        srcs: dict[str, Artifact] = {}) -> cmd_args:
+        srcs: dict[str, Artifact] = {},
+        computed_metadata: dict[str, str] = {}) -> cmd_args:
     cmd = []
 
     cmd.append(ctx.attrs._wheel[RunInfo])
@@ -101,6 +119,9 @@ def _whl_cmd(
         cmd.append("--entry-points={}".format(json.encode(ctx.attrs.entry_points)))
 
     for key, val in ctx.attrs.extra_metadata.items():
+        cmd.extend(["--metadata", key, val])
+
+    for key, val in computed_metadata.items():
         cmd.extend(["--metadata", key, val])
 
     for requires in ctx.attrs.requires:
@@ -377,6 +398,26 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
     if not platform:
         fail("platform must be set either on python_wheel target or in python_wheel_toolchain")
 
+    # Resolve ABI tag: explicit attr > toolchain default
+    abi = value_or(ctx.attrs.abi, wheel_toolchain.abi)
+
+    # Auto-detect CPython tags for wheels with native extensions (PEP 427).
+    # When native extensions are present and no explicit ABI override is set,
+    # switch from py*-none to cpXXX-cpXXX tags.
+    python_version = _python_version_from_tag(python)
+
+    # Normalize python tag to PEP 425 format: "py3.12" -> "py312"
+    if "." in python:
+        python = python.replace(".", "")
+
+    if extensions and abi == "none":
+        cp_tag = _cpython_tag(python_version)
+        python = cp_tag
+        abi = cp_tag
+
+    # Computed metadata for WHEEL/METADATA files
+    computed_metadata = {"Requires-Python": "==" + python_version + ".*"}
+
     def normalize_name(name):
         # Normalize name part of the *.whl file per:
         #  * https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory
@@ -406,7 +447,7 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
         normalize_name(dist),
         ctx.attrs.version,
         python,
-        wheel_toolchain.abi,
+        abi,
         platform,
     ]
 
@@ -416,9 +457,10 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
         ctx = ctx,
         output = wheel,
         platform = platform,
-        abi = wheel_toolchain.abi,
+        abi = abi,
         python = python,
         manifests = srcs + native_srcs,
+        computed_metadata = computed_metadata,
     )
     ctx.actions.run(whl_cmd, category = "wheel")
 
@@ -467,9 +509,10 @@ def _impl(ctx: AnalysisContext) -> list[Provider]:
         ctx = ctx,
         output = ewheel,
         platform = platform,
-        abi = wheel_toolchain.abi,
+        abi = abi,
         python = python,
         srcs = {"{}.pth".format(dist): pth},
+        computed_metadata = computed_metadata,
     )
     ctx.actions.run(ewhl_cmd, category = "editable_wheel")
     sub_targets["editable"] = [
@@ -493,6 +536,7 @@ python_wheel = rule(
         dist = attrs.option(attrs.string(), default = None),
         version = attrs.string(default = "1.0.0"),
         python = attrs.option(attrs.string(), default = None),
+        abi = attrs.option(attrs.string(), default = None),
         entry_points = attrs.dict(
             key = attrs.string(),
             value = attrs.dict(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/buck2-prelude/pull/31

## What
The `python_wheel` rule now auto-detects native C extensions and produces PEP 427/425 compliant wheel filenames and metadata:

- **Extension wheels**: `py3.12-none` → `cp312-cp312` (CPython-specific ABI tags)
- **Pure Python wheels**: `py3.12-none` → `py312-none` (PEP 425 normalized python tag)
- **Explicit ABI overrides**: respected (e.g. `abi = "abi3"` is not overridden)

Additionally, the `python_wheel` fbsource macro now supports build info version suffixing via `-c build_info.build_time=YYYY.M.D -c build_info.revision=HASH`. This produces PEP 440 compliant versions like `1.0.0.2026.1.1.0+hgabc123`. The suffix is only appended when the configs are explicitly set.

## Context
Previously, wheels with native C extensions were tagged `py3.12-none`, which means "pure Python, no ABI dependency" — incorrect for wheels containing `.so` extensions compiled against CPython's C API. This caused `pip`/`uv` compatibility issues. The `pyx_wheel` macro in `msl_infra/dev/pyx/` existed as a genrule workaround to fix these tags post-build. With this change, the fix happens at the source and `pyx_wheel` is no longer needed.

## Changes
1. **`prelude/python/python_wheel.bzl`**: Added `_python_version_from_tag()` and `_cpython_tag()` helpers. Auto-detect extensions and switch to `cp312-cp312` tags when `abi == "none"`. Normalize python tag to PEP 425 format (`py3.12` → `py312`). Added `abi` attribute for explicit overrides. Added `Requires-Python` computed metadata.
2. **`tools/build_defs/fb_native/python_wheel.bzl`**: Added conditional build info version suffixing (timestamp, revision, or both).
3. **Tests**: 9 genrule checks for cpython tag correctness, 1 shared_libs tag check, 11 Python unit tests for version suffix PEP 440 compliance, updated wheel_metadata test.

Reviewed By: suo, manav-a, seemethere

Differential Revision: D93168164


