### PR TITLE
## Summary  The Go toolchain example fails to build on Windows

### DIFF
--- a/examples/toolchains/go_toolchain/toolchains/BUCK
+++ b/examples/toolchains/go_toolchain/toolchains/BUCK
@@ -33,15 +33,25 @@ http_archive(
     urls = ["https://go.dev/dl/go1.24.4.linux-amd64.tar.gz"],
 )
 
+http_archive(
+    name = "archive_go1.24.4.windows-amd64",
+    sha256 = "b751a1136cb9d8a2e7ebb22c538c4f02c09b98138c7c8bfb78a54a4566c013b1",
+    strip_prefix = "go",
+    type = "zip",
+    urls = ["https://go.dev/dl/go1.24.4.windows-amd64.zip"],
+)
+
 go_bootstrap_distr(
     name = "go_bootstrap_distr",
     go_os_arch = select({
         "config//os:linux": select({"config//cpu:x86_64": ("linux", "amd64")}),
         "config//os:macos": select({"config//cpu:arm64": ("darwin", "arm64")}),
+        "config//os:windows": select({"config//cpu:x86_64": ("windows", "amd64")}),
     }),
     go_root = select({
         "config//os:linux": select({"config//cpu:x86_64": ":archive_go1.24.4.linux-amd64"}),
         "config//os:macos": select({"config//cpu:arm64": ":archive_go1.24.4.darwin-arm64"}),
+        "config//os:windows": select({"config//cpu:x86_64": ":archive_go1.24.4.windows-amd64"}),
     }),
 )
 
@@ -54,6 +64,7 @@ go_bootstrap_toolchain(
     env_go_os = select({
         "config//os:linux": "linux",
         "config//os:macos": "darwin",
+        "config//os:windows": "windows",
     }),
     go_bootstrap_distr = ":go_bootstrap_distr",
     visibility = ["PUBLIC"],
@@ -64,10 +75,12 @@ go_distr(
     go_os_arch = select({
         "config//os:linux": select({"config//cpu:x86_64": ("linux", "amd64")}),
         "config//os:macos": select({"config//cpu:arm64": ("darwin", "arm64")}),
+        "config//os:windows": select({"config//cpu:x86_64": ("windows", "amd64")}),
     }),
     go_root = select({
         "config//os:linux": select({"config//cpu:x86_64": ":archive_go1.24.4.linux-amd64"}),
         "config//os:macos": select({"config//cpu:arm64": ":archive_go1.24.4.darwin-arm64"}),
+        "config//os:windows": select({"config//cpu:x86_64": ":archive_go1.24.4.windows-amd64"}),
     }),
     version = "1.24.4",
 )


### PR DESCRIPTION

The `go_toolchain` already had a Windows entry in `env_go_os`, but its dependency chain (`tool_pack` → `go_bootstrap_toolchain` → `go_bootstrap_distr`) was missing Windows entries entirely.

## Changes

All changes in `examples/toolchains/go_toolchain/toolchains/BUCK`:

- Added `http_archive` for `go1.24.4.windows-amd64.zip`
- Added `"config//os:windows"` entries to `go_bootstrap_distr` (`go_os_arch` and `go_root` selects)
- Added `"config//os:windows": "windows"` to `go_bootstrap_toolchain` `env_go_os`
- Added `"config//os:windows"` entries to `go_distr` (`go_os_arch` and `go_root` selects)

## Context

The prelude already fully supports Windows:
- `go_bootstrap_distr` and `go_distr` handle `.exe` suffix for `go_os == "windows"`
- `system_go_bootstrap_toolchain` detects `os.is_windows`
- `link.bzl` handles Windows extensions (`.exe`, `.dll`, `.lib`)
- `prelude//os:windows` constraint and platform detection exist

The gap was only in the example hermetic toolchain config not including Windows archives and select entries.
Fixes https://github.com/facebook/buck2/issues/1270