### PR TITLE
add UEFI OS constraint value

### DIFF
--- a/prelude/os/BUCK
+++ b/prelude/os/BUCK
@@ -139,6 +139,15 @@ config_setting(
     visibility = ["PUBLIC"],
 )
 
+# UEFI applications
+config_setting(
+    name = "uefi",
+    constraint_values = [
+        "//os/constraints:uefi",
+    ],
+    visibility = ["PUBLIC"],
+)
+
 # For platforms with no OS, like microcontrollers.
 config_setting(
     name = "none",

--- a/prelude/os/constraints/BUCK
+++ b/prelude/os/constraints/BUCK
@@ -84,6 +84,12 @@ constraint_value(
 )
 
 constraint_value(
+    name = "uefi",
+    constraint_setting = ":os",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
     name = "none",
     constraint_setting = ":os",
     visibility = ["PUBLIC"],


### PR DESCRIPTION
This change adds a `//os/constraints:uefi` value (and `//os:uefi` alias) to support building UEFI applications using buck2. ofc UEFI is only an OS in the wider sense (and it is kinda like weird windows), but it is how other toolchains (e.g. Rust and LLVM) treat UEFI.