### PR TITLE
Track symlinks between local files via DICE dependencies

### DIFF
--- a/app/buck2_common/src/file_ops/dice.rs
+++ b/app/buck2_common/src/file_ops/dice.rs
@@ -38,6 +38,7 @@ use crate::file_ops::delegate::get_delegated_file_ops;
 use crate::file_ops::error::FileReadError;
 use crate::file_ops::error::extended_ignore_error;
 use crate::file_ops::metadata::RawPathMetadata;
+use crate::file_ops::metadata::RawSymlink;
 use crate::file_ops::metadata::ReadDirOutput;
 use crate::ignores::file_ignores::FileIgnoreResult;
 use crate::io::ReadDirError;
@@ -300,10 +301,38 @@ impl Key for ReadFileKey {
         ctx: &mut DiceComputations,
         _cancellations: &CancellationContext,
     ) -> Self::Value {
-        get_delegated_file_ops(ctx, self.0.cell(), CheckIgnores::No)
-            .await?
-            .read_file_if_exists(ctx, self.0.path())
-            .await
+        let file_ops = get_delegated_file_ops(ctx, self.0.cell(), CheckIgnores::No).await?;
+
+        // Check if the path goes through a symlink. We call the delegate
+        // directly (not via PathMetadataKey) to avoid a circular DICE
+        // dependency, since PathMetadataKey::compute depends on ReadFileKey.
+        let metadata = file_ops
+            .read_path_metadata_if_exists(ctx, self.0.path())
+            .await?;
+        if let Some(RawPathMetadata::Symlink {
+            ref at,
+            to: RawSymlink::Relative(ref target, _),
+        }) = metadata
+        {
+            let at = at.as_ref();
+            // If the symlink is an ancestor directory (at != requested path),
+            // track it via PathMetadataKey. The file watcher will dirty
+            // PathMetadataKey(at) when the symlink is retargeted, cascading
+            // here.
+            //
+            // For leaf symlinks (at == self.0), the file watcher already
+            // dirties ReadFileKey(self.0) directly, so no extra dep needed —
+            // and adding one would cycle through PathMetadataKey.
+            if at != self.0.as_ref() {
+                ctx.compute(&PathMetadataKey(at.to_owned())).await??;
+            }
+            // Follow the symlink to the real path. Chains are handled
+            // recursively since the target's compute also checks.
+            return ctx.compute(&ReadFileKey(target.dupe())).await?;
+        }
+
+        // RawSymlink::External falls straight through to here
+        file_ops.read_file_if_exists(ctx, self.0.path()).await
     }
 
     fn equality(_: &Self::Value, _: &Self::Value) -> bool {
@@ -449,5 +478,576 @@ async fn read_dir_ext(
             Some(e) => Err(e),
             None => Err(e.into()),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use buck2_core::cells::cell_path::CellPath;
+    use buck2_core::cells::name::CellName;
+    use dice::UserComputationData;
+    use dice::testing::DiceBuilder;
+
+    use super::*;
+    use crate::file_ops::testing::TestFileOps;
+
+    fn cell() -> CellName {
+        CellName::testing_new("cell")
+    }
+
+    fn cell_path(p: &str) -> CellPath {
+        CellPath::testing_new(&format!("cell//{p}"))
+    }
+
+    async fn build_dice(file_ops: &TestFileOps) -> dice::DiceTransaction {
+        file_ops
+            .mock_in_cell(cell(), DiceBuilder::new())
+            .build(UserComputationData::new())
+            .unwrap()
+            .commit()
+            .await
+    }
+
+    #[tokio::test]
+    async fn read_file_through_leaf_symlink() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("target.txt"), "hello".to_owned())]),
+            vec![(cell_path("link.txt"), cell_path("target.txt"))],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("hello"));
+    }
+
+    #[tokio::test]
+    async fn read_file_through_symlink_to_nonexistent_then_retarget() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![(cell_path("link.txt"), cell_path("gone.txt"))],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content, None);
+
+        // Retarget link.txt to a file that exists.
+        // In real life, that's `ln -sf real.txt link.txt`.
+        file_ops.replace_live(&TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("real.txt"), "hello".to_owned())]),
+            vec![(cell_path("link.txt"), cell_path("real.txt"))],
+        ));
+
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("link.txt"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("hello"));
+    }
+
+    #[tokio::test]
+    async fn read_file_through_directory_symlink() {
+        // a -> b (directory symlink), read a/e.txt which resolves to b/e.txt
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("b/e.txt"), "world".to_owned())]),
+            vec![(cell_path("a"), cell_path("b"))],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("world"));
+    }
+
+    /// Tests chained relative directory symlinks:
+    ///   a -> b, b/c -> ../d
+    /// Reading a/c/e.txt resolves:
+    ///   a/c/e.txt → (a is symlink) → b/c/e.txt → (b/c is symlink to ../d = d) → d/e.txt
+    ///
+    /// DICE dep graph:
+    ///   ReadFileKey(a/c/e.txt)
+    ///     ├─ PathMetadataKey(a)        ← tracks the a symlink
+    ///     └─ ReadFileKey(b/c/e.txt)
+    ///          ├─ PathMetadataKey(b/c)  ← tracks the b/c symlink
+    ///          └─ ReadFileKey(d/e.txt)  ← the real file
+    #[tokio::test]
+    async fn read_file_through_chained_directory_symlinks() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("d/e.txt"), "chained".to_owned())]),
+            vec![
+                (cell_path("a"), cell_path("b")),
+                (cell_path("b/c"), cell_path("d")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("chained"));
+    }
+
+    /// Helper: dirty specific keys via FileChangeTracker and commit a new transaction.
+    async fn dirty_and_commit(
+        ctx: dice::DiceTransaction,
+        dirty: impl FnOnce(&mut FileChangeTracker),
+    ) -> dice::DiceTransaction {
+        let mut updater = ctx.into_updater();
+        let mut tracker = FileChangeTracker::new();
+        dirty(&mut tracker);
+        tracker.write_to_dice(&mut updater).unwrap();
+        updater.commit().await
+    }
+
+    #[tokio::test]
+    async fn dirty_target_invalidates_leaf_symlink() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("target.txt"), "v1".to_owned())]),
+            vec![(cell_path("link.txt"), cell_path("target.txt"))],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        file_ops.set_file_content(&cell_path("target.txt"), "v2");
+
+        // No-op transaction: nothing dirtied → cached proxy returns old content.
+        let mut ctx = dirty_and_commit(ctx, |_| {}).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"), "should still be cached");
+
+        // File watcher: target.txt changed → recomputes, picks up new content.
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("target.txt"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after dirtying target"
+        );
+    }
+
+    /// Retarget a leaf symlink: link.txt changes from target.txt to other.txt.
+    /// The file watcher dirties ReadFileKey(link.txt) directly (not via
+    /// PathMetadataKey), exercising the at == self.0 branch in ReadFileKey::compute.
+    #[tokio::test]
+    async fn retarget_leaf_symlink_invalidates_read() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("target.txt"), "v1".to_owned())]),
+            vec![(cell_path("link.txt"), cell_path("target.txt"))],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        // Retarget link.txt -> other.txt
+        file_ops.replace_live(&TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("other.txt"), "v2".to_owned())]),
+            vec![(cell_path("link.txt"), cell_path("other.txt"))],
+        ));
+
+        // File watcher reports link.txt changed → dirties ReadFileKey(link.txt)
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("link.txt"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after retargeting leaf symlink"
+        );
+    }
+
+    #[tokio::test]
+    async fn dirty_real_path_invalidates_through_directory_symlink() {
+        // a -> b, reading a/e.txt (really b/e.txt)
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("b/e.txt"), "v1".to_owned())]),
+            vec![(cell_path("a"), cell_path("b"))],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        file_ops.set_file_content(&cell_path("b/e.txt"), "v2");
+
+        // No-op: nothing dirty → cached
+        let mut ctx = dirty_and_commit(ctx, |_| {}).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"), "should still be cached");
+
+        // Dirty the real path b/e.txt → recomputes a/e.txt with new content
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("b/e.txt"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after dirtying real path b/e.txt"
+        );
+    }
+
+    #[tokio::test]
+    async fn retarget_ancestor_symlink_invalidates_read() {
+        // a -> b, reading a/e.txt (resolves to b/e.txt)
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("b/e.txt"), "v1".to_owned())]),
+            vec![(cell_path("a"), cell_path("b"))],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        // Retarget a -> c, with c/e.txt = "v2"
+        file_ops.replace_live(&TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("c/e.txt"), "v2".to_owned())]),
+            vec![(cell_path("a"), cell_path("c"))],
+        ));
+
+        // File watcher reports `a` symlink retargeted →
+        // PathMetadataKey(a) dirty → ReadFileKey(a/e.txt) recomputes →
+        // now resolves to c/e.txt
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("a"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after retargeting ancestor symlink"
+        );
+    }
+
+    /// a -> b, b/c -> ../d, reading a/c/e.txt (resolves to d/e.txt)
+    /// Dirty the real file d/e.txt and verify it cascades through both hops.
+    #[tokio::test]
+    async fn dirty_real_path_invalidates_through_chained_symlinks() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("d/e.txt"), "v1".to_owned())]),
+            vec![
+                (cell_path("a"), cell_path("b")),
+                (cell_path("b/c"), cell_path("d")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        file_ops.set_file_content(&cell_path("d/e.txt"), "v2");
+
+        // No-op → cached
+        let mut ctx = dirty_and_commit(ctx, |_| {}).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"), "should still be cached");
+
+        // Dirty d/e.txt → cascades through b/c/e.txt → a/c/e.txt
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("d/e.txt"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after dirtying real path d/e.txt"
+        );
+    }
+
+    /// a -> b, b/c -> ../d, reading a/c/e.txt (resolves to d/e.txt)
+    /// Retarget b/c from ../d to ../f, with f/e.txt = "v2".
+    #[tokio::test]
+    async fn retarget_intermediate_symlink_invalidates_through_chain() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("d/e.txt"), "v1".to_owned())]),
+            vec![
+                (cell_path("a"), cell_path("b")),
+                (cell_path("b/c"), cell_path("d")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        // Retarget b/c -> ../f, with f/e.txt = "v2"
+        file_ops.replace_live(&TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("f/e.txt"), "v2".to_owned())]),
+            vec![
+                (cell_path("a"), cell_path("b")),
+                (cell_path("b/c"), cell_path("f")),
+            ],
+        ));
+
+        // Dirty b/c → cascades through a/c/e.txt
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("b/c"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after retargeting intermediate symlink b/c"
+        );
+    }
+
+    // ---- Cross-cell helpers ----
+
+    fn other_cell() -> CellName {
+        CellName::testing_new("other")
+    }
+
+    fn other_cell_path(p: &str) -> CellPath {
+        CellPath::testing_new(&format!("other//{p}"))
+    }
+
+    async fn build_dice_two_cells(
+        cell_ops: &TestFileOps,
+        other_ops: &TestFileOps,
+    ) -> dice::DiceTransaction {
+        let builder = cell_ops.mock_in_cell(cell(), DiceBuilder::new());
+        let builder = other_ops.mock_in_cell(other_cell(), builder);
+        builder
+            .build(UserComputationData::new())
+            .unwrap()
+            .commit()
+            .await
+    }
+
+    /// Leaf symlink in one cell pointing to a file in another cell.
+    /// cell//link.txt → other//target.txt
+    #[tokio::test]
+    async fn read_file_through_cross_cell_leaf_symlink() {
+        let cell_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![(cell_path("link.txt"), other_cell_path("target.txt"))],
+        );
+        let other_ops = TestFileOps::new_with_files(BTreeMap::from([(
+            other_cell_path("target.txt"),
+            "cross-cell".to_owned(),
+        )]));
+        let mut ctx = build_dice_two_cells(&cell_ops, &other_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("cross-cell"));
+    }
+
+    /// Dirty the target file in another cell; verify invalidation cascades
+    /// back through the cross-cell symlink.
+    #[tokio::test]
+    async fn dirty_target_invalidates_cross_cell_leaf_symlink() {
+        let cell_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![(cell_path("link.txt"), other_cell_path("target.txt"))],
+        );
+        let other_ops = TestFileOps::new_with_files(BTreeMap::from([(
+            other_cell_path("target.txt"),
+            "v1".to_owned(),
+        )]));
+        let mut ctx = build_dice_two_cells(&cell_ops, &other_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        other_ops.set_file_content(&other_cell_path("target.txt"), "v2");
+
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(other_cell_path("target.txt"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("link.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after dirtying cross-cell target"
+        );
+    }
+
+    /// Directory symlink crossing cells: cell//a → other//b, read cell//a/e.txt.
+    #[tokio::test]
+    async fn read_file_through_cross_cell_directory_symlink() {
+        let cell_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![(cell_path("a"), other_cell_path("b"))],
+        );
+        let other_ops = TestFileOps::new_with_files(BTreeMap::from([(
+            other_cell_path("b/e.txt"),
+            "remote-dir".to_owned(),
+        )]));
+        let mut ctx = build_dice_two_cells(&cell_ops, &other_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("remote-dir"));
+    }
+
+    /// External symlinks (pointing outside the project root) are not
+    /// DICE-tracked. ReadFileKey falls through to the delegate, which
+    /// reads the content directly.
+    ///
+    /// We will then get stale reads.
+    #[tokio::test]
+    async fn external_symlink_falls_through_to_delegate() {
+        use std::path::PathBuf;
+
+        use buck2_fs::paths::forward_rel_path::ForwardRelativePathBuf;
+
+        use crate::external_symlink::ExternalSymlink;
+
+        let symlink = Arc::new(
+            ExternalSymlink::new(
+                PathBuf::from("/outside/project"),
+                ForwardRelativePathBuf::empty(),
+            )
+            .unwrap(),
+        );
+        let file_ops = TestFileOps::new_with_symlinks_and_external_content(BTreeMap::from([(
+            cell_path("ext_link"),
+            (symlink, "external-content".to_owned()),
+        )]));
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("ext_link").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("external-content"));
+
+        // The external target changes, but the file watcher has no visibility
+        // into paths outside the project — nothing gets dirtied.
+        file_ops.set_external_symlink_content(&cell_path("ext_link"), "updated-external");
+
+        let mut ctx = dirty_and_commit(ctx, |_| {}).await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("ext_link").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("external-content"),
+            "stale: DICE has no dep on the external target, so the cached proxy returns old content"
+        );
+    }
+
+    /// a -> b, b/c -> ../d, reading a/c/e.txt
+    /// Retarget a from b to g (where g/c -> ../h, h/e.txt = "v2").
+    #[tokio::test]
+    async fn retarget_outermost_symlink_invalidates_through_chain() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("d/e.txt"), "v1".to_owned())]),
+            vec![
+                (cell_path("a"), cell_path("b")),
+                (cell_path("b/c"), cell_path("d")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(content.as_deref(), Some("v1"));
+
+        // Retarget a -> g, with g/c -> ../h, h/e.txt = "v2"
+        file_ops.replace_live(&TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::from([(cell_path("h/e.txt"), "v2".to_owned())]),
+            vec![
+                (cell_path("a"), cell_path("g")),
+                (cell_path("g/c"), cell_path("h")),
+            ],
+        ));
+
+        // Dirty `a` → ReadFileKey(a/c/e.txt) recomputes entire chain
+        let mut ctx = dirty_and_commit(ctx, |t| {
+            t.file_contents_changed(cell_path("a"));
+        })
+        .await;
+        let content =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/c/e.txt").as_ref())
+                .await
+                .unwrap();
+        assert_eq!(
+            content.as_deref(),
+            Some("v2"),
+            "should see new content after retargeting outermost symlink a"
+        );
     }
 }

--- a/app/buck2_common/src/file_ops/dice.rs
+++ b/app/buck2_common/src/file_ops/dice.rs
@@ -289,6 +289,115 @@ impl ReadFileProxy {
     }
 }
 
+/// Split a CellPath into a Vec of components for use in the BTreeSet.
+/// Vec<T> uses lexicographic Ord over elements, so descendants always sort
+/// immediately after their ancestors — unlike CellPath's string-based Ord
+/// where characters like `-` and `.` (< `/`) can interleave.
+fn path_components(path: &CellPath) -> PathComponents {
+    PathComponents(
+        path.cell(),
+        path.path().iter().map(|c| c.to_owned()).collect(),
+    )
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct PathComponents(CellName, Vec<buck2_fs::paths::file_name::FileNameBuf>);
+
+impl PathComponents {
+    fn starts_with(&self, other: &Self) -> bool {
+        self.0 == other.0 && self.1.starts_with(&other.1)
+    }
+}
+
+/// Walk the symlink chain from `start` via delegates (no DICE keys) and
+/// return an error if we detect a cycle or expansion. Checks:
+///   i.  exact revisit  (p → a → b → a)
+///   ii. descendant of a visited path (p → a/b → c/d → a/b/e)
+///   iii. ancestor of a visited path  (p → a/b → c/d → a)
+async fn verify_no_symlink_cycle(
+    ctx: &mut DiceComputations<'_>,
+    origin: &Arc<CellPath>,
+    start: &Arc<CellPath>,
+) -> buck2_error::Result<()> {
+    use std::collections::BTreeSet;
+
+    let mut visited: BTreeSet<PathComponents> = BTreeSet::new();
+    visited.insert(path_components(origin));
+    let mut current: Arc<CellPath> = start.dupe();
+
+    // We stop iteration at 40 resolves, like Linux does when it hits ELOOP.
+    for _ in 0..40 {
+        let key = path_components(&current);
+        if has_path_overlap(&visited, &key) {
+            return Err(buck2_error::buck2_error!(
+                buck2_error::ErrorTag::Environment,
+                "symlink cycle detected resolving `{}`: \
+                 `{}` overlaps with a previously visited path",
+                origin,
+                current
+            ));
+        }
+        visited.insert(key);
+
+        let ops = get_delegated_file_ops(ctx, current.cell(), CheckIgnores::No).await?;
+        let metadata = ops
+            .read_path_metadata_if_exists(ctx, current.path())
+            .await?;
+        match metadata {
+            Some(RawPathMetadata::Symlink {
+                to: RawSymlink::Relative(target, _),
+                ..
+            }) => {
+                current = target;
+            }
+            _ => return Ok(()),
+        }
+    }
+    Err(buck2_error::buck2_error!(
+        buck2_error::ErrorTag::Environment,
+        "too many levels of symbolic links resolving `{}`",
+        origin
+    ))
+}
+
+/// Returns true if `key` is equal to, a descendant of, or an ancestor of
+/// any component-vec already in `visited`.
+///
+/// Because Vec<FileNameBuf> sorts component-wise, descendants of a path
+/// form a contiguous range immediately after it in the BTreeSet.
+/// The predecessor is the only ancestor candidate, and the successor
+/// is the only descendant candidate.
+fn has_path_overlap(
+    visited: &std::collections::BTreeSet<PathComponents>,
+    key: &PathComponents,
+) -> bool {
+    use std::ops::Bound;
+
+    // exact match
+    if visited.contains(key) {
+        return true;
+    }
+    // Key is a descendant of a visited path.
+    // With component-wise ordering, the only candidate ancestor is the
+    // largest element < key.
+    if let Some(prev) = visited.range::<PathComponents, _>(..key).next_back() {
+        if key.starts_with(prev) {
+            return true;
+        }
+    }
+    // Key is an ancestor of a visited path.
+    // The only candidate descendant is the smallest element > key.
+    if let Some(next) = visited
+        .range::<PathComponents, _>((Bound::Excluded(key), Bound::Unbounded))
+        .next()
+    {
+        if next.starts_with(key) {
+            return true;
+        }
+    }
+    false
+}
+
 #[derive(Clone, Dupe, Display, Debug, Eq, Hash, PartialEq, Allocative, Pagable)]
 #[pagable_typetag(dice::DiceKeyDyn)]
 struct ReadFileKey(Arc<CellPath>);
@@ -314,6 +423,12 @@ impl Key for ReadFileKey {
             to: RawSymlink::Relative(ref target, _),
         }) = metadata
         {
+            // DICE doesn't detect cycles between distinct keys, so
+            // a→b→a would recurse forever. Walk the chain via
+            // delegates (no DICE deps) to verify it terminates before
+            // we make the recursive DICE call.
+            verify_no_symlink_cycle(ctx, &self.0, target).await?;
+
             let at = at.as_ref();
             // If the symlink is an ancestor directory (at != requested path),
             // track it via PathMetadataKey. The file watcher will dirty
@@ -1004,6 +1119,107 @@ mod tests {
             content.as_deref(),
             Some("external-content"),
             "stale: DICE has no dep on the external target, so the cached proxy returns old content"
+        );
+    }
+
+    /// a -> b -> a: DICE detects the cycle and returns an error.
+    #[tokio::test]
+    async fn recursive_leaf_symlink_returns_error() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![
+                (cell_path("a"), cell_path("b")),
+                (cell_path("b"), cell_path("a")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let err = DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a").as_ref())
+            .await
+            .expect_err("symlink cycle should produce an error")
+            .to_string();
+        assert!(
+            err.contains("overlaps"),
+            "must be detected by overlap check, not the 40-hop limit: {err}"
+        );
+    }
+
+    /// Case ii: infinite expansion via descendant.
+    /// a/b -> c/d (leaf), c -> a/b (directory).
+    /// Reading a/b: a/b → c/d → (c resolves to a/b) a/b/d → c/d/d → a/b/d/d → ...
+    /// The path grows by /d each hop. Detected because a/b/d is a
+    /// descendant of the previously visited a/b.
+    #[tokio::test]
+    async fn recursive_via_descendant_returns_error() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![
+                (cell_path("a/b"), cell_path("c/d")),
+                (cell_path("c"), cell_path("a/b")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let err = DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("a/b").as_ref())
+            .await
+            .expect_err("symlink expansion via descendant should produce an error")
+            .to_string();
+        assert!(
+            err.contains("overlaps"),
+            "must be detected by overlap check, not the 40-hop limit: {err}"
+        );
+    }
+
+    /// Case iii: resolution to ancestor.
+    /// p -> a/b/c (leaf), a/b/c -> d/e (leaf), d/e -> a (leaf).
+    /// We visit a/b/c, then d/e, then a — an ancestor of a/b/c.
+    /// Although a is a directory and the chain would terminate naturally,
+    /// we reject it as a suspect resolution. Trying to glob inside
+    /// of such a directory would expand forever, for example.
+    #[tokio::test]
+    async fn symlink_resolution_to_ancestor_returns_error() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![
+                (cell_path("p"), cell_path("a/b/c")),
+                (cell_path("a/b/c"), cell_path("d/e")),
+                (cell_path("d/e"), cell_path("a")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let err = DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("p").as_ref())
+            .await
+            .expect_err("symlink resolution to ancestor should produce an error")
+            .to_string();
+        assert!(
+            err.contains("overlaps"),
+            "must be detected by overlap check, not the 40-hop limit: {err}"
+        );
+    }
+
+    /// Detects use of naive String ordering by paths in set of visited
+    /// symlink resolutions.
+    #[tokio::test]
+    async fn ancestor_detection_not_foiled_by_interleaving_path() {
+        let file_ops = TestFileOps::new_with_files_and_symlinks(
+            BTreeMap::new(),
+            vec![
+                (cell_path("p"), cell_path("a/b/c")),
+                (cell_path("a/b/c"), cell_path("a-z")),
+                (cell_path("a-z"), cell_path("a")),
+            ],
+        );
+        let mut ctx = build_dice(&file_ops).await;
+
+        let result =
+            DiceFileComputations::read_file_if_exists(&mut ctx, cell_path("p").as_ref()).await;
+        let err = result
+            .expect_err("Should have found symlink cycle")
+            .to_string();
+        assert!(
+            err.contains("overlaps"),
+            "must be detected by overlap check, not the 40-hop limit: {err}"
         );
     }
 

--- a/app/buck2_common/src/file_ops/testing.rs
+++ b/app/buck2_common/src/file_ops/testing.rs
@@ -11,6 +11,7 @@
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use allocative::Allocative;
 use async_trait::async_trait;
@@ -18,6 +19,7 @@ use buck2_core::cells::cell_path::CellPath;
 use buck2_core::cells::cell_path::CellPathRef;
 use buck2_core::cells::name::CellName;
 use buck2_core::cells::paths::CellRelativePath;
+use buck2_core::cells::paths::CellRelativePathBuf;
 use buck2_fs::paths::file_name::FileNameBuf;
 use cmp_any::PartialEqAny;
 use dice::DiceComputations;
@@ -46,55 +48,191 @@ use crate::file_ops::metadata::TrackedFileDigest;
 use crate::file_ops::trait_::FileOps;
 use crate::ignores::file_ignores::FileIgnoreResult;
 
+#[derive(Clone)]
 enum TestFileOpsEntry {
     File(String /*data*/, FileMetadata),
-    ExternalSymlink(Arc<ExternalSymlink>),
+    ExternalSymlink(Arc<ExternalSymlink>, Option<String> /*data*/),
+    /// A symlink to another path within the project. The CellPath is the
+    /// resolved target (what `at` points to after resolving), and the Symlink
+    /// holds the raw relative target string.
+    InternalSymlink(CellPath, Arc<crate::file_ops::metadata::Symlink>),
     Directory(BTreeSet<SimpleDirEntry>),
 }
 
+/// Immutable snapshot of test filesystem state. Captured in `ReadFileProxy`
+/// closures so that cached proxies keep their original data even after the
+/// live state is mutated.
+#[derive(Clone, Dupe)]
+struct TestFileOpsSnapshot(Arc<BTreeMap<CellPath, TestFileOpsEntry>>);
+
+#[async_trait]
+impl FileOps for TestFileOpsSnapshot {
+    async fn read_file_if_exists(
+        &self,
+        path: CellPathRef<'async_trait>,
+    ) -> buck2_error::Result<Option<String>> {
+        Ok(self.0.get(&path.to_owned()).and_then(|e| match e {
+            TestFileOpsEntry::File(data, ..) => Some(data.clone()),
+            TestFileOpsEntry::ExternalSymlink(_, data) => data.clone(),
+            TestFileOpsEntry::InternalSymlink(target, _) => {
+                self.0.get(target).and_then(|e| match e {
+                    TestFileOpsEntry::File(data, ..) => Some(data.clone()),
+                    _ => None,
+                })
+            }
+            _ => None,
+        }))
+    }
+
+    async fn read_dir(
+        &self,
+        path: CellPathRef<'async_trait>,
+    ) -> buck2_error::Result<ReadDirOutput> {
+        let included = self
+            .0
+            .get(&path.to_owned())
+            .and_then(|e| match e {
+                TestFileOpsEntry::Directory(listing) => {
+                    Some(listing.iter().cloned().sorted().collect::<Vec<_>>().into())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| {
+                buck2_error::buck2_error!(
+                    buck2_error::ErrorTag::Environment,
+                    "couldn't find dir {:?}",
+                    path
+                )
+            })?;
+        Ok(ReadDirOutput { included })
+    }
+
+    async fn read_path_metadata_if_exists(
+        &self,
+        path: CellPathRef<'async_trait>,
+    ) -> buck2_error::Result<Option<RawPathMetadata>> {
+        // Walk ancestors to find directory symlinks, like the real IO layer.
+        let cell = path.cell();
+        let mut components = path.path().iter();
+        let mut current = CellPath::new(cell, CellRelativePathBuf::unchecked_new(String::new()));
+        while let Some(component) = components.next() {
+            current = current.join(component);
+            if let Some(TestFileOpsEntry::InternalSymlink(target, symlink)) = self.0.get(&current) {
+                let rest: buck2_fs::paths::forward_rel_path::ForwardRelativePathBuf =
+                    components.collect();
+                let mut resolved = target.clone();
+                if !rest.is_empty() {
+                    resolved = resolved.join(&rest);
+                }
+                return Ok(Some(RawPathMetadata::Symlink {
+                    at: Arc::new(current),
+                    to: RawSymlink::Relative(Arc::new(resolved), symlink.dupe()),
+                }));
+            }
+        }
+
+        self.0.get(&path.to_owned()).map_or(Ok(None), |e| {
+            match e {
+                TestFileOpsEntry::File(_data, metadata) => {
+                    Ok(RawPathMetadata::File(metadata.to_owned()))
+                }
+                TestFileOpsEntry::ExternalSymlink(sym, _) => Ok(RawPathMetadata::Symlink {
+                    at: Arc::new(path.to_owned()),
+                    to: RawSymlink::External(sym.dupe()),
+                }),
+                TestFileOpsEntry::InternalSymlink(..) => {
+                    unreachable!("should have been handled in ancestor walk above")
+                }
+                TestFileOpsEntry::Directory(..) => Ok(RawPathMetadata::Directory),
+            }
+            .map(Some)
+        })
+    }
+
+    async fn is_ignored(
+        &self,
+        _path: CellPathRef<'async_trait>,
+    ) -> buck2_error::Result<FileIgnoreResult> {
+        Ok(FileIgnoreResult::Ok)
+    }
+
+    async fn buildfiles<'a>(&self, _cell: CellName) -> buck2_error::Result<Arc<[FileNameBuf]>> {
+        Ok(Arc::from_iter([FileNameBuf::unchecked_new("BUCK")]))
+    }
+}
+
+/// Mutable handle to test filesystem state. Holds a shared slot that
+/// `TestCellFileOps` snapshots from on each DICE recomputation.
 #[derive(Allocative, Clone, Dupe)]
 pub struct TestFileOps {
     #[allocative(skip)]
-    entries: Arc<BTreeMap<CellPath, TestFileOpsEntry>>,
+    live: Arc<Mutex<Arc<BTreeMap<CellPath, TestFileOpsEntry>>>>,
+}
+
+/// Different cells are presumed to be adjacent on disk.
+fn compute_raw_target(from: &CellPath, to: &CellPath) -> buck2_fs::paths::RelativePathBuf {
+    let from_parts: Vec<&str> = std::iter::once(from.cell().as_str())
+        .chain(from.path().iter().map(|c| c.as_str()))
+        .collect();
+    let to_parts: Vec<&str> = std::iter::once(to.cell().as_str())
+        .chain(to.path().iter().map(|c| c.as_str()))
+        .collect();
+    let common = from_parts
+        .iter()
+        .zip(to_parts.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let up_count = from_parts.len() - 1 - common;
+    let mut parts: Vec<&str> = std::iter::repeat_n("..", up_count).collect();
+    parts.extend_from_slice(&to_parts[common..]);
+    buck2_fs::paths::RelativePathBuf::from(parts.join("/"))
+}
+
+fn build_entries(
+    inputs: BTreeMap<CellPath, TestFileOpsEntry>,
+) -> BTreeMap<CellPath, TestFileOpsEntry> {
+    let mut entries = BTreeMap::new();
+    for (path, entry) in inputs {
+        let mut file_type = match entry {
+            TestFileOpsEntry::Directory(..) => FileType::Directory,
+            TestFileOpsEntry::ExternalSymlink(..) | TestFileOpsEntry::InternalSymlink(..) => {
+                FileType::Symlink
+            }
+            TestFileOpsEntry::File(..) => FileType::File,
+        };
+        // make sure the test setup is correct and concise
+        assert!(
+            entries.insert(path.to_owned(), entry).is_none(),
+            "Adding `{path}`, it already exists."
+        );
+
+        let mut path = path.as_ref();
+
+        // now add to / create the parent directories
+        while let (Some(dir), Some(name)) = (path.parent(), path.path().file_name()) {
+            let dir_entry = entries
+                .entry(dir.to_owned())
+                .or_insert_with(|| TestFileOpsEntry::Directory(BTreeSet::new()));
+            match dir_entry {
+                TestFileOpsEntry::Directory(listing) => {
+                    listing.insert(SimpleDirEntry {
+                        file_type,
+                        file_name: name.to_owned(),
+                    });
+                    file_type = FileType::Directory;
+                    path = dir;
+                }
+                _ => panic!("Adding `{path}`, but `{dir}` exists and is not a dir"),
+            };
+        }
+    }
+    entries
 }
 
 impl TestFileOps {
     fn new(inputs: BTreeMap<CellPath, TestFileOpsEntry>) -> Self {
-        let mut entries = BTreeMap::new();
-        for (path, entry) in inputs {
-            let mut file_type = match entry {
-                TestFileOpsEntry::Directory(..) => FileType::Directory,
-                TestFileOpsEntry::ExternalSymlink(..) => FileType::Symlink,
-                TestFileOpsEntry::File(..) => FileType::File,
-            };
-            // make sure the test setup is correct and concise
-            assert!(
-                entries.insert(path.to_owned(), entry).is_none(),
-                "Adding `{path}`, it already exists."
-            );
-
-            let mut path = path.as_ref();
-
-            // now add to / create the parent directories
-            while let (Some(dir), Some(name)) = (path.parent(), path.path().file_name()) {
-                let dir_entry = entries
-                    .entry(dir.to_owned())
-                    .or_insert_with(|| TestFileOpsEntry::Directory(BTreeSet::new()));
-                match dir_entry {
-                    TestFileOpsEntry::Directory(listing) => {
-                        listing.insert(SimpleDirEntry {
-                            file_type,
-                            file_name: name.to_owned(),
-                        });
-                        file_type = FileType::Directory;
-                        path = dir;
-                    }
-                    _ => panic!("Adding `{path}`, but `{dir}` exists and is not a dir"),
-                };
-            }
-        }
         TestFileOps {
-            entries: Arc::new(entries),
+            live: Arc::new(Mutex::new(Arc::new(build_entries(inputs)))),
         }
     }
 
@@ -136,9 +274,98 @@ impl TestFileOps {
         Self::new(
             symlinks
                 .into_iter()
-                .map(|(path, s)| (path, TestFileOpsEntry::ExternalSymlink(s)))
+                .map(|(path, s)| (path, TestFileOpsEntry::ExternalSymlink(s, None)))
                 .collect::<BTreeMap<CellPath, TestFileOpsEntry>>(),
         )
+    }
+
+    pub fn new_with_symlinks_and_external_content(
+        symlinks: BTreeMap<CellPath, (Arc<ExternalSymlink>, String)>,
+    ) -> Self {
+        Self::new(
+            symlinks
+                .into_iter()
+                .map(|(path, (s, data))| (path, TestFileOpsEntry::ExternalSymlink(s, Some(data))))
+                .collect::<BTreeMap<CellPath, TestFileOpsEntry>>(),
+        )
+    }
+
+    /// Creates a TestFileOps from a mix of files and internal (relative) symlinks.
+    /// `symlinks`: (symlink_path, resolved_target_path). The raw relative
+    /// target is computed automatically, including cross-cell symlinks.
+    pub fn new_with_files_and_symlinks(
+        files: BTreeMap<CellPath, String>,
+        symlinks: Vec<(CellPath, CellPath)>,
+    ) -> Self {
+        let cas_digest_config = CasDigestConfig::testing_default();
+
+        let mut entries = BTreeMap::new();
+        for (path, data) in files {
+            entries.insert(
+                path,
+                TestFileOpsEntry::File(
+                    data.clone(),
+                    FileMetadata {
+                        digest: TrackedFileDigest::from_content(data.as_bytes(), cas_digest_config),
+                        is_executable: false,
+                    },
+                ),
+            );
+        }
+        for (link_path, resolved) in symlinks {
+            let raw = compute_raw_target(&link_path, &resolved);
+            entries.insert(
+                link_path,
+                TestFileOpsEntry::InternalSymlink(
+                    resolved,
+                    Arc::new(crate::file_ops::metadata::Symlink::new(raw)),
+                ),
+            );
+        }
+        Self::new(entries)
+    }
+
+    /// Get a snapshot of the current filesystem state
+    fn snapshot(&self) -> TestFileOpsSnapshot {
+        TestFileOpsSnapshot(self.live.lock().unwrap().dupe())
+    }
+
+    /// Replace the whole filesystem with another
+    pub fn replace_live(&self, new: &TestFileOps) {
+        *self.live.lock().unwrap() = new.live.lock().unwrap().dupe();
+    }
+
+    /// Sets the content of a particular file. Does NOT invalidate the path, you must also call
+    /// `dirty_and_commit`.
+    pub fn set_file_content(&self, path: &CellPath, content: &str) {
+        let cas_digest_config = CasDigestConfig::testing_default();
+        let mut live = self.live.lock().unwrap();
+        let mut entries = (**live).clone();
+        match entries.get_mut(path) {
+            Some(TestFileOpsEntry::File(data, metadata)) => {
+                *data = content.to_owned();
+                *metadata = FileMetadata {
+                    digest: TrackedFileDigest::from_content(content.as_bytes(), cas_digest_config),
+                    is_executable: false,
+                };
+            }
+            _ => panic!("set_file_content: path {path} not found or not a file"),
+        }
+        *live = Arc::new(entries);
+    }
+
+    pub fn set_external_symlink_content(&self, path: &CellPath, content: &str) {
+        let mut live = self.live.lock().unwrap();
+        let mut entries = (**live).clone();
+        match entries.get_mut(path) {
+            Some(TestFileOpsEntry::ExternalSymlink(_, data)) => {
+                *data = Some(content.to_owned());
+            }
+            _ => panic!(
+                "set_external_symlink_content: path {path} not found or not an external symlink"
+            ),
+        }
+        *live = Arc::new(entries);
     }
 
     pub fn mock_in_cell(&self, cell: CellName, builder: DiceBuilder) -> DiceBuilder {
@@ -147,7 +374,7 @@ impl TestFileOps {
             Arc::new(TestCellFileOps(
                 cell,
                 Self {
-                    entries: Arc::clone(&self.entries),
+                    live: Arc::clone(&self.live),
                 },
             )),
         )));
@@ -175,67 +402,32 @@ impl FileOps for TestFileOps {
         &self,
         path: CellPathRef<'async_trait>,
     ) -> buck2_error::Result<Option<String>> {
-        Ok(self.entries.get(&path.to_owned()).and_then(|e| match e {
-            TestFileOpsEntry::File(data, ..) => Some(data.clone()),
-            _ => None,
-        }))
+        self.snapshot().read_file_if_exists(path).await
     }
 
     async fn read_dir(
         &self,
         path: CellPathRef<'async_trait>,
     ) -> buck2_error::Result<ReadDirOutput> {
-        let included = self
-            .entries
-            .get(&path.to_owned())
-            .and_then(|e| match e {
-                TestFileOpsEntry::Directory(listing) => {
-                    Some(listing.iter().cloned().sorted().collect::<Vec<_>>().into())
-                }
-                _ => None,
-            })
-            .ok_or_else(|| {
-                buck2_error::buck2_error!(
-                    buck2_error::ErrorTag::Environment,
-                    "couldn't find dir {:?}",
-                    path
-                )
-            })?;
-        Ok(ReadDirOutput { included })
+        self.snapshot().read_dir(path).await
     }
 
     async fn read_path_metadata_if_exists(
         &self,
         path: CellPathRef<'async_trait>,
     ) -> buck2_error::Result<Option<RawPathMetadata>> {
-        self.entries.get(&path.to_owned()).map_or(Ok(None), |e| {
-            match e {
-                TestFileOpsEntry::File(_data, metadata) => {
-                    Ok(RawPathMetadata::File(metadata.to_owned()))
-                }
-                TestFileOpsEntry::ExternalSymlink(sym) => Ok(RawPathMetadata::Symlink {
-                    at: Arc::new(path.to_owned()),
-                    to: RawSymlink::External(sym.dupe()),
-                }),
-                _ => Err(buck2_error::buck2_error!(
-                    buck2_error::ErrorTag::Tier0,
-                    "couldn't get metadata for {:?}",
-                    path
-                )),
-            }
-            .map(Some)
-        })
+        self.snapshot().read_path_metadata_if_exists(path).await
     }
 
     async fn is_ignored(
         &self,
-        _path: CellPathRef<'async_trait>,
+        path: CellPathRef<'async_trait>,
     ) -> buck2_error::Result<FileIgnoreResult> {
-        Ok(FileIgnoreResult::Ok)
+        self.snapshot().is_ignored(path).await
     }
 
-    async fn buildfiles<'a>(&self, _cell: CellName) -> buck2_error::Result<Arc<[FileNameBuf]>> {
-        Ok(Arc::from_iter([FileNameBuf::unchecked_new("BUCK")]))
+    async fn buildfiles<'a>(&self, cell: CellName) -> buck2_error::Result<Arc<[FileNameBuf]>> {
+        self.snapshot().buildfiles(cell).await
     }
 }
 
@@ -250,9 +442,10 @@ impl FileOpsDelegate for TestCellFileOps {
         _ctx: &mut DiceComputations<'_>,
         path: &'async_trait CellRelativePath,
     ) -> buck2_error::Result<ReadFileProxy> {
+        let snap = self.1.snapshot();
         Ok(ReadFileProxy::new_with_captures(
-            (CellPath::new(self.0, path.to_owned()), self.1.dupe()),
-            move |(path, ops)| async move { FileOps::read_file_if_exists(&ops, path.as_ref()).await },
+            (CellPath::new(self.0, path.to_owned()), snap),
+            move |(path, snap)| async move { FileOps::read_file_if_exists(&snap, path.as_ref()).await },
         ))
     }
 
@@ -262,8 +455,9 @@ impl FileOpsDelegate for TestCellFileOps {
         _ctx: &mut DiceComputations<'_>,
         path: &'async_trait CellRelativePath,
     ) -> buck2_error::Result<Arc<[RawDirEntry]>> {
+        let snap = self.1.snapshot();
         let path = CellPath::new(self.0, path.to_owned());
-        let simple_entries = FileOps::read_dir(&self.1, path.as_ref()).await?.included;
+        let simple_entries = FileOps::read_dir(&snap, path.as_ref()).await?.included;
         Ok(simple_entries
             .iter()
             .map(|e| RawDirEntry {
@@ -278,8 +472,9 @@ impl FileOpsDelegate for TestCellFileOps {
         _ctx: &mut DiceComputations<'_>,
         path: &'async_trait CellRelativePath,
     ) -> buck2_error::Result<Option<RawPathMetadata>> {
+        let snap = self.1.snapshot();
         let path = CellPath::new(self.0, path.to_owned());
-        FileOps::read_path_metadata_if_exists(&self.1, path.as_ref()).await
+        FileOps::read_path_metadata_if_exists(&snap, path.as_ref()).await
     }
 
     fn eq_token(&self) -> PartialEqAny<'_> {


### PR DESCRIPTION
### Problem

Here's a test case that I was quite alarmed Buck fails at. The use case is reading files at bzl eval time that don't have a .toml suffix, as TOML, for https://github.com/cormacrelf/elk which I have updated to depend on this entire thing at the heart of its strategy only to realise it doesn't work very well at all. (I would be happy with a way to tell load() to load as TOML if we can't get symlinks to work.)

```sh
BUCK
blah.lock
blah.lock.toml -> blah.lock   [a symlink]
```

```toml
# blah.lock
value = "original"
```

```starlark
# BUCK
load(":blah.lock.toml", "value")

genrule(
    name = "test",
    out = "out.txt",
    cmd = "echo {} > $OUT".format(value),
)
```

Now, buck *does not pick up changes to blah.lock*.

```sh
buck2 build --out=- :test
{value: original}

echo 'value = "changed"' > blah.lock

buck2 build --out=- :test
{value: original}

# wat?
# now you have to buck2 clean to get it to pick up changes...
```

### Solution

Support invalidating through symlinks.

I am not very familiar with the fs operations here, but it's working alright. This is still pretty likely not to be quite correct and I invite some attention on the implementation.

In general, directory symlinks are already handled quite well by `fn read_path_metadata` in `buck2_common/src/io/fs.rs`. The fs metadata we get in the dice compute() function is really well designed, so whoever wrote that, great work. E.g. we get the first directory symlink found when navigating from the project root, with the rest as a forward relative path. This maps very nicely onto the recursive dice dependencies; we just resolve that first dir symlink and keep going. This was all very easy to actually implement, and the real code change is tiny.

The tests are more involved.

Things to think about

- Cross cell symlinks -> the cell is included in all these dice keys. No problem.
- External symlinks -> buck won't be receiving any watchman updates for external symlinks, so we basically don't change behaviour at all for these, DICE treats them as it did all symlinks before, having no knowledge they are anything but local files/dirs. As before, symlinks get resolved where FileOps is ultimately implemented: `fn read_path_metadata` in `buck2_common/src/io/fs.rs`.
- **Recursive symlinks** should cause buck2 errors. **Done**. This one was extra tricky. Claude has obviously read the Bazel codebase, it tried to rely on CellPath sorting a/b before a-b, which it does not. I added a test for catching recursion in a contorted case like this. We can actually make ForwardRelativePath's PartialOrd/Ord impls do that, it would be convenient in this exact spot but blast radius is big enough already.

Testing

- This has unit tests for which the harness had to be significantly upgraded to behave more like the real world IO ops. It is neat that we have something pretty closely approximating what a filesystem will do, but that is obviously quite dependent on the test harness being exactly right.
- We basically need integrations test versions of all the tests I added. I can't run those, so maybe someone at Meta can translate em.
- For what it's worth, if you run this branch, it does invalidate through symlinks as designed and does catch symlink recursion etc.