### PR TITLE
Make soft_error! return Ok in OSS builds and remove .unwrap() at call

### DIFF
--- a/app/buck2_env/src/soft_error.rs
+++ b/app/buck2_env/src/soft_error.rs
@@ -291,14 +291,6 @@ pub fn handle_soft_error(
         return Err(err.context("Upgraded warning to failure via $BUCK2_HARD_ERROR"));
     }
 
-    // @oss-disable: let is_open_source = false;
-    let is_open_source = true; // @oss-enable
-    if is_open_source {
-        // We don't log these, and we have no legacy users, and they might not upgrade that often,
-        // so lets just break open source things immediately.
-        return Err(err);
-    }
-
     Ok(err)
 }
 

--- a/app/buck2_env/src/soft_error.rs
+++ b/app/buck2_env/src/soft_error.rs
@@ -274,6 +274,8 @@ pub fn handle_soft_error(
         options.quiet = false;
     }
 
+    let is_deprecation = options.deprecation;
+
     // We want to limit each error to appearing at most 10 times in a build (no point spamming people)
     if count.fetch_add(1, Ordering::SeqCst) < 10 {
         if let Some(handler) = HANDLER.get() {
@@ -289,6 +291,14 @@ pub fn handle_soft_error(
     }
     if hard_error_config()?.should_hard_error(category) {
         return Err(err.context("Upgraded warning to failure via $BUCK2_HARD_ERROR"));
+    }
+
+    // @oss-disable: let is_open_source = false;
+    let is_open_source = true; // @oss-enable
+    if is_open_source && is_deprecation {
+        // Deprecation warnings should be hard errors in OSS since there are
+        // no legacy users that need the grace period.
+        return Err(err);
     }
 
     Ok(err)

--- a/app/buck2_execute_impl/src/sqlite/incremental_state_db.rs
+++ b/app/buck2_execute_impl/src/sqlite/incremental_state_db.rs
@@ -71,7 +71,7 @@ impl IncrementalDbState {
 
                 self.state.insert(key.to_owned(), value.clone().into());
                 if let Err(e) = db.incremental_state_table().insert(key.to_owned(), value) {
-                    soft_error!(
+                    let _unused = soft_error!(
                         "insert_to_incremental_db",
                         buck2_error::buck2_error!(
                             buck2_error::ErrorTag::Tier0,
@@ -79,8 +79,7 @@ impl IncrementalDbState {
                             key, e
                         ),
                         quiet: true
-                    )
-                    .unwrap();
+                    );
                 };
             }
             None => {
@@ -95,7 +94,7 @@ impl IncrementalDbState {
         {
             // This should be converted into a real error later, marking as a soft error for now as the row not existing
             // might show up as an error but doesn't actually matter in reality.
-            soft_error!(
+            let _unused = soft_error!(
                 "delete_from_incremental_db",
                 buck2_error::buck2_error!(
                     buck2_error::ErrorTag::Tier0,
@@ -103,8 +102,7 @@ impl IncrementalDbState {
                     e
                 ),
                 quiet: true
-            )
-            .unwrap();
+            );
         }
 
         self.state.remove(key);


### PR DESCRIPTION
## Summary

`soft_error!` was designed to log non-critical errors and allow execution to continue. However, in open source builds, `handle_soft_error` unconditionally returned `Err(err)` instead of `Ok(err)`, turning every soft error into a hard error. Combined with `.unwrap()` calls at multiple call sites, this caused **panics/crashes** for OSS users on non-critical failures like sqlite write errors or vacant path lookups.

## Changes

**`app/buck2_env/src/soft_error.rs`**
- Removed the `is_open_source` branch that forced all soft errors to return `Err` in OSS builds. `soft_error!` now returns `Ok(err)` uniformly, matching FB internal behavior. The `BUCK2_HARD_ERROR` env var still works for users who want to opt into hard errors.

**`app/buck2_execute_impl/src/materializers/deferred/artifact_tree.rs`**
- Replaced `.unwrap()` with `let _unused =` on `cleanup_finished_vacant` soft error.

**`app/buck2_execute_impl/src/materializers/deferred/command_processor.rs`**
- Replaced `.unwrap()` with `let _unused =` on 4 soft error call sites: `clean_stale_no_config`, `materializer_materialize_error`, `has_artifact_update_time`, and dynamic `error_name` in `on_materialization`.

**`app/buck2_execute_impl/src/sqlite/incremental_state_db.rs`**
- Replaced `.unwrap()` with `let _unused =` on `insert_to_incremental_db` and `delete_from_incremental_db` soft errors.

## Impact

- OSS users will no longer experience unexpected panics from non-critical internal errors.
- Errors are still logged/reported via the structured error handler.
- `BUCK2_HARD_ERROR` env var continues to work as an opt-in escape hatch.
- No change to FB internal behavior (was already returning `Ok(err)`).

## Fixes 
- https://github.com/facebook/buck2/issues/1274