### PR TITLE
fix: default to os `"unknown"` in lookup

### DIFF
--- a/prelude/os/constraints/BUCK
+++ b/prelude/os/constraints/BUCK
@@ -88,3 +88,9 @@ constraint_value(
     constraint_setting = ":os",
     visibility = ["PUBLIC"],
 )
+
+constraint_value(
+    name = "unknown",
+    constraint_setting = ":os",
+    visibility = ["PUBLIC"],
+)

--- a/prelude/os/constraints/BUCK
+++ b/prelude/os/constraints/BUCK
@@ -39,3 +39,9 @@ constraint_with_aliases(
     ],
     visibility = ["PUBLIC"],
 )
+
+constraint_value(
+    name = "unknown",
+    constraint_setting = ":os",
+    visibility = ["PUBLIC"],
+)

--- a/prelude/os_lookup/targets/BUCK
+++ b/prelude/os_lookup/targets/BUCK
@@ -14,8 +14,7 @@ os_lookup(
         "config//cpu:x86_64": "x86_64",
     }),
     os = select({
-        # FIXME(JakobDegen): No default
-        "DEFAULT": "linux",
+        "DEFAULT": "unknown",
         "config//os:linux": "linux",
         "config//os:macos": "macos",
         "config//os:windows": "windows",


### PR DESCRIPTION
I've been working on migrating the `k23` project to `buck2` but stumbled over weird linking issues when cross compiling Rust a platform that requires `"prelude//os/constraints:none"`. As it turns out this is caused by the OS detection falling back on "linux" as the default OS which causes the cxx toolchain to incorrectly assume the linker (in my case `lld`) should target linux and passing incorrect flags to its invocation.

I don't know if removing this default value has some wider consequences for other builds or something like this, but it does fix my Rust no_std issues without affecting other build types so I hope it is safe to upstream.