### PR TITLE
Make soft_error no-op by default and error on opt-in in OSS (#1293)

### DIFF
--- a/app/buck2/src/check_user_allowed.rs
+++ b/app/buck2/src/check_user_allowed.rs
@@ -87,7 +87,7 @@ pub(crate) fn check_user_allowed() -> buck2_error::Result<()> {
         if let Ok(home_dir) = AbsPath::new(&home_dir) {
             let home_dir_metadata = fs_util::metadata(home_dir).categorize_internal()?;
             if home_dir_metadata.uid() != 0 {
-                soft_error!("root_not_allowed", RootError.into())?;
+                soft_error!("root_not_allowed", RootError.into(), error_on_oss: true)?;
             }
         }
     }

--- a/app/buck2_action_impl/src/actions/impls/run/dep_files.rs
+++ b/app/buck2_action_impl/src/actions/impls/run/dep_files.rs
@@ -1527,7 +1527,7 @@ impl ConcreteDepFiles {
                 .buck_error_context("Invalid line encountered in dep file")?;
 
             if let Err(e) = Self::add_path_to_selector(path, &mut selector, fs, builder) {
-                soft_error!("failed_to_add_dep_file_path_to_selector", e)?;
+                soft_error!("failed_to_add_dep_file_path_to_selector", e, error_on_oss: true)?;
                 return Ok(None);
             }
         }

--- a/app/buck2_anon_target/src/anon_target_attr_coerce.rs
+++ b/app/buck2_anon_target/src/anon_target_attr_coerce.rs
@@ -273,7 +273,8 @@ fn to_anon_target_any(value: Value, ctx: &AnonAttrCtx) -> buck2_error::Result<An
     } else {
         soft_error!(
             "coerce_to_any",
-            AnonTargetCoercionError::CannotCoerceToAny(value.get_type(), value.to_repr()).into()
+            AnonTargetCoercionError::CannotCoerceToAny(value.get_type(), value.to_repr()).into(),
+            error_on_oss: true
         )?;
         Ok(AnonTargetAttr::String(StringLiteral(
             ctx.intern_str(&value.to_str()),

--- a/app/buck2_bxl/src/bxl/starlark_defs/context/actions.rs
+++ b/app/buck2_bxl/src/bxl/starlark_defs/context/actions.rs
@@ -307,7 +307,8 @@ fn bxl_actions_methods(builder: &mut MethodsBuilder) {
             soft_error!(
                 "bxl_acessing_exec_platform",
                 buck2_error!(buck2_error::ErrorTag::Input, "Anon target or dynamic action accesses bxl.Actions.exec_deps."),
-                quiet: true
+                quiet: true,
+                error_on_oss: true
             )?;
         }
 
@@ -324,7 +325,8 @@ fn bxl_actions_methods(builder: &mut MethodsBuilder) {
             soft_error!(
                 "bxl_acessing_exec_platform",
                 buck2_error!(buck2_error::ErrorTag::Input, "Anon target or dynamic action accesses bxl.Actions.toolchains."),
-                quiet: true
+                quiet: true,
+                error_on_oss: true
             )?;
         }
         Ok(this.toolchains)

--- a/app/buck2_bxl/src/bxl/starlark_defs/target_list_expr.rs
+++ b/app/buck2_bxl/src/bxl/starlark_defs/target_list_expr.rs
@@ -334,7 +334,8 @@ impl<'v> TargetListExpr<'v, ConfiguredTargetNode> {
                 soft_error!(
                     "bxl_unconfigured_target_in_cquery",
                     TargetExprError::UnconfiguredTargetInCquery(unconfigured_label.to_owned())
-                        .into()
+                        .into(),
+                    error_on_oss: true
                 )?;
             }
         }

--- a/app/buck2_bxl/src/command.rs
+++ b/app/buck2_bxl/src/command.rs
@@ -581,7 +581,8 @@ pub(crate) fn parse_bxl_label_from_cli(
                 got: bxl_path.to_owned(),
                 wanted: reformed_path,
             }
-            .into()
+            .into(),
+            error_on_oss: true
         )?;
     }
 

--- a/app/buck2_cfg_constructor/src/calculation.rs
+++ b/app/buck2_cfg_constructor/src/calculation.rs
@@ -180,6 +180,7 @@ impl CfgConstructorCalculationImpl for CfgConstructorCalculationInstance {
                         target.label(),
                     ),
                     quiet: true,
+                    error_on_oss: true,
                 )
                 .ok();
                 let mut merged = match m.as_json() {

--- a/app/buck2_client_ctx/src/query_args.rs
+++ b/app/buck2_client_ctx/src/query_args.rs
@@ -84,6 +84,7 @@ impl CommonAttributeArgs {
                 "output_attributes",
                 ArgErrors::OutputAttributesDeprecated.into(),
                 deprecation: true,
+                error_on_oss: true,
             )?;
         }
 

--- a/app/buck2_common/src/init.rs
+++ b/app/buck2_common/src/init.rs
@@ -625,7 +625,8 @@ impl DaemonStartupConfig {
                              This will be the default very soon."
                         ),
                         deprecation: true,
-                        quiet: false
+                        quiet: false,
+                        error_on_oss: true
                     )?;
                     Some(from_config.unwrap_or_else(|| "skip_lowering".to_owned()))
                 } else {

--- a/app/buck2_configured/src/nodes.rs
+++ b/app/buck2_configured/src/nodes.rs
@@ -1263,6 +1263,7 @@ impl ConfiguredTargetNodeCalculationImpl for ConfiguredTargetNodeCalculationInst
                     soft_error!(
                         "dep_only_incompatible_version_two", reason.to_soft_err(),
                         quiet: false,
+                        error_on_oss: true,
                         // Log at least one sample per unique package.
                         low_cardinality_key_for_additional_logview_samples: Some(Box::new(target.unconfigured().pkg())),
                     )?;
@@ -1278,6 +1279,7 @@ impl ConfiguredTargetNodeCalculationImpl for ConfiguredTargetNodeCalculationInst
                                 reason.to_soft_err(),
                                 quiet: true,
                                 task: false,
+                                error_on_oss: true,
                             )?;
                         }
                     }

--- a/app/buck2_core/src/provider/flavors.rs
+++ b/app/buck2_core/src/provider/flavors.rs
@@ -58,7 +58,8 @@ pub fn map_flavors(flavors: &str, full_target: &str) -> buck2_error::Result<Prov
             "platform_flavor",
             buck2_error::buck2_error!(buck2_error::ErrorTag::Input, "Platform flavor found in target: {}", full_target),
             deprecation: true,
-            quiet: true
+            quiet: true,
+            error_on_oss: true
         )?;
         flavors_parts.remove(index);
     }

--- a/app/buck2_core/src/target/name.rs
+++ b/app/buck2_core/src/target/name.rs
@@ -109,7 +109,8 @@ impl TargetName {
                 "label_has_comma",
                 TargetNameError::LabelHasSpecialCharacter(name.to_owned(), ',').into(),
                 deprecation: true,
-                quiet: true
+                quiet: true,
+                error_on_oss: true
             )?;
         }
         if name.contains('$') {
@@ -117,7 +118,8 @@ impl TargetName {
                 "label_has_dollar_sign",
                 TargetNameError::LabelHasSpecialCharacter(name.to_owned(), '$').into(),
                 deprecation: true,
-                quiet: true
+                quiet: true,
+                error_on_oss: true
             )?;
         }
 

--- a/app/buck2_core/tests/soft_error.rs
+++ b/app/buck2_core/tests/soft_error.rs
@@ -15,7 +15,6 @@ use std::sync::Once;
 use buck2_core::error::StructuredErrorOptions;
 use buck2_core::error::initialize;
 use buck2_core::error::reset_soft_error_counters;
-use buck2_core::is_open_source;
 use buck2_core::soft_error;
 use buck2_error::buck2_error;
 
@@ -51,9 +50,6 @@ fn test_init() -> MutexGuard<'static, ()> {
 
 #[test]
 fn test_soft_error() {
-    if is_open_source() {
-        return; // Errors are always hard in open source
-    }
     let _guard = test_init();
 
     let before_error_line = line!();
@@ -73,9 +69,6 @@ fn test_soft_error() {
 
 #[test]
 fn test_reset_counters() {
-    if is_open_source() {
-        return; // Errors are always hard in open source
-    }
     let _guard = test_init();
 
     assert_eq!(0, RESULT.lock().unwrap().len(), "Sanity check");

--- a/app/buck2_env/src/soft_error.rs
+++ b/app/buck2_env/src/soft_error.rs
@@ -228,6 +228,10 @@ pub struct StructuredErrorOptions {
     /// Create a task for this error.
     pub task: bool,
     pub deprecation: bool,
+    /// When true, this soft error will be promoted to a hard error in open source builds.
+    /// Use this for deprecation/migration errors that OSS users should see.
+    /// Monitoring/logging errors should leave this as false (the default).
+    pub error_on_oss: bool,
     pub daemon_in_memory_state_is_corrupted: bool,
     pub daemon_materializer_state_is_corrupted: bool,
     pub action_cache_is_corrupted: bool,
@@ -245,6 +249,7 @@ impl Default for StructuredErrorOptions {
             quiet: true,
             task: true,
             deprecation: false,
+            error_on_oss: false,
             daemon_in_memory_state_is_corrupted: false,
             daemon_materializer_state_is_corrupted: false,
             action_cache_is_corrupted: false,
@@ -274,6 +279,8 @@ pub fn handle_soft_error(
         options.quiet = false;
     }
 
+    let error_on_oss = options.error_on_oss;
+
     // We want to limit each error to appearing at most 10 times in a build (no point spamming people)
     if count.fetch_add(1, Ordering::SeqCst) < 10 {
         if let Some(handler) = HANDLER.get() {
@@ -293,9 +300,10 @@ pub fn handle_soft_error(
 
     // @oss-disable: let is_open_source = false;
     let is_open_source = true; // @oss-enable
-    if is_open_source {
-        // We don't log these, and we have no legacy users, and they might not upgrade that often,
-        // so lets just break open source things immediately.
+    if is_open_source && error_on_oss {
+        // In open source builds, only deprecation/migration soft errors (those with
+        // error_on_oss: true) are promoted to hard errors. Monitoring/logging soft errors
+        // are no-ops, matching internal behavior.
         return Err(err);
     }
 

--- a/app/buck2_execute/src/execute/request.rs
+++ b/app/buck2_execute/src/execute/request.rs
@@ -794,7 +794,8 @@ impl OutputType {
                 )
                 .into(),
                 deprecation: true,
-                quiet: true
+                quiet: true,
+                error_on_oss: true
             )?;
             Ok(())
         } else if self == output_type

--- a/app/buck2_interpreter/src/soft_error.rs
+++ b/app/buck2_interpreter/src/soft_error.rs
@@ -16,7 +16,7 @@ pub struct Buck2StarlarkSoftErrorHandler;
 impl SoftErrorHandler for Buck2StarlarkSoftErrorHandler {
     fn soft_error(&self, category: &str, error: starlark::Error) -> Result<(), starlark::Error> {
         let error = buck2_error::Error::from(error);
-        soft_error!(&format!("starlark_rust_{category}"), error, deprecation: true, quiet:true)?;
+        soft_error!(&format!("starlark_rust_{category}"), error, deprecation: true, quiet: true, error_on_oss: true)?;
         Ok(())
     }
 }

--- a/app/buck2_interpreter_for_build/src/attrs/coerce/attr_type/any.rs
+++ b/app/buck2_interpreter_for_build/src/attrs/coerce/attr_type/any.rs
@@ -68,7 +68,8 @@ fn to_literal(value: Value, ctx: &dyn AttrCoercionContext) -> buck2_error::Resul
     } else {
         soft_error!(
             "coerce_to_any",
-            AnyError::CannotCoerce(value.get_type(), value.to_repr()).into()
+            AnyError::CannotCoerce(value.get_type(), value.to_repr()).into(),
+            error_on_oss: true
         )?;
         Ok(CoercedAttr::String(StringLiteral(
             ctx.intern_str(&value.to_str()),

--- a/app/buck2_interpreter_for_build/src/attrs/coerce/ctx.rs
+++ b/app/buck2_interpreter_for_build/src/attrs/coerce/ctx.rs
@@ -297,7 +297,7 @@ impl AttrCoercionContext for BuildAttrCoercionContext {
                 if self.package_boundary_exception {
                     info!("{} (could be due to a package boundary violation)", e);
                 } else {
-                    soft_error!("source_directory_includes_subpackage", e.into())?;
+                    soft_error!("source_directory_includes_subpackage", e.into(), error_on_oss: true)?;
                 }
             }
             let files = listing.files_within(&path).duped().collect();
@@ -311,7 +311,7 @@ impl AttrCoercionContext for BuildAttrCoercionContext {
             if self.package_boundary_exception {
                 info!("{} (could be due to a package boundary violation)", e);
             } else {
-                soft_error!("source_file_missing", e.into(), quiet: true)?;
+                soft_error!("source_file_missing", e.into(), quiet: true, error_on_oss: true)?;
             }
 
             Ok(CoercedPath::File(path.to_arc()))

--- a/app/buck2_interpreter_for_build/src/interpreter/buckconfig.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/buckconfig.rs
@@ -234,7 +234,8 @@ fn read_config_and_report_deprecated(
         soft_error!(
             format!("deprecated_config_{section}_{prop}").as_str(),
             DeprecatedConfigError(property, msg).into(),
-            quiet: true
+            quiet: true,
+            error_on_oss: true
         )?;
     }
     Ok(result)

--- a/app/buck2_interpreter_for_build/src/interpreter/functions/soft_error.rs
+++ b/app/buck2_interpreter_for_build/src/interpreter/functions/soft_error.rs
@@ -35,7 +35,8 @@ enum SoftErrorError {
 pub(crate) fn register_soft_error(builder: &mut GlobalsBuilder) {
     /// Produce an error that will become a hard error at some point in the future, but
     /// for now is a warning which is logged to the server.
-    /// In the open source version of Buck2 this function always results in an error.
+    /// In the open source version of Buck2 this function always results in an error
+    /// (deprecation soft errors are promoted to hard errors in OSS builds).
     ///
     /// Called passing a stable key (must be `snake_case` and start with `starlark_`,
     /// used for consistent reporting) and an arbitrary message (used for debugging).
@@ -77,7 +78,7 @@ pub(crate) fn register_soft_error(builder: &mut GlobalsBuilder) {
             .into()
         };
 
-        soft_error!(category, err, quiet: quiet.unwrap_or_default(),)?;
+        soft_error!(category, err, quiet: quiet.unwrap_or_default(), error_on_oss: true)?;
         Ok(NoneType)
     }
 }

--- a/app/buck2_node/src/attrs/coerced_attr.rs
+++ b/app/buck2_node/src/attrs/coerced_attr.rs
@@ -727,6 +727,7 @@ impl CoercedAttr {
                             select.as_display_no_ctx()
                         ),
                         quiet: true,
+                        error_on_oss: true,
                     );
                 }
                 _ => {}

--- a/app/buck2_query_impls/src/dice.rs
+++ b/app/buck2_query_impls/src/dice.rs
@@ -100,7 +100,8 @@ impl LiteralParser {
                         LiteralParserError::ExpectingTargetPatternWithoutProviders(
                             value.to_owned()
                         )
-                        .into()
+                        .into(),
+                        error_on_oss: true
                     )?;
                 }
                 ParsedPattern::Target(package, target_name, TargetPatternExtra)

--- a/app/buck2_server/src/ctx.rs
+++ b/app/buck2_server/src/ctx.rs
@@ -1030,6 +1030,7 @@ fn collect_config_metadata_into(config: &LegacyBuckConfig, data: &mut UserComput
             ),
             quiet: false,
             deprecation: true,
+            error_on_oss: true,
         ).ok();
     }
 

--- a/app/buck2_server_commands/src/build.rs
+++ b/app/buck2_server_commands/src/build.rs
@@ -159,6 +159,7 @@ async fn build(
             RunArgsMissingSeparator.into(),
             quiet: false,
             deprecation: true,
+            error_on_oss: true,
         )?;
     }
 

--- a/app/buck2_server_ctx/src/concurrency.rs
+++ b/app/buck2_server_ctx/src/concurrency.rs
@@ -734,7 +734,8 @@ impl ConcurrencyHandler {
                     active_commands,
                     current_command.format_argv(),
                 )
-                .into()
+                .into(),
+                error_on_oss: true
             )?;
         }
 

--- a/app/buck2_test/src/local_resource_setup.rs
+++ b/app/buck2_test/src/local_resource_setup.rs
@@ -76,7 +76,7 @@ pub(crate) async fn required_providers<'v>(
             Ok(Some(x)) => Some(Ok(x)),
             Ok(None) => None,
             Err(e) => {
-                let _ignore = soft_error!("missing_required_local_resource", e, quiet: true);
+                let _ignore = soft_error!("missing_required_local_resource", e, quiet: true, error_on_oss: true);
                 None
             }
         })


### PR DESCRIPTION
Summary:

soft_error! is used for two different purposes: (1) deprecation/migration errors that should eventually be disallowed, and (2) monitoring/logging errors for internal infrastructure issues. Previously, ALL soft errors were promoted to hard errors in OSS builds, which caused unnecessary failures for OSS users when monitoring-only soft errors fired (specifically panics when unwrapping monitoring-only soft errors in materializer).

This change adds an `error_on_oss: bool` field to `StructuredErrorOptions` (default `false`). In OSS builds, only soft errors with `error_on_oss: true` are promoted to hard errors. All other soft errors become no-ops on OSS, matching internal behavior.

Audited all ~70 soft_error call sites and opted in ~28 deprecation/migration sites to `error_on_oss: true` (deprecated CLI flags, deprecated configs, package boundary violations, invalid target names, deprecated BXL/Starlark APIs, etc.). The ~40 monitoring/logging sites (Eden health, materializer state, CAS artifacts, build analytics, OOM detection, etc.) keep the default and will no longer break OSS builds.

Post coming in Buck2 Dev

Reviewed By: IanChilds

Differential Revision: D100954580
