### PR TITLE
starlark: Export the `RecordTypeMatcher` for users in the public API

### DIFF
--- a/starlark-rust/starlark/src/values/types/record.rs
+++ b/starlark-rust/starlark/src/values/types/record.rs
@@ -49,4 +49,5 @@ pub(crate) mod record_type;
 pub(crate) mod ty_record_type;
 
 pub use crate::values::record::instance::Record;
+pub use crate::values::record::matcher::RecordTypeMatcher;
 pub use crate::values::record::record_type::RecordType;

--- a/starlark-rust/starlark/src/values/types/record/matcher.rs
+++ b/starlark-rust/starlark/src/values/types/record/matcher.rs
@@ -28,9 +28,11 @@ use crate::values::types::type_instance_id::TypeInstanceId;
 use crate::values::typing::type_compiled::matcher::TypeMatcher;
 use crate::values::typing::type_compiled::matcher::TypeMatcherDyn;
 
+/// Allows you to compare `Record`'s from different files, since they otherwise have no unique
+/// identity.
 #[derive(Hash, Debug, Eq, PartialEq, Clone, Dupe, Allocative, Pagable)]
 #[pagable_typetag(TypeMatcherDyn)]
-pub(crate) struct RecordTypeMatcher {
+pub struct RecordTypeMatcher {
     pub(crate) id: TypeInstanceId,
 }
 


### PR DESCRIPTION
This fixes https://github.com/facebook/starlark-rust/issues/120. Since it allows users now to compare records from different files.