### PR TITLE
Wire up opt/dev modifiers in OSS

### DIFF
--- a/PACKAGE
+++ b/PACKAGE
@@ -1,0 +1,18 @@
+load("@prelude//cfg/modifier:alias.bzl", "OSS_ALIASES")
+load("@prelude//cfg/modifier:cfg_constructor.bzl", "cfg_constructor_post_constraint_analysis", "cfg_constructor_pre_constraint_analysis")
+load("@prelude//cfg/modifier:common.bzl", "MODIFIER_METADATA_KEY")
+load("@prelude//cfg/modifier/set_cfg_modifiers.bzl", "set_cfg_modifiers")
+
+set_cfg_modifiers(["ovr_config//build_mode:dev"])
+
+# https://buck2.build/docs/users/how_tos/modifiers_setup/
+#
+# This is required for -m MODIFIER to do anything. Otherwise you need
+# to use configuration transitions.
+native.set_cfg_constructor(
+    aliases = OSS_ALIASES,
+    extra_data = struct(),
+    key = MODIFIER_METADATA_KEY,
+    stage0 = cfg_constructor_pre_constraint_analysis,
+    stage1 = cfg_constructor_post_constraint_analysis,
+)

--- a/prelude/build_mode/BUCK
+++ b/prelude/build_mode/BUCK
@@ -10,3 +10,15 @@ config_setting(
     name = "arvr_mode",
     visibility = ["PUBLIC"],
 )
+
+constraint_value(
+    name = "dev",
+    constraint_setting = "//build_mode/constraints:core_build_mode",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "opt",
+    constraint_setting = "//build_mode/constraints:core_build_mode",
+    visibility = ["PUBLIC"],
+)

--- a/prelude/build_mode/constraints/BUCK
+++ b/prelude/build_mode/constraints/BUCK
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+load("@prelude//utils:source_listing.bzl", "source_listing")
+
+oncall("build_infra")
+
+source_listing()
+
+constraint_setting(
+    name = "core_build_mode",
+    visibility = ["PUBLIC"],
+)

--- a/prelude/build_mode/default_opt_cxx/BUCK
+++ b/prelude/build_mode/default_opt_cxx/BUCK
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+load("@prelude//utils:source_listing.bzl", "source_listing")
+
+oncall("build_infra")
+
+source_listing()
+
+constraint_setting(
+    name = "default_opt_cxx_setting",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "enabled",
+    constraint_setting = ":default_opt_cxx_setting",
+    visibility = ["PUBLIC"],
+)
+
+constraint_value(
+    name = "disabled",
+    constraint_setting = ":default_opt_cxx_setting",
+    visibility = ["PUBLIC"],
+)

--- a/prelude/cfg/modifier/alias.bzl
+++ b/prelude/cfg/modifier/alias.bzl
@@ -26,4 +26,7 @@ All constraints used in these aliases must also be available in OSS.
 # 3. It's unlikely a user has to ever define an alias twice in both the `alias` buckconfig
 # and in modifier aliases because a modifier alias is a constraint value/config setting
 # and those don't typically get built on CLI.
-OSS_ALIASES = struct()
+OSS_ALIASES = struct(
+    dev = ["ovr_config//build_mode:dev", "ovr_config//build_mode/default_opt_cxx:enabled"],
+    opt = ["ovr_config//build_mode:opt", "ovr_config//build_mode/default_opt_cxx:enabled"],
+)

--- a/shim/BUCK
+++ b/shim/BUCK
@@ -28,7 +28,10 @@ system_cxx_toolchain(
     # with clang-only flags and rejects them.
     compiler_type = "gcc",
     cxx_compiler = "g++",
-    cxx_flags = ["-std=c++20"],
+    cxx_flags = ["-std=c++20"] + select({
+        "ovr_config//build_mode/default_opt_cxx:enabled": ["-O2"],
+        "DEFAULT": [],
+    }),
     # The sandcastle OSS-bootstrap environment has `gcc`/`g++` on PATH but
     # not `clang`/`clang++` or `lld`, which are the defaults pulled in by
     # `prelude//toolchains/cxx/clang:path_clang_tools`. Using `g++` as the
@@ -77,6 +80,11 @@ system_python_bootstrap_toolchain(
 system_rust_toolchain(
     name = "rust",
     default_edition = "2021",
+    rustc_flags = select({
+        "ovr_config//build_mode:opt": ["-O"],
+        "ovr_config//build_mode:dev": ["-C", "debuginfo=2"],
+        "DEFAULT": [],
+    }),
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
Motivation: I want builds of an acceptably-fast buck2 (with acceptably-fast evaluator) so I can dogfood buck2 in-tree.

This may not match what is going on in fbcode. idk, feel free to change it if you want.

I tried:
```
bootstrap/buck2 build -m opt :buck2 --out buck2
```

It's compiling way slower, so I think it's working as intended.