### PR TITLE
fix(rust): resolve build-script `OUT_DIR` paths to content-based path

### DIFF
--- a/prelude/rust/tools/buildscript_run.py
+++ b/prelude/rust/tools/buildscript_run.py
@@ -16,11 +16,14 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, IO, NamedTuple, Optional
-
+from typing import IO, Any, NamedTuple, Optional
 
 IS_WINDOWS: bool = os.name == "nt"
 TOOL_CWD: str = os.path.join(os.getcwd(), "")
+
+# Sentinel used to mark OUT_DIR-relative paths emitted by buildscripts.
+# We later replace this sentinel with the actual content-addressed path, once that is known.
+OUT_DIR_SENTINEL: str = "${__BUILDSCRIPT_OUT_DIR__}"
 
 
 def eprint(*args: Any, **kwargs: Any) -> None:
@@ -249,6 +252,16 @@ def main() -> None:  # noqa: C901
     cargo_rustc_link_search_pattern = re.compile(
         "^cargo::?rustc-link-search=([a-z]+=)?(.+)"
     )
+    out_dir_abs = env["OUT_DIR"]
+
+    # Rewrite a path inside OUT_DIR to OUT_DIR_SENTINEL; None if it is elsewhere.
+    def reanchor_out_dir(path: str) -> Optional[str]:
+        if path == out_dir_abs:
+            return OUT_DIR_SENTINEL
+        if path.startswith(out_dir_abs + os.sep):
+            return OUT_DIR_SENTINEL + path[len(out_dir_abs) :]
+        return None
+
     flags = ""
     for line in script_output.split("\n"):
         cargo_rustc_cfg_match = cargo_rustc_cfg_pattern.match(line)
@@ -260,7 +273,10 @@ def main() -> None:  # noqa: C901
         if cargo_rustc_env_match:
             key = cargo_rustc_env_match.group(1)
             value = cargo_rustc_env_match.group(2)
-            if value.startswith(TOOL_CWD):
+            reanchored = reanchor_out_dir(value)
+            if reanchored is not None:
+                flags += f"--env-set={key}={reanchored}\n"
+            elif value.startswith(TOOL_CWD):
                 relative_path = value[len(TOOL_CWD) :]
                 flags += f"--env-set={key}=$(abspath {relative_path})\n"
             else:
@@ -275,7 +291,10 @@ def main() -> None:  # noqa: C901
         if args.rustc_link_search and cargo_rustc_link_search_match:
             kind = cargo_rustc_link_search_match.group(1) or ""
             path = cargo_rustc_link_search_match.group(2)
-            if path.startswith(TOOL_CWD):
+            reanchored = reanchor_out_dir(path)
+            if reanchored is not None:
+                flags += f"-L{kind}{reanchored}\n"
+            elif path.startswith(TOOL_CWD):
                 relative_path = path[len(TOOL_CWD) :]
                 flags += f"-L{kind}$(abspath {relative_path})\n"
             else:

--- a/prelude/rust/tools/rustc_action.py
+++ b/prelude/rust/tools/rustc_action.py
@@ -27,7 +27,11 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, IO, NamedTuple, Optional
+from typing import IO, Any, NamedTuple, Optional
+
+# Sentinel used to mark OUT_DIR-relative paths emitted by buildscripts.
+# We later replace this sentinel with the actual content-addressed path, once that is known.
+OUT_DIR_SENTINEL: str = "${__BUILDSCRIPT_OUT_DIR__}"
 
 DEBUG = False
 
@@ -340,8 +344,13 @@ async def main() -> int:  # noqa: C901
     separator = args.rustc.index("--rustc-action-separator")
     rustc_cmd, rustc_args_orig = args.rustc[:separator], args.rustc[separator + 1 :]
 
+    out_dir = env.get("OUT_DIR")
+
     rustc_args = []
     for arg in rustc_args_orig:
+        # Resolve OUT_DIR_SENTINEL to the consumer's canonical OUT_DIR.
+        if out_dir is not None and OUT_DIR_SENTINEL in arg:
+            arg = arg.replace(OUT_DIR_SENTINEL, out_dir)
         # Build.bzl uses the following expression to generate remap flags:
         #   cmd_args("--remap-path-prefix=", ... "=", ctx.label.path, path_sep, delimiter = "")
         # The ctx.label.path (which is of type StarlarkCellPath) has the
@@ -362,7 +371,7 @@ async def main() -> int:  # noqa: C901
         # build scripts relies on `--env-set` as the implementation of "cargo:rustc-env".
         # Tracking issue: https://github.com/rust-lang/rust/issues/118372
         if arg.startswith("--env-set="):
-            flag, key, value = arg.split("=", 3)
+            flag, key, value = arg.split("=", 2)
             env[key] = value
             continue
 


### PR DESCRIPTION
Rust build scripts that emit a path inside OUT_DIR via `cargo:rustc-env` or `cargo:rustc-link-search` (eg cranelift) intermittently failed to compile because the content-addressed OUT_DIR will be materialized at `<content-hash>/OUT_DIR` while the `cargo:rustc-env`  value will continue to use the placeholder `output_artifacts/OUT_DIR` path.

This change adds logic to `buildscript_run.py` and `rustc_action.py` to rewrite paths that live inside the `OUT_DIR` to be prefixed with a sentinel `${__BUILDSCRIPT_OUT_DIR__}` that we then resolve later when the content hash is known.