### PR TITLE
Fix find_missing_cache LRU size from ~52M entries to 500K

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -670,7 +670,7 @@ impl REClient {
             capabilities,
             instance_name,
             find_missing_cache: Mutex::new(FindMissingCache {
-                cache: LruCache::new(NonZeroUsize::new(50 << 20).unwrap()), // 50Mb
+                cache: LruCache::new(NonZeroUsize::new(500_000).unwrap()),
                 ttl: Duration::from_hours(12), // 12 hours TODO: Tune this parameter
                 last_check: Instant::now(),
             }),


### PR DESCRIPTION
LruCache::new() takes an entry count, not a byte size. The previous value of 50 << 20 (52,428,800) created a cache capable of holding ~52 million entries, not 50MB as the comment claimed. Each entry is roughly 150-200 bytes (TDigest with a heap-allocated SHA256 hash string + LRU node overhead), so the cache was effectively unbounded at ~8-10GB.

Reduce to 500,000 entries which is more than sufficient for even very large builds and uses ~100MB in the worst case.