### PR TITLE
Fix OSS docs build broken by starlark-fmt

### DIFF
--- a/prelude/apple/apple_rules_impl.bzl
+++ b/prelude/apple/apple_rules_impl.bzl
@@ -9,7 +9,7 @@
 # @oss-disable[end= ]: load("@prelude//apple/meta_only:meta_only_rules.bzl", "meta_only_apple_rule_attributes", "meta_only_apple_rule_implementations")
 
 # @oss-disable[end= ]: implemented_rules = {} | meta_only_apple_rule_implementations()
-} # @oss-enable
+implemented_rules = {} # @oss-enable
 
 # @oss-disable[end= ]: extra_attributes = {} | meta_only_apple_rule_attributes()
-} # @oss-enable
+extra_attributes = {} # @oss-enable


### PR DESCRIPTION
Summary:
D103610286 (starlark-fmt) collapsed the multi-line dict literal in
`apple_rules_impl.bzl` from:

```
implemented_rules = {
} | meta_only_apple_rule_implementations()  # oss-disable
# oss-enable: }
```

to:

```
implemented_rules = {} | meta_only_apple_rule_implementations()  # oss-disable
# oss-enable: }
```

Before this change, the codesync for OSS would:
1. Keep `implemented_rules = {` (no annotation)
2. Remove the `} | ...  # oss-disable` line
3. Uncomment `# oss-enable: }` → `}`

Result: `implemented_rules = {}` ✓

After starlark-fmt merged `{` onto the same line as `oss-disable`:
1. Remove `implemented_rules = {} | ...  # oss-disable` (entire line)
2. Uncomment `# oss-enable: }` → `}`

Result: just `}` → parse error! ✗

Fix: Update the `oss-enable` comments to contain the full replacement
expressions.

Differential Revision: D105386920


