### PR TITLE
Increase default CAS TTL from 60 seconds to 3 hours

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -439,7 +439,7 @@ impl REClientBuilder {
                 max_concurrent_uploads_per_action: opts.max_concurrent_uploads_per_action,
                 // NOTE: This is an arbitrary number because RBE does not return information
                 // on the TTL of the remote blob.
-                cas_ttl_secs: opts.cas_ttl_secs.unwrap_or(60),
+                cas_ttl_secs: opts.cas_ttl_secs.unwrap_or(3 * 60 * 60),
             },
             grpc_clients,
             capabilities,


### PR DESCRIPTION
The default of 60 seconds is far too aggressive. When FindMissingBlobs reports a digest as present, we assume it will remain available for only cas_ttl_secs. With a 60-second TTL, nearly every action rechecks the same digests since their assumed TTL expires almost immediately. Three hours is a more realistic lower bound for CAS blob retention.