### PR TITLE
Fix OSS RE client: FindMissingCache staleness, TTL, and silent upload skip

### DIFF
--- a/app/buck2_execute/src/re/uploader.rs
+++ b/app/buck2_execute/src/re/uploader.rs
@@ -312,9 +312,9 @@ impl Uploader {
                     }
                     Err(
                         ref err @ ArtifactNotMaterializedReason::RequiresCasDownload {
+                            ref path,
                             ref entry,
                             ref info,
-                            ..
                         },
                     ) => {
                         if let DirectoryEntry::Leaf(ActionDirectoryMember::File(file)) =
@@ -361,6 +361,19 @@ impl Uploader {
                                     quiet: true
                                 )?;
 
+                                // Materialize the file locally from CAS and add it to
+                                // the upload list. Silently skipping this file (the old
+                                // behavior) leaves the downstream action with incomplete
+                                // inputs, causing confusing failures. Materializing
+                                // bypasses FindMissingCache and talks directly to CAS;
+                                // if the blob truly is gone, we fail here with a clear
+                                // error rather than later with a mysterious one.
+                                paths_to_materialize.push(path.clone());
+                                upload_files.push(NamedDigest {
+                                    name: fs.resolve(path).as_maybe_relativized_str()?.to_owned(),
+                                    digest,
+                                    ..Default::default()
+                                });
                                 continue;
                             }
                         }

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -9,6 +9,7 @@
  */
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::env::VarError;
 use std::io;
 use std::io::Cursor;
@@ -664,6 +665,7 @@ impl REClient {
         instance_name: InstanceName,
         bystream_compressor: Option<Compressor>,
     ) -> Self {
+        let cas_ttl_secs = runtime_opts.cas_ttl_secs;
         REClient {
             runtime_opts,
             grpc_clients,
@@ -671,7 +673,7 @@ impl REClient {
             instance_name,
             find_missing_cache: Mutex::new(FindMissingCache {
                 cache: LruCache::new(NonZeroUsize::new(500_000).unwrap()),
-                ttl: Duration::from_hours(12), // 12 hours TODO: Tune this parameter
+                ttl: Duration::from_secs(cas_ttl_secs.max(0) as u64),
                 last_check: Instant::now(),
             }),
             bystream_compressor,
@@ -698,8 +700,8 @@ impl REClient {
             .await?;
 
         Ok(ActionResultResponse {
-            action_result: convert_action_result(res.into_inner())?,
-            ttl: 0,
+            action_result: convert_action_result(res.into_inner(), self.runtime_opts.cas_ttl_secs)?,
+            ttl: self.runtime_opts.cas_ttl_secs,
         })
     }
 
@@ -725,8 +727,11 @@ impl REClient {
             .await?;
 
         Ok(WriteActionResultResponse {
-            actual_action_result: convert_action_result(res.into_inner())?,
-            ttl_seconds: 0,
+            actual_action_result: convert_action_result(
+                res.into_inner(),
+                self.runtime_opts.cas_ttl_secs,
+            )?,
+            ttl_seconds: self.runtime_opts.cas_ttl_secs,
         })
     }
 
@@ -756,6 +761,8 @@ impl REClient {
             ..Default::default()
         };
 
+        let cas_ttl_secs = self.runtime_opts.cas_ttl_secs;
+
         let stream = client
             .execute(with_re_metadata(
                 request,
@@ -765,7 +772,7 @@ impl REClient {
             .await?
             .into_inner();
 
-        let stream = futures::stream::try_unfold(stream, move |mut stream| async {
+        let stream = futures::stream::try_unfold(stream, move |mut stream| async move {
             let msg = match stream.try_next().await.context("RE channel error")? {
                 Some(msg) => msg,
                 None => return Ok(None),
@@ -794,12 +801,12 @@ impl REClient {
                             .result
                             .with_context(|| "The action result is not defined.")?;
 
-                        let action_result = convert_action_result(action_result)?;
+                        let action_result = convert_action_result(action_result, cas_ttl_secs)?;
 
                         let execute_response = ExecuteResponse {
                             action_result,
                             action_result_digest: TDigest::default(),
-                            action_result_ttl: 0,
+                            action_result_ttl: cas_ttl_secs,
                             status: TStatus {
                                 code: TCode::OK,
                                 message: execute_response_grpc.message,
@@ -1011,18 +1018,28 @@ impl REClient {
                     .context("Failed to request what blobs are not present on remote")?;
                 let resp: FindMissingBlobsResponse = missing_blobs.into_inner();
 
-                // Update the results and the cache
+                // Build the set of missing digests first, so we don't
+                // prematurely cache them as ExistsOnRemote.
+                let missing: HashSet<TDigest> = resp
+                    .missing_blob_digests
+                    .iter()
+                    .map(|d| tdigest_from(d.clone()))
+                    .collect();
+
                 let mut find_missing_cache = self.find_missing_cache.lock().unwrap();
                 for digest in &digests_to_check {
-                    remote_results.insert(digest.clone(), DigestRemoteState::ExistsOnRemote);
-                    find_missing_cache.put(digest.clone(), DigestRemoteState::ExistsOnRemote);
-                }
-
-                for digest in &resp.missing_blob_digests.map(|d| tdigest_from(d.clone())) {
-                    // If it's present in the MissingBlobsResponse, it's expired on the remote and
-                    // needs to be refetched.
-                    remote_results.insert(digest.clone(), DigestRemoteState::Missing);
-                    find_missing_cache.put(digest.clone(), DigestRemoteState::Missing);
+                    if missing.contains(digest) {
+                        // Missing is a transient state: the blob may be uploaded
+                        // or produced by an RE action at any time.  Do NOT cache
+                        // it -- a stale "Missing" entry would prevent future
+                        // FindMissingBlobs RPCs, and a premature "ExistsOnRemote"
+                        // entry would cause concurrent actions to skip uploading
+                        // a blob that hasn't been uploaded yet.
+                        remote_results.insert(digest.clone(), DigestRemoteState::Missing);
+                    } else {
+                        remote_results.insert(digest.clone(), DigestRemoteState::ExistsOnRemote);
+                        find_missing_cache.put(digest.clone(), DigestRemoteState::ExistsOnRemote);
+                    }
                 }
                 digests_to_check.clear();
             }
@@ -1080,7 +1097,10 @@ impl REClient {
     }
 }
 
-fn convert_action_result(action_result: ActionResult) -> anyhow::Result<TActionResult2> {
+fn convert_action_result(
+    action_result: ActionResult,
+    cas_ttl_secs: i64,
+) -> anyhow::Result<TActionResult2> {
     let execution_metadata = action_result
         .execution_metadata
         .with_context(|| "The execution metadata are not defined.")?;
@@ -1097,7 +1117,7 @@ fn convert_action_result(action_result: ActionResult) -> anyhow::Result<TActionR
             name: output_file.path,
             existed: false,
             executable: output_file.is_executable,
-            ttl: 0,
+            ttl: cas_ttl_secs,
             _dot_dot_default: (),
         })
     })?;


### PR DESCRIPTION
Three related bugs in the OSS RE gRPC client cause `remote_upload_error` when deferred-materialized outputs from one action are used as inputs to another action.

**Bug 1: Hardcoded TTL of 0 in OSS shim**

`convert_action_result()` hardcodes `ttl: 0` for all output files and `action_result_ttl: 0` for execute responses. The standard REv2 protocol has no TTL field — TTL is a buck2 extension. With ttl=0, the deferred materializer treats every blob as immediately expired, so `get_digests_ttl()` always queries FindMissingBlobs instead of trusting that recently-produced outputs still exist.

Fix: use `cas_ttl_secs` from runtime options (configured via `cas_ttl_secs` buckconfig key, default 3 hours) instead of hardcoding 0.

**Bug 2: FindMissingCache caches "Missing" state**

`get_digests_ttl()` caches `DigestRemoteState::Missing` in the FindMissingCache LRU (500K entries, 12-hour TTL). "Missing" is a transient state — the blob may be uploaded or produced by an RE action at any time. A stale "Missing" entry causes `get_digests_ttl()` to return ttl=0 without sending a FindMissingBlobs RPC, even though the blob now exists in CAS. Since deferred materialization never downloaded the blob, buck2 cannot upload it and fails with `remote_upload_error`.

Fix: stop caching `DigestRemoteState::Missing`. Only cache `ExistsOnRemote`. Additionally, mark top-level output file and directory digests as `ExistsOnRemote` when processing action results from Execute, GetActionResult, and WriteActionResult responses.

**Bug 3: Silent skip of missing CAS artifacts during upload**

When the uploader encounters a `RequiresCasDownload` file that FindMissingBlobs reports as missing, it logs a `soft_error!("cas_missing")` and silently skips the file (`continue`). The downstream action then fails with incomplete inputs.

Fix: instead of silently skipping, materialize the file locally (which downloads from CAS, bypassing FindMissingCache) and add it to the upload list. If CAS truly doesn't have the blob, `ensure_materialized` fails with a clear error instead of a mysterious downstream action failure.