### PR TITLE
Fix panic on I/O error during ByteStream upload

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -1529,7 +1529,7 @@ where
         let mut upload_segments = Vec::new();
         let mut buf = vec![0; max_total_batch_size];
         loop {
-            let n_read = reader.read(&mut buf).await.unwrap();
+            let n_read = reader.read(&mut buf).await?;
             if n_read == 0 {
                 break;
             }


### PR DESCRIPTION
The read call in the ByteStream upload loop used .unwrap(), which would panic on any I/O error. Replace with ? to propagate the error.