### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/build-and-examples.yml
+++ b/.github/workflows/build-and-examples.yml
@@ -1,6 +1,10 @@
 name: Build and Examples
 on:
   workflow_dispatch: # allows manual triggering
+
+permissions:
+  contents: read
+
 jobs:
   macos-build-examples:
     runs-on: macos-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,10 @@ on:
   push:
   pull_request:
   workflow_dispatch: # allows manual triggering
+
+permissions:
+  contents: read
+
 jobs:
   linux-build-and-test:
     runs-on: 4-core-ubuntu


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.