### PR TITLE
Make soft error act the same in OSS

### DIFF
--- a/app/buck2_core/tests/soft_error.rs
+++ b/app/buck2_core/tests/soft_error.rs
@@ -15,7 +15,6 @@ use std::sync::Once;
 use buck2_core::error::StructuredErrorOptions;
 use buck2_core::error::initialize;
 use buck2_core::error::reset_soft_error_counters;
-use buck2_core::is_open_source;
 use buck2_core::soft_error;
 use buck2_error::buck2_error;
 
@@ -51,9 +50,6 @@ fn test_init() -> MutexGuard<'static, ()> {
 
 #[test]
 fn test_soft_error() {
-    if is_open_source() {
-        return; // Errors are always hard in open source
-    }
     let _guard = test_init();
 
     let before_error_line = line!();
@@ -73,9 +69,6 @@ fn test_soft_error() {
 
 #[test]
 fn test_reset_counters() {
-    if is_open_source() {
-        return; // Errors are always hard in open source
-    }
     let _guard = test_init();
 
     assert_eq!(0, RESULT.lock().unwrap().len(), "Sanity check");

--- a/app/buck2_env/src/soft_error.rs
+++ b/app/buck2_env/src/soft_error.rs
@@ -291,14 +291,6 @@ pub fn handle_soft_error(
         return Err(err.context("Upgraded warning to failure via $BUCK2_HARD_ERROR"));
     }
 
-    // @oss-disable: let is_open_source = false;
-    let is_open_source = true; // @oss-enable
-    if is_open_source {
-        // We don't log these, and we have no legacy users, and they might not upgrade that often,
-        // so lets just break open source things immediately.
-        return Err(err);
-    }
-
     Ok(err)
 }
 


### PR DESCRIPTION
I'm going to propose that the soft_error macro should act the same for meta's internal build versus the OSS build.  Particularly, there have been times where benign uncommon situations are a quiet soft error for meta, and a panic for the OSS community.  I think the best situation for the OSS community is identical behavior as the meta build.