### PR TITLE
Fix OSS RE client ignoring skip_cache_lookup

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -744,7 +744,7 @@ impl REClient {
 
         let request = GExecuteRequest {
             instance_name: self.instance_name.as_str().to_owned(),
-            skip_cache_lookup: false,
+            skip_cache_lookup: execute_request.skip_cache_lookup,
             execution_policy: Some(ExecutionPolicy {
                 priority: execute_request
                     .execution_policy


### PR DESCRIPTION
The execute_with_progress method was hardcoding skip_cache_lookup to false instead of forwarding the value from the ExecuteRequest. This meant --skip-cache-read and induced cache misses had no effect when using the open source remote execution client.

I don't see any reason why this should be hardcoded, so I believe this is a bug.