### PR TITLE
Remove FB-internal 'load' statement

### DIFF
--- a/docs/getting_started/tutorial_first_build.md
+++ b/docs/getting_started/tutorial_first_build.md
@@ -160,8 +160,10 @@ rust_binary(
 Let's briefly see what this does (we'll keep explanations minimal, just enough
 for this step! ):
 
+<FbInternalOnly>
 - `load(...)` is a load statement. It tells Buck2 to load the definition of the
   `rust_binary`.
+</FbInternalOnly>
 - `rust_binary` is a Buck2 rule that tells Buck2 how to build a Rust binary.
 - `name = "main"`: We're giving our build target a name, "main". This is how
   we'll refer to it in Buck2 commands.


### PR DESCRIPTION
It looks like `rust_binary` is in scope by default, at least in the non-`FbInternalOnly` version. In that case the `load` comment is confusing.