### PR TITLE
fix: stop using broken buck-resources crate from crates.io

### DIFF
--- a/shed/completion_verify/BUCK
+++ b/shed/completion_verify/BUCK
@@ -18,7 +18,7 @@ rust_binary(
         },
     }),
     deps = [
-        "fbsource//third-party/rust:buck-resources",
+        "fbcode//buck2/integrations/resources/rust:buck_resources",
         "fbsource//third-party/rust:clap",
         "fbsource//third-party/rust:ptyprocess",
         "fbsource//third-party/rust:tempfile",

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -48,7 +48,6 @@ bit-vec = "0.9"
 bitflags = "2.11.1"
 blake3 = { version = "=1.8.2", features = ["mmap", "rayon", "traits-preview"] } # Check overlay before updating
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
-buck-resources = "1"
 bumpalo = { version = "3.20.2", features = ["allocator_api", "collections"] }
 byteorder = "1.5"
 bytemuck = { version = "1.25", features = ["const_zeroed", "derive", "min_const_generics", "must_cast", "nightly_portable_simd", "nightly_stdsimd"] }


### PR DESCRIPTION
Instead: use the one in-tree! The problem with the one on crates.io is that it got published with a BUCK file in the source tarball, so it breaks Buck when you `reindeer vendor` it as the sources are no longer visible. The crates.io publication should certainly be fixed, but there's no reason to use the crates.io version in-repo to begin with.

Fixes: https://github.com/facebook/buck2/issues/1226