### PR TITLE
Fsync buckd_info after writing daemon process info

### DIFF
--- a/app/buck2_daemon/src/daemon.rs
+++ b/app/buck2_daemon/src/daemon.rs
@@ -136,6 +136,9 @@ pub(crate) fn write_process_info(
 ) -> buck2_error::Result<()> {
     let file = File::create(daemon_dir.buckd_info())?;
     serde_json::to_writer(&file, &process_info)?;
+    // Fsync so the endpoint/auth token are durable before clients race
+    // to read this file; a crash here would otherwise lose them.
+    file.sync_all()?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`write_process_info` writes the daemon's `buckd.info` JSON (endpoint,
auth token, pid, version) and lets the `File` drop without calling
`sync_all()`. `std::fs::File`'s `Drop` only closes the FD; it does not
fsync. If the daemon crashes (or the host loses power) shortly after
this call returns, the kernel page cache may not have been flushed,
leaving newly-spawned clients unable to discover or authenticate to
the daemon on next startup.

This adds a single `file.sync_all()?` to guarantee durability of this
client/daemon rendezvous metadata before the function returns.

## Risk / cost

- One extra `fsync(2)` per daemon startup. Negligible (~ms).
- No public API change. No behavior change on the success path.
- Adds one more error-return source (fsync failure), surfaced via the
  existing `buck2_error::Result<()>` return type.

## Test plan

- [ ] `cargo check -p buck2_daemon` clean
- [ ] Existing `test_daemon_smoke` in `app/buck2_daemon/src/daemon.rs` passes