### PR TITLE
buck expand-external-cell: suggest disabling external cells

### DIFF
--- a/app/buck2_client/src/commands/expand_external_cell.rs
+++ b/app/buck2_client/src/commands/expand_external_cell.rs
@@ -43,10 +43,6 @@ pub struct ExpandExternalCellsCommand {
     cells: Vec<String>,
 }
 
-const REMINDER_TEXT: &str = "Reminder: For edits to the expanded cell to take effect on \
-your build, you must additionally remove the entry from the `external_cells` section of your \
-buckconfig\n";
-
 #[async_trait::async_trait(?Send)]
 impl StreamingCommand for ExpandExternalCellsCommand {
     const COMMAND_NAME: &'static str = "expand-external-cell";
@@ -83,11 +79,21 @@ impl StreamingCommand for ExpandExternalCellsCommand {
 
         let mut lines: Vec<String> = resp
             .paths
-            .into_iter()
+            .iter()
             .map(|(cell, path)| format!("Expanded external cell {cell} to {path}."))
             .collect();
         lines.push(String::new());
-        lines.push(REMINDER_TEXT.to_owned());
+        lines.push(
+            "Reminder: For edits to the expanded cells to take effect on \
+your build, disable the external cells in buckconfig:\n[external_cells]"
+                .to_owned(),
+        );
+        lines.extend(
+            resp.paths
+                .keys()
+                .map(|cell| format!("{cell} = disabled")),
+        );
+        lines.push(String::new());
 
         ExitResult::success().with_stdout(lines.join("\n").into_bytes())
     }


### PR DESCRIPTION
Test plan:
```
$ cat .buckconfig.local
[cells]
buck2-haskell = buck2-haskell

[external_cells]
buck2-haskell = git

[external_cell_buck2-haskell]
git_origin = https://github.com/MercuryTechnologies/buck2-haskell.git
commit_hash = cf63dfaf6dd0c29aa66e00987bfa3f27f1add5f4

$ cargo r --release -p buck2 -- expand-external-cell buck2-haskell
    Finished `release` profile [optimized] target(s) in 0.39s
     Running `target/release/buck2 expand-external-cell buck2-haskell`
File changed: gh_facebook_buck2//.jj/.watchman-cookie-thinpad.local-33177-263
File changed: buck2-haskell//ide/ide.bxl
File changed: buck2-haskell//ide/README.md
198 additional file change events
Build ID: 755d9c03-4d37-4d82-b3a7-5ff10a13aa20
Command: expand-external-cell.
Time elapsed: 0.0s
Expanded external cell buck2-haskell to buck2-haskell.

Reminder: For edits to the expanded cells to take effect on your build, disable the external cells in buckconfig:
[external_cells]
buck2-haskell = disabled
```