### PR TITLE
Convert unnecessary soft error to debug logging (#1291)

### DIFF
--- a/app/buck2_execute_impl/src/materializers/deferred/artifact_tree.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred/artifact_tree.rs
@@ -11,7 +11,6 @@
 use std::sync::Arc;
 
 use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
-use buck2_core::soft_error;
 use buck2_directory::directory::directory_ref::DirectoryRef;
 use buck2_directory::directory::entry::DirectoryEntry;
 use buck2_error::BuckErrorContext;
@@ -359,8 +358,7 @@ impl ArtifactTree {
                 }
             }
             Err(e) => {
-                // NOTE: This shouldn't normally happen?
-                let _unused = soft_error!("cleanup_finished_vacant", e, quiet: true);
+                tracing::debug!("cleanup_finished_vacant: {}", e);
             }
         }
     }

--- a/app/buck2_execute_impl/src/materializers/deferred/artifact_tree.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred/artifact_tree.rs
@@ -360,7 +360,7 @@ impl ArtifactTree {
             }
             Err(e) => {
                 // NOTE: This shouldn't normally happen?
-                soft_error!("cleanup_finished_vacant", e, quiet: true).unwrap();
+                let _unused = soft_error!("cleanup_finished_vacant", e, quiet: true);
             }
         }
     }

--- a/app/buck2_execute_impl/src/materializers/deferred/command_processor.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred/command_processor.rs
@@ -548,12 +548,11 @@ impl<T: IoHandler> DeferredMaterializerCommandProcessor<T> {
                             Some(cmd.create_clean_fut(&mut self, None, daemon_id));
                     } else {
                         // This should never happen
-                        soft_error!(
+                        let _unused = soft_error!(
                             "clean_stale_no_config",
                             buck2_error!(buck2_error::ErrorTag::Tier0, "clean scheduled without being configured"),
                             quiet: true
-                        )
-                            .unwrap();
+                        );
                     }
                 }
             }
@@ -751,12 +750,11 @@ impl<T: IoHandler> DeferredMaterializerCommandProcessor<T> {
                     .materializer_state_table()
                     .update_access_times(buffer.iter().collect::<Vec<_>>())
                 {
-                    soft_error!(
+                    let _unused = soft_error!(
                         "materializer_materialize_error",
                         e,
                         quiet: true
-                    )
-                    .unwrap();
+                    );
                     return "Found error while updating access times in sqlite db".to_owned();
                 }
             }
@@ -1021,7 +1019,7 @@ impl<T: IoHandler> DeferredMaterializerCommandProcessor<T> {
                         .materializer_state_table()
                         .update_access_times(vec![&path])
                     {
-                        soft_error!("has_artifact_update_time", e, quiet: true).unwrap();
+                        let _unused = soft_error!("has_artifact_update_time", e, quiet: true);
                     }
                 }
             }
@@ -1457,7 +1455,7 @@ fn on_materialization(
             .materializer_state_table()
             .insert(path, metadata, timestamp)
         {
-            soft_error!(error_name, e, quiet: true).unwrap();
+            let _unused = soft_error!(error_name, e, quiet: true);
         }
     }
 


### PR DESCRIPTION
Summary:

It's entirely possible for paths to be re-declared by a subsequent command before cleanup path request gets processed. Not sure why a soft error was added here but it's too broad for detecting bugs in materializer.

Differential Revision: D100418271
