### PR TITLE
Drop mutex early in notify file watcher sync2

### DIFF
--- a/app/buck2_file_watcher/src/notify.rs
+++ b/app/buck2_file_watcher/src/notify.rs
@@ -283,8 +283,10 @@ impl NotifyFileWatcher {
         &self,
         mut dice: DiceTransactionUpdater,
     ) -> buck2_error::Result<(buck2_data::FileWatcherStats, DiceTransactionUpdater)> {
-        let mut guard = self.data.lock().unwrap();
-        let old = mem::replace(&mut *guard, Ok(NotifyFileData::new()));
+        let old = {
+            let mut guard = self.data.lock().unwrap();
+            mem::replace(&mut *guard, Ok(NotifyFileData::new()))
+        };
         let (stats, changes) = old?.sync();
         if let Some(changes) = changes {
             changes.write_to_dice(&mut dice)?;


### PR DESCRIPTION
The lock was held for the entire duration of sync() and write_to_dice(), blocking the notify callback thread from processing new filesystem events. Now the lock is only held for the mem::replace swap.

My hope is that this will cause buck2 to miss fs events slightly less often.