### PR TITLE
Refactor stdout and stderr handling in BuckdLifecycle

### DIFF
--- a/app/buck2_build_api/src/materialize.rs
+++ b/app/buck2_build_api/src/materialize.rs
@@ -125,7 +125,7 @@ pub async fn materialize_and_upload_artifact_group(
                 async move {
                     match contexts.1 {
                         UploadContext::Skip => Ok(()),
-                        UploadContext::Upload => ensure_uploaded(&mut ctx, group.clone()).await,
+                        UploadContext::Upload => ensure_uploaded(&mut ctx, group).await,
                     }
                 }
                 .boxed()

--- a/app/buck2_client_ctx/src/daemon/client/connect.rs
+++ b/app/buck2_client_ctx/src/daemon/client/connect.rs
@@ -452,13 +452,11 @@ impl<'a> BuckdLifecycle<'a> {
         let mut stdout_taken = child
             .stdout
             .take()
-            .ok_or_else(|| internal_error!("Child should have its stdout piped"))
-            .unwrap();
+            .ok_or_else(|| internal_error!("Child should have its stdout piped"))?;
         let mut stderr_taken = child
             .stderr
             .take()
-            .ok_or_else(|| internal_error!("Child should have its stderr piped"))
-            .unwrap();
+            .ok_or_else(|| internal_error!("Child should have its stderr piped"))?;
 
         let status_fut = async {
             let result = timeout(timeout_secs, child.wait()).await;

--- a/app/buck2_execute_local/src/win/process_group.rs
+++ b/app/buck2_execute_local/src/win/process_group.rs
@@ -16,7 +16,6 @@ use std::process::Command;
 use std::process::ExitStatus;
 use std::time::Duration;
 
-use buck2_error::BuckErrorContext;
 use buck2_error::internal_error;
 use buck2_resource_control::ActionFreezeEventReceiver;
 use buck2_resource_control::path::CgroupPathBuf;

--- a/app/buck2_fs/src/fs_util.rs
+++ b/app/buck2_fs/src/fs_util.rs
@@ -23,8 +23,10 @@ use std::path::Path;
 use std::path::PathBuf;
 
 pub use buck2_env::soft_error::soft_error;
+#[cfg(not(windows))]
 use buck2_error::BuckErrorContext;
 use buck2_error::buck2_error;
+#[cfg(not(windows))]
 use buck2_error::internal_error;
 use relative_path::RelativePath;
 use relative_path::RelativePathBuf;
@@ -166,7 +168,7 @@ fn symlink_impl(original: &Path, link: &AbsPath) -> Result<(), IoError> {
         if let Some(common_path) = common_path(&target_abspath, link) {
             let from_common = target_abspath
                 .strip_prefix(&common_path)
-                .map_err(|e| IoError::new(io::Error::new(io::ErrorKind::Other, e)))?;
+                .map_err(|e| IoError::new(io::Error::other(e)))?;
             let common_canonicalized = common_path.canonicalize().map_err(IoError::new)?;
             common_canonicalized.join(from_common)
         } else {


### PR DESCRIPTION
## Summary

Simplified error handling for child process stdout and stderr by replacing unwrap() with the ? operator for better error propagation.

- Replace `.ok_or_else(|| internal_error!(...)).unwrap()` with
  `.ok_or_else(|| internal_error!(...))?` in `start_server_unix`
- The function already returns `buck2_error::Result<()>`, so `?`
  propagates the error gracefully instead of panicking the client
- The same function already uses `?` on the line immediately above
  (`cmd.spawn()?`) — this change makes the error handling consistent

## Test plan
- `cargo check -p buck2_client_ctx` — compiles cleanly
- `cargo test -p buck2_client_ctx` — all tests pass
- Behavioral: if stdout/stderr pipes are unexpectedly missing after
  spawn, the client now returns a descriptive error instead of panicking