### PR TITLE
fix: allow `str` in `_lintify` signature

### DIFF
--- a/prelude/rust/build.bzl
+++ b/prelude/rust/build.bzl
@@ -911,7 +911,7 @@ def symlinked_dirs(
         hidden = transitive_deps.project_as_args("artifacts_args"),
     )
 
-def _lintify(flag: str, clippy: bool, lints: list[ResolvedStringWithMacros]) -> cmd_args:
+def _lintify(flag: str, clippy: bool, lints: list[str | ResolvedStringWithMacros]) -> cmd_args:
     return cmd_args(
         [lint for lint in lints if clippy or not str(lint).startswith("\"clippy::")],
         format = "-{}{{}}".format(flag),


### PR DESCRIPTION
The current `_lintify` signature only allows `ResolvedStringWithMacros` with afaik you cannot actually pass to it. This means a custom Rust toolchain cannot actually set `allow_lints`, `deny_lint`, etc.

this changes fixes this by just changing the signature to `str | ResolvedStringWithMacros` similar to other functions in the prelude.