### PR TITLE
Propagate linker_type correctly in the `system_cxx_toolchain`

### DIFF
--- a/prelude/toolchains/cxx.bzl
+++ b/prelude/toolchains/cxx.bzl
@@ -98,8 +98,8 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
     archiver_supports_argfiles = os != Os("macos")
     additional_linker_flags = ["-fuse-ld=lld"] if os == Os("linux") and cxx_tools_info.linker != "g++" and cxx_tools_info.cxx_compiler != "g++" else []
 
+    linker_type = cxx_tools_info.linker_type
     if os == Os("windows"):
-        linker_type = LinkerType("windows")
         binary_extension = "exe"
         object_file_extension = "obj"
         static_library_extension = "lib"
@@ -116,10 +116,8 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
         shared_library_versioned_name_format = "{}.so.{}"
 
         if os == Os("macos"):
-            linker_type = LinkerType("darwin")
             pic_behavior = PicBehavior("always_enabled")
         else:
-            linker_type = LinkerType("gnu")
             pic_behavior = PicBehavior("supported")
 
     if cxx_tools_info.compiler_type == "clang":

--- a/prelude/toolchains/cxx/clang/tools.bzl
+++ b/prelude/toolchains/cxx/clang/tools.bzl
@@ -9,7 +9,7 @@
 load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerType")
 load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 
-def _path_clang_tools_impl(_ctx) -> list[Provider]:
+def _path_clang_tools_impl(ctx) -> list[Provider]:
     return [
         DefaultInfo(),
         CxxToolsInfo(
@@ -23,11 +23,16 @@ def _path_clang_tools_impl(_ctx) -> list[Provider]:
             archiver = "ar",
             archiver_type = "gnu",
             linker = "clang++",
-            linker_type = LinkerType("gnu"),
+            linker_type = LinkerType(ctx.attrs.linker_type),
         ),
     ]
 
 path_clang_tools = rule(
     impl = _path_clang_tools_impl,
-    attrs = {},
+    attrs = {
+        "linker_type": attrs.string(default = select({
+            "DEFAULT": "gnu",
+            "config//os:macos": "darwin",
+        })),
+    },
 )


### PR DESCRIPTION
Previously the system cxx toolchain would hard code the linker type based off the os. This works fine in most cases but breaks windows gnu builds for example. The `linker_type` is already correctly provided by the `CxxToolsInfo` type but ignored. This pr uses the linker_type from there instead and adds a select to the path clang tools to separate darwin from gnu targets.