### PR TITLE
starlark: Support unpacking `Set`'s

### DIFF
--- a/starlark-rust/starlark/src/tests/derive/module/unpack_value.rs
+++ b/starlark-rust/starlark/src/tests/derive/module/unpack_value.rs
@@ -26,6 +26,7 @@ use crate::values::Value;
 use crate::values::ValueOf;
 use crate::values::dict::UnpackDictEntries;
 use crate::values::list::UnpackList;
+use crate::values::set::UnpackSetEntries;
 
 // TODO(nmj): Figure out default values here. ValueOf<i32> = 5 should work.
 #[starlark_module]
@@ -115,6 +116,10 @@ fn validate_module(builder: &mut GlobalsBuilder) {
             },
         }
     }
+    fn with_set<'v>(v: ValueOf<'v, UnpackSetEntries<i32>>) -> anyhow::Result<(Value<'v>, String)> {
+        let repr = v.typed.entries.iter().join(", ");
+        Ok((v.value, repr))
+    }
 }
 
 // The standard error these raise on incorrect types
@@ -174,4 +179,14 @@ fn test_either_of() {
     a.eq("'s'", "with_either('s')");
     a.fail("with_either(noop(None))", BAD);
     a.fail("with_either(noop({}))", BAD);
+}
+
+#[test]
+fn test_set_of() {
+    let mut a = Assert::new();
+    a.globals_add(validate_module);
+    a.eq("(set([2]), '2')", "with_set(set([2]))");
+    a.eq("(set([2, 3]), '2, 3')", "with_set(set([2,3]))");
+    a.fail("with_set(noop(None))", BAD);
+    a.fail("with_set(noop({}))", BAD);
 }

--- a/starlark-rust/starlark/src/values/types/set.rs
+++ b/starlark-rust/starlark/src/values/types/set.rs
@@ -19,6 +19,8 @@
 pub(crate) mod methods;
 pub(crate) mod refs;
 pub(crate) mod set;
+pub(crate) mod unpack;
 pub(crate) mod value;
 pub use crate::values::set::refs::SetMut;
 pub use crate::values::set::refs::SetRef;
+pub use crate::values::set::unpack::UnpackSetEntries;

--- a/starlark-rust/starlark/src/values/types/set/refs.rs
+++ b/starlark-rust/starlark/src/values/types/set/refs.rs
@@ -54,6 +54,22 @@ impl<'v> Clone for SetRef<'v> {
     }
 }
 
+impl<'v> SetRef<'v> {
+    /// Downcast the value to a set.
+    pub fn from_value(x: Value<'v>) -> Option<SetRef<'v>> {
+        if x.unpack_frozen().is_some() {
+            x.downcast_ref::<SetGen<FrozenSetData>>().map(|x| SetRef {
+                aref: Either::Right(coerce(&x.0)),
+            })
+        } else {
+            let ptr = x.downcast_ref::<SetGen<RefCell<SetData<'v>>>>()?;
+            Some(SetRef {
+                aref: Either::Left(ptr.0.borrow()),
+            })
+        }
+    }
+}
+
 impl<'v> Dupe for SetRef<'v> {}
 
 /// Mutably borrowed `Set`.

--- a/starlark-rust/starlark/src/values/types/set/unpack.rs
+++ b/starlark-rust/starlark/src/values/types/set/unpack.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 The Starlark in Rust Authors.
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::values::UnpackValue;
+use crate::values::Value;
+use crate::values::set::SetRef;
+use crate::values::type_repr::SetType;
+use crate::values::type_repr::StarlarkTypeRepr;
+
+/// Unpack a `Set`.
+///
+pub struct UnpackSetEntries<K> {
+    /// Entries of the set.
+    pub entries: Vec<K>,
+}
+
+impl<K> Default for UnpackSetEntries<K> {
+    fn default() -> Self {
+        UnpackSetEntries {
+            entries: Vec::new(),
+        }
+    }
+}
+
+impl<K: StarlarkTypeRepr> StarlarkTypeRepr for UnpackSetEntries<K> {
+    type Canonical = <SetType<K> as StarlarkTypeRepr>::Canonical;
+
+    fn starlark_type_repr() -> crate::typing::Ty {
+        SetType::<K>::starlark_type_repr()
+    }
+}
+
+impl<'v, K: UnpackValue<'v>> UnpackValue<'v> for UnpackSetEntries<K> {
+    type Error = K::Error;
+
+    fn unpack_value_impl(value: Value<'v>) -> Result<Option<Self>, Self::Error> {
+        let Some(set) = SetRef::unpack_value_opt(value) else {
+            return Ok(None);
+        };
+        let mut entries = Vec::with_capacity(set.aref.content.len());
+        for k in set.aref.iter() {
+            let Some(k) = K::unpack_value_impl(k)? else {
+                return Ok(None);
+            };
+            entries.push(k);
+        }
+        Ok(Some(UnpackSetEntries { entries }))
+    }
+}


### PR DESCRIPTION
It didn't support it yet and it is useful for embedder's. I mostly followed stepancheg's advice in the bug.

This fixes https://github.com/facebook/starlark-rust/issues/144

cc @ndmitchell for visibility. 