### PR TITLE
Make FindMissingBlobs batch size configurable

### DIFF
--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -458,6 +458,13 @@ pub struct Buck2OssReConfiguration {
     pub max_total_batch_size: Option<usize>,
     /// Maximum number of concurrent upload requests for each action.
     pub max_concurrent_uploads_per_action: Option<usize>,
+    /// Maximum number of digests to ask about in a single
+    /// `FindMissingBlobs` (a.k.a. `GetDigestsTtl`) RPC. Larger values
+    /// reduce per-call wall-clock latency by issuing fewer round-trips,
+    /// at the cost of bigger requests and more concurrent server load
+    /// when many actions issue independent calls. Recommended to raise
+    /// only in combination with `[buck2] deduplicate_get_digests_ttl_calls`.
+    pub find_missing_blobs_batch_size: Option<usize>,
     /// Time that digests are assumed to live in CAS after being touched.
     pub cas_ttl_secs: Option<i64>,
     /// Interval in seconds for HTTP/2 ping frames to detect stale connections.
@@ -568,6 +575,10 @@ impl Buck2OssReConfiguration {
             max_concurrent_uploads_per_action: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_concurrent_uploads_per_action",
+            })?,
+            find_missing_blobs_batch_size: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "find_missing_blobs_batch_size",
             })?,
             cas_ttl_secs: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -246,6 +246,8 @@ pub struct RERuntimeOpts {
     max_concurrent_uploads_per_action: Option<usize>,
     /// Time that digests are assumed to live in CAS after being touched.
     cas_ttl_secs: i64,
+    /// Maximum number of digests per `FindMissingBlobs` RPC.
+    find_missing_blobs_batch_size: usize,
 }
 
 struct InstanceName(Option<String>);
@@ -440,6 +442,9 @@ impl REClientBuilder {
                 // NOTE: This is an arbitrary number because RBE does not return information
                 // on the TTL of the remote blob.
                 cas_ttl_secs: opts.cas_ttl_secs.unwrap_or(3 * 60 * 60),
+                find_missing_blobs_batch_size: opts
+                    .find_missing_blobs_batch_size
+                    .unwrap_or(100),
             },
             grpc_clients,
             capabilities,
@@ -975,6 +980,7 @@ impl REClient {
         let mut remote_results: HashMap<TDigest, DigestRemoteState> = HashMap::new();
         let mut digests_to_check: Vec<TDigest> = Vec::new();
 
+        let batch_size = self.runtime_opts.find_missing_blobs_batch_size;
         let mut digest_iter = request.digests.iter();
         while digest_iter.len() > 0 {
             // Sort our blobs based on what action we need to take
@@ -988,7 +994,7 @@ impl REClient {
                         // We can check this blob
                         digests_to_check.push(digest.clone());
                     }
-                    if digests_to_check.len() >= 100 {
+                    if digests_to_check.len() >= batch_size {
                         break;
                     }
                 }


### PR DESCRIPTION
The OSS RE client batches `FindMissingBlobs` requests at a hard-coded limit of 100 digests per RPC. With many digests this serializes into a long chain of small round-trips: 10k digests at ~300ms RTT becomes a 30-second wall-clock pause on the FMB stage.

Expose the limit as `[buck2_re_client] find_missing_blobs_batch_size` (default 100, preserving existing behavior). Operators with deduped get_digests_ttl calls and a server that tolerates larger requests can raise this to collapse the FMB stage into a single round-trip.

Larger values are only safe when paired with
`[buck2] deduplicate_get_digests_ttl_calls = true`. Without dedup, N concurrent actions each issue an N-digest request simultaneously, producing a thundering herd against the RE backend; the existing 100 default was implicitly throttling that fanout via sequential batching.