### PR TITLE
Recursive type checker

### DIFF
--- a/starlark-rust/starlark/src/typing/bindings.rs
+++ b/starlark-rust/starlark/src/typing/bindings.rs
@@ -231,7 +231,7 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
             let name = &p.node.ident;
             let ty = p.node.ty;
             let ty = Self::resolve_ty_opt(ty, typecheck_mode, codemap)?;
-            let name_ty = match &p.node.kind {
+            let ty = match &p.node.kind {
                 DefParamKind::Regular(mode, default_value) => {
                     let required = match default_value.is_some() {
                         true => ParamIsRequired::No,
@@ -256,25 +256,23 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
                             ));
                         }
                     }
-                    Some((name, ty))
+                    ty
                 }
                 DefParamKind::Args => {
                     // There is the type we require people calling us use (usually any)
                     // and then separately the type we are when we are running (always tuple)
                     args = Some(ty.dupe());
-                    Some((name, Ty::basic(TyBasic::Tuple(TyTuple::Of(ArcTy::new(ty))))))
+                    Ty::basic(TyBasic::Tuple(TyTuple::Of(ArcTy::new(ty))))
                 }
                 DefParamKind::Kwargs => {
                     let var_ty = Ty::dict(Ty::string(), ty.clone());
                     kwargs = Some(ty.dupe());
-                    Some((name, var_ty))
+                    var_ty
                 }
             };
-            if let Some((name, ty)) = name_ty {
-                self.bindings
-                    .types
-                    .insert(name.resolved_binding_id(codemap)?, ty);
-            }
+            self.bindings
+                .types
+                .insert(name.resolved_binding_id(codemap)?, ty);
         }
         let params2 = ParamSpec::new_parts(pos_only, pos_or_named, args, named_only, kwargs)
             .map_err(|e| InternalError::from_error(e, def.signature_span(), codemap))?;

--- a/starlark-rust/starlark/src/typing/bindings.rs
+++ b/starlark-rust/starlark/src/typing/bindings.rs
@@ -101,12 +101,43 @@ pub(crate) struct Bindings<'a> {
     pub(crate) check_type: Vec<(Span, Option<&'a CstExpr>, Ty)>,
 }
 
+/// Basically a child `def`.
+pub(crate) struct ChildDef<'a> {
+    pub(crate) body: &'a CstStmt,
+    pub(crate) return_type: Ty,
+    pub(crate) param_types: HashMap<BindingId, Ty>,
+}
+
 pub(crate) struct BindingsCollect<'a, 'b> {
     pub(crate) bindings: Bindings<'a>,
     pub(crate) approximations: &'b mut Vec<Approximation>,
+    pub(crate) children_sink: Option<&'b mut Vec<ChildDef<'a>>>,
 }
 
 impl<'a, 'b> BindingsCollect<'a, 'b> {
+    /// Collect all the assignments to variables in a scope.
+    ///
+    /// This function only fails on internal errors.
+    pub(crate) fn collect_scope(
+        scope: &'a CstStmt,
+        return_type: &Ty,
+        visible: &HashMap<BindingId, Ty>,
+        typecheck_mode: TypecheckMode,
+        codemap: &CodeMap,
+        approximations: &'b mut Vec<Approximation>,
+        children_sink: &'b mut Vec<ChildDef<'a>>,
+    ) -> Result<Bindings<'a>, InternalError> {
+        let mut res = BindingsCollect {
+            bindings: Bindings::default(),
+            approximations,
+            children_sink: Some(children_sink),
+        };
+        res.bindings.types = visible.clone();
+
+        res.visit(Visit::Stmt(scope), return_type, typecheck_mode, codemap)?;
+        Ok(res.bindings)
+    }
+
     /// Collect all the assignments to variables.
     ///
     /// This function only fails on internal errors.
@@ -119,6 +150,7 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         let mut res = BindingsCollect {
             bindings: Bindings::default(),
             approximations,
+            children_sink: None,
         };
 
         res.visit(Visit::Stmt(x), &Ty::any(), typecheck_mode, codemap)?;
@@ -242,6 +274,7 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         let mut args = None;
         let mut named_only = Vec::new();
         let mut kwargs = None;
+        let mut param_types = HashMap::new();
 
         for p in params {
             let name = &p.node.ident;
@@ -286,9 +319,7 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
                     var_ty
                 }
             };
-            self.bindings
-                .types
-                .insert(name.resolved_binding_id(codemap)?, ty);
+            param_types.insert(name.resolved_binding_id(codemap)?, ty);
         }
         let params2 = ParamSpec::new_parts(pos_only, pos_or_named, args, named_only, kwargs)
             .map_err(|e| InternalError::from_error(e, def.signature_span(), codemap))?;
@@ -307,7 +338,17 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
             name.span,
             codemap,
         )?;
-        def.visit_children_err(|x| self.visit(x, &ret_ty, typecheck_mode, codemap))?;
+
+        def.visit_header_err(|x| self.visit(x, &ret_ty, typecheck_mode, codemap))?;
+
+        // Function body just gets added to the queue.
+        if let Some(sink) = &mut self.children_sink {
+            sink.push(ChildDef {
+                body: &def.body,
+                param_types,
+                return_type: ret_ty,
+            });
+        }
         Ok(())
     }
 

--- a/starlark-rust/starlark/src/typing/bindings.rs
+++ b/starlark-rust/starlark/src/typing/bindings.rs
@@ -39,6 +39,7 @@ use crate::codemap::Span;
 use crate::codemap::Spanned;
 use crate::eval::compiler::scope::BindingId;
 use crate::eval::compiler::scope::ResolvedIdent;
+use crate::eval::compiler::scope::payload::CstAssignIdent;
 use crate::eval::compiler::scope::payload::CstAssignIdentExt;
 use crate::eval::compiler::scope::payload::CstAssignTarget;
 use crate::eval::compiler::scope::payload::CstExpr;
@@ -206,6 +207,21 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         }
     }
 
+    /// Insert an explicit type for the binding.
+    fn type_annotation(
+        &mut self,
+        binding: &CstAssignIdent,
+        ty: Ty,
+        _error_span: Span,
+        codemap: &CodeMap,
+    ) -> Result<(), InternalError> {
+        let resolved_id = binding.resolved_binding_id(codemap)?;
+        // FIXME: This could be duplicated if you declare the type of a variable twice.
+        // We would only see the second one.
+        self.bindings.types.insert(resolved_id, ty);
+        Ok(())
+    }
+
     fn visit_def(
         &mut self,
         def: &'a DefP<CstPayload>,
@@ -277,10 +293,20 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         let params2 = ParamSpec::new_parts(pos_only, pos_or_named, args, named_only, kwargs)
             .map_err(|e| InternalError::from_error(e, def.signature_span(), codemap))?;
         let ret_ty = Self::resolve_ty_opt(return_type.as_deref(), typecheck_mode, codemap)?;
-        self.bindings.types.insert(
-            name.resolved_binding_id(codemap)?,
+
+        // Defining a function is like an annotated assignment
+        //
+        //     foo: Function[...] = lambda x, y: ...
+        //
+        // (even if there are no type annotations, because even just having parameters
+        // is a kind of type annotation).
+        //
+        self.type_annotation(
+            name,
             Ty::function(params2, ret_ty.clone()),
-        );
+            name.span,
+            codemap,
+        )?;
         def.visit_children_err(|x| self.visit(x, &ret_ty, typecheck_mode, codemap))?;
         Ok(())
     }
@@ -301,11 +327,7 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
                             .check_type
                             .push((ty.span, Some(rhs), ty2.clone()));
                         if let AssignTargetP::Identifier(id) = &**lhs {
-                            // FIXME: This could be duplicated if you declare the type of a variable twice,
-                            // we would only see the second one.
-                            self.bindings
-                                .types
-                                .insert(id.resolved_binding_id(codemap)?, ty2);
+                            self.type_annotation(id, ty2, lhs.span.merge(ty.span), codemap)?;
                         }
                     }
                     self.assign(lhs, BindExpr::Expr(rhs), codemap)?

--- a/starlark-rust/starlark/src/typing/bindings.rs
+++ b/starlark-rust/starlark/src/typing/bindings.rs
@@ -111,7 +111,7 @@ pub(crate) struct ChildDef<'a> {
 pub(crate) struct BindingsCollect<'a, 'b> {
     pub(crate) bindings: Bindings<'a>,
     pub(crate) approximations: &'b mut Vec<Approximation>,
-    pub(crate) children_sink: Option<&'b mut Vec<ChildDef<'a>>>,
+    pub(crate) children_sink: &'b mut Vec<ChildDef<'a>>,
 }
 
 impl<'a, 'b> BindingsCollect<'a, 'b> {
@@ -130,31 +130,12 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         let mut res = BindingsCollect {
             bindings: Bindings::default(),
             approximations,
-            children_sink: Some(children_sink),
+            children_sink,
         };
         res.bindings.types = visible.clone();
 
         res.visit(Visit::Stmt(scope), return_type, typecheck_mode, codemap)?;
         Ok(res.bindings)
-    }
-
-    /// Collect all the assignments to variables.
-    ///
-    /// This function only fails on internal errors.
-    pub(crate) fn collect_one(
-        x: &'a mut CstStmt,
-        typecheck_mode: TypecheckMode,
-        codemap: &CodeMap,
-        approximations: &'b mut Vec<Approximation>,
-    ) -> Result<Self, InternalError> {
-        let mut res = BindingsCollect {
-            bindings: Bindings::default(),
-            approximations,
-            children_sink: None,
-        };
-
-        res.visit(Visit::Stmt(x), &Ty::any(), typecheck_mode, codemap)?;
-        Ok(res)
     }
 
     fn assign(
@@ -342,13 +323,11 @@ impl<'a, 'b> BindingsCollect<'a, 'b> {
         def.visit_header_err(|x| self.visit(x, &ret_ty, typecheck_mode, codemap))?;
 
         // Function body just gets added to the queue.
-        if let Some(sink) = &mut self.children_sink {
-            sink.push(ChildDef {
-                body: &def.body,
-                param_types,
-                return_type: ret_ty,
-            });
-        }
+        self.children_sink.push(ChildDef {
+            body: &def.body,
+            param_types,
+            return_type: ret_ty,
+        });
         Ok(())
     }
 

--- a/starlark-rust/starlark/src/typing/error.rs
+++ b/starlark-rust/starlark/src/typing/error.rs
@@ -146,6 +146,14 @@ impl TypingOrInternalError {
             Self::Internal(e) => e.into_eval_exception(),
         }
     }
+
+    #[cold]
+    pub(crate) fn into_error(self) -> crate::Error {
+        match self {
+            Self::Typing(e) => e.into_error(),
+            Self::Internal(e) => e.into_error(),
+        }
+    }
 }
 
 /// Like [`TypingOrInternalError`], but without context on the typing variant.

--- a/starlark-rust/starlark/src/typing/error.rs
+++ b/starlark-rust/starlark/src/typing/error.rs
@@ -138,6 +138,16 @@ impl From<InternalError> for TypingOrInternalError {
     }
 }
 
+impl TypingOrInternalError {
+    #[cold]
+    pub(crate) fn into_eval_exception(self) -> EvalException {
+        match self {
+            Self::Typing(e) => e.into_eval_exception(),
+            Self::Internal(e) => e.into_eval_exception(),
+        }
+    }
+}
+
 /// Like [`TypingOrInternalError`], but without context on the typing variant.
 pub enum TypingNoContextOrInternalError {
     /// Types are not compatible.

--- a/starlark-rust/starlark/src/typing/typecheck.rs
+++ b/starlark-rust/starlark/src/typing/typecheck.rs
@@ -23,7 +23,6 @@ use std::fmt::Display;
 use dupe::Dupe;
 use starlark_map::unordered_map::UnorderedMap;
 use starlark_syntax::slice_vec_ext::VecExt;
-use starlark_syntax::syntax::ast::StmtP;
 use starlark_syntax::syntax::ast::Visibility;
 use starlark_syntax::syntax::module::AstModuleFields;
 use starlark_syntax::syntax::top_level_stmts::top_level_stmts_mut;
@@ -321,12 +320,12 @@ impl AstModuleTypecheck for AstModule {
         let scope_errors = scope_errors.into_map(TypingError::from_eval_exception);
         // We don't really need to properly unpack top-level statements,
         // but make it safe against future changes.
-        let mut cst: Vec<&mut CstStmt> = top_level_stmts_mut(&mut cst);
+        let mut cst_toplevel: Vec<&mut CstStmt> = top_level_stmts_mut(&mut cst);
         let oracle = TypingOracleCtx { codemap: &codemap };
 
         let mut approximations = Vec::new();
         let (fill_types_errors, module_var_types) = match fill_types_for_lint_typechecker(
-            &mut cst,
+            &mut cst_toplevel,
             oracle,
             &scope_data,
             &mut approximations,
@@ -346,58 +345,43 @@ impl AstModuleTypecheck for AstModule {
         };
 
         let mut typemap = UnorderedMap::new();
+        let oracle = TypingOracleCtx { codemap: &codemap };
+        let mut type_checker = TypeChecker {
+            oracle,
+            typecheck_mode: TypecheckMode::Lint,
+            module_var_types: &module_var_types,
+            approximations: &mut approximations,
+            all_solved_types: HashMap::new(),
+        };
         let mut all_solve_errors = Vec::new();
 
-        for top in cst.iter_mut() {
-            if let StmtP::Def(_) = &mut top.node {
-                let bindings = match BindingsCollect::collect_one(
-                    top,
-                    TypecheckMode::Lint,
-                    &codemap,
-                    &mut approximations,
-                ) {
-                    Ok(bindings) => bindings,
-                    Err(e) => {
-                        return (
-                            vec![InternalError::into_error(e)],
-                            TypeMap {
-                                codemap,
-                                bindings: UnorderedMap::new(),
-                            },
-                            Interface::default(),
-                            Vec::new(),
-                        );
-                    }
-                };
-                let (solve_errors, types, solve_approximations) =
-                    match solve_bindings(bindings.bindings, oracle, &module_var_types) {
-                        Ok(x) => x,
-                        Err(e) => {
-                            return (
-                                vec![e.into_error()],
-                                TypeMap {
-                                    codemap,
-                                    bindings: UnorderedMap::new(),
-                                },
-                                Interface::default(),
-                                Vec::new(),
-                            );
-                        }
-                    };
+        let mut error_handler = |error| {
+            all_solve_errors.push(error);
+            // continue checking
+            Ok(())
+        };
+        if let Err(unrecoverable) = type_checker.check_module_scope(&cst, &mut error_handler) {
+            // This is generally an internal error, since most typing errors are handled
+            // by error_handler. Except some type errors that can't (yet?) be recovered.
+            return (
+                vec![unrecoverable.into_error()],
+                TypeMap {
+                    codemap,
+                    bindings: UnorderedMap::new(),
+                },
+                Interface::default(),
+                Vec::new(),
+            );
+        }
 
-                all_solve_errors.extend(solve_errors);
-                approximations.extend(solve_approximations);
-
-                for (id, ty) in &types {
-                    let binding = scope_data.get_binding(*id);
-                    let name = binding.name.as_str().to_owned();
-                    let span = match binding.source {
-                        BindingSource::Source(span) => span,
-                        BindingSource::FromModule => Span::default(),
-                    };
-                    typemap.insert(*id, (name, span, ty.clone()));
-                }
-            }
+        for (id, ty) in &type_checker.all_solved_types {
+            let binding = scope_data.get_binding(*id);
+            let name = binding.name.as_str().to_owned();
+            let span = match binding.source {
+                BindingSource::Source(span) => span,
+                BindingSource::FromModule => Span::default(),
+            };
+            typemap.insert(*id, (name, span, ty.clone()));
         }
 
         let typemap = TypeMap {

--- a/starlark-rust/starlark/src/typing/typecheck.rs
+++ b/starlark-rust/starlark/src/typing/typecheck.rs
@@ -46,6 +46,7 @@ use crate::typing::bindings::BindingsCollect;
 use crate::typing::ctx::TypingContext;
 use crate::typing::error::InternalError;
 use crate::typing::error::TypingError;
+use crate::typing::error::TypingOrInternalError;
 use crate::typing::fill_types_for_lint::ModuleVarTypes;
 use crate::typing::fill_types_for_lint::fill_types_for_lint_typechecker;
 use crate::typing::interface::Interface;
@@ -54,6 +55,110 @@ use crate::typing::oracle::ctx::TypingOracleCtx;
 use crate::typing::ty::Approximation;
 use crate::typing::ty::Ty;
 use crate::values::FrozenHeap;
+
+/// Recursive function type-checker.
+///
+/// You can call `solve_bindings` on as big or as little input as you like, but it
+/// is O(n * m) where n is the number of expressions assigned to bindings, and m is
+/// a measure of complexity of the assignments (`a=1; b=a; b=""; c=b; a=c` is
+/// deliberately complex). If you lump all bindings in an entire module together and
+/// solve them all at once, `m` is set to the most complex function and `n` is large.
+///
+/// Fortunately, because of variable shadowing and no `global` keyword, we only ever
+/// need to look at a function body to determine the types of its local bindings from
+/// the assignments made to it.
+///
+/// ```python
+/// x = 5
+/// def child():
+///     x = "string"   # completely different binding, no relation to outer `x`
+/// ```
+///
+/// In some circumstances child scopes could influence parent scopes via mutation
+/// methods, but it's not a big loss if we don't infer in these cases.
+///
+/// ```python
+/// xs = list()
+/// def child():
+///     xs.push(5)  # could influence type of xs, but we will not support this
+/// ```
+///
+/// So we can solve bindings for every scope individually. That's what this does.
+/// As for ordering, a parent scope is finished and solved before we check any of
+/// its child scopes, so child scopes have access to parent binding solutions.
+///
+/// ```python
+/// x = 5
+/// def child():
+///     y = x    # y solves to `int | str`
+/// x = "string"
+/// ```
+///
+pub(crate) struct TypeChecker<'a> {
+    pub(crate) oracle: TypingOracleCtx<'a>,
+    pub(crate) typecheck_mode: TypecheckMode,
+    pub(crate) module_var_types: &'a ModuleVarTypes,
+    pub(crate) approximations: &'a mut Vec<Approximation>,
+    pub(crate) all_solved_types: HashMap<BindingId, Ty>,
+}
+
+impl<'a> TypeChecker<'a> {
+    fn codemap(&self) -> &'a CodeMap {
+        self.oracle.codemap
+    }
+
+    /// Typecheck an entire module.
+    ///
+    /// To just immediately return on encountering a type error, pass `&mut Err` as the error
+    /// handler. To collect errors and continue, be sure to return Ok from the error handler.
+    pub(crate) fn check_module_scope(
+        &mut self,
+        module: &CstStmt,
+        eh: &mut dyn FnMut(TypingError) -> Result<(), TypingError>,
+    ) -> Result<(), TypingOrInternalError> {
+        self.check_scope(module, &Ty::any(), &HashMap::default(), eh)
+    }
+
+    /// Recursive scope check. Checks the scope's bindings, and then all child defs.
+    pub(crate) fn check_scope(
+        &mut self,
+        body: &CstStmt,
+        return_type: &Ty,
+        visible: &HashMap<BindingId, Ty>,
+        eh: &mut dyn FnMut(TypingError) -> Result<(), TypingError>,
+    ) -> Result<(), TypingOrInternalError> {
+        let mut children = Vec::new();
+        let bindings = BindingsCollect::collect_scope(
+            body,
+            return_type,
+            visible,
+            self.typecheck_mode,
+            self.codemap(),
+            self.approximations,
+            &mut children,
+        )?;
+        let (errors, solved, mut approx) =
+            solve_bindings(bindings, self.oracle, self.module_var_types)?;
+
+        self.approximations.append(&mut approx);
+
+        for error in errors {
+            eh(error)?;
+        }
+
+        // Save all solved types to the output
+        let solved_copy = solved.iter().map(|(&b, ty)| (b, ty.dupe()));
+        self.all_solved_types.extend(solved_copy.clone());
+
+        for child in children {
+            let mut child_visible = visible.clone();
+            child_visible.extend(solved_copy.clone());
+            child_visible.extend(child.param_types);
+            self.check_scope(child.body, &child.return_type, &child_visible, eh)?;
+        }
+        Ok(())
+    }
+}
 
 // Things which are None in the map have type void - they are never constructed
 pub(crate) fn solve_bindings(

--- a/starlark-rust/starlark/src/typing/user.rs
+++ b/starlark-rust/starlark/src/typing/user.rs
@@ -292,6 +292,15 @@ impl TyCustomImpl for TyUser {
         }
         self.supertypes.iter().any(|x| x == other)
     }
+
+    fn bin_op(
+        &self,
+        bin_op: super::TypingBinOp,
+        rhs: &TyBasic,
+        _ctx: &TypingOracleCtx,
+    ) -> Result<Ty, TypingNoContextOrInternalError> {
+        Ok(self.base.bin_op(bin_op, rhs)?)
+    }
 }
 
 #[cfg(test)]

--- a/starlark-rust/starlark_syntax/src/syntax/uniplate.rs
+++ b/starlark-rust/starlark_syntax/src/syntax/uniplate.rs
@@ -86,6 +86,36 @@ impl<P: AstPayload> DefP<P> {
         f(Visit::Stmt(body));
     }
 
+    /// Visit the parameters and return type, but not the body
+    pub fn visit_header_err<'a, E>(
+        &'a self,
+        mut f: impl FnMut(Visit<'a, P>) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let DefP {
+            name: _,
+            params,
+            return_type,
+            body: _,
+            payload: _,
+        } = self;
+        let mut result = Ok(());
+        params.iter().for_each(|x| {
+            x.visit_expr(|x| {
+                if result.is_ok() {
+                    result = f(Visit::Expr(x));
+                }
+            })
+        });
+        return_type.iter().for_each(|x| {
+            x.visit_expr(|x| {
+                if result.is_ok() {
+                    result = f(Visit::Expr(x));
+                }
+            })
+        });
+        result
+    }
+
     pub fn visit_children_err<'a, E>(
         &'a self,
         mut f: impl FnMut(Visit<'a, P>) -> Result<(), E>,


### PR DESCRIPTION
Just this part of #1148. It is described most fully in the doc comment in typecheck.rs. As a reminder, the big impact is that we now typecheck top level assignments and function calls.

OSS buck is not actually building right now (https://github.com/facebook/buck2/issues/1280). But with some dumb fixes to those issues applied on top, this builds.

I added one extra change 'Fix TyUser not forwarding bin_op' so that the prelude typechecks. i.e. `buck2 starlark typecheck prelude/**/*.bzl`. There were only failures because these things always appeared in top-level bindings e.g. `Blah = provider(fields = ... RunInfo | None, ... )`. Under real world usage I don't know, run it on your systems and see what shakes out.

Attn @Wilfred who wanted this separate in 1148.