### PR TITLE
buckconfig/watchmanconfig: ignore jj directory & cargo

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -15,7 +15,10 @@ ignore = \
     app_dep_graph_rules, \
     examples, \
     integrations/rust-project/tests, \
-    tests
+    tests, \
+    .jj, \
+    .git, \
+    target
 
 [rust]
 default_edition = 2024

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-    "ignore_dirs": ["buck-out", ".git", ".sl"]
+    "ignore_dirs": ["buck-out", ".git", ".sl", ".jj", "target"]
 }


### PR DESCRIPTION
Neither of the configurations were actually ignoring these things; it's necessary to duplicate exclusions in both to stop the internal (fallback) file watcher from emitting junk into DICE, even though the excludes in it don't affect the internal watcher itself (it still sets inotify on the directories unconditionally).