### PR TITLE
bugfix: external cells race condition/inconsistent state

### DIFF
--- a/app/buck2_core/Cargo.toml
+++ b/app/buck2_core/Cargo.toml
@@ -27,7 +27,7 @@ relative-path = { workspace = true }
 sequence_trie = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
-starlark_map = { workspace = true, features = ["pagable"] }
+starlark_map = { workspace = true, features = ["pagable_dep"] }
 static_assertions = { workspace = true }
 strong_hash = { workspace = true }
 tempfile = { workspace = true }

--- a/app/buck2_external_cells/src/git.rs
+++ b/app/buck2_external_cells/src/git.rs
@@ -118,14 +118,9 @@ impl IoRequest for GitFetchIoRequest {
         })?;
 
         run_git(&path, |c| {
-            c.arg("remote")
-                .arg("add")
-                .arg("origin")
-                .arg(self.setup.git_origin.as_ref());
-        })?;
-
-        run_git(&path, |c| {
-            c.arg("fetch").arg("origin").arg(self.setup.commit.as_ref());
+            c.arg("fetch")
+                .arg(self.setup.git_origin.as_ref())
+                .arg(self.setup.commit.as_ref());
         })?;
 
         run_git(&path, |c| {


### PR DESCRIPTION
The `git remote add origin` command is not idempotent: if a `.git/config` already has an "origin" remote, it fails with "remote origin already exists". This happens when cross-process races leave a partially-initialized repo (e.g. daemon restart mid-fetch, `--no-buckd`, or two daemons briefly overlapping). The in-process semaphore only coordinates within a single daemon process.

Fix by removing the named remote entirely. `git fetch` accepts a URL directly as its first argument, so `git remote add origin` is unnecessary.

The bug presented itself as:
```
Computing legacy buckconfigs for cell `prelude`

Caused by:
    Error fetching external cell with git, exit code: ExitStatus(unix_wait_status(768)), stderr:
    error: remote origin already exists.
```