### PR TITLE
rust-project --target flag

### DIFF
--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -75,6 +75,7 @@ pub(crate) fn to_project_json(
     global_extra_cfgs: &[String],
     first_party_extra_cfgs: &[String],
     buck: &Buck,
+    rustc_target: Option<&String>,
 ) -> Result<ProjectJson, anyhow::Error> {
     let project_root = buck.resolve_project_root()?;
 
@@ -235,7 +236,7 @@ pub(crate) fn to_project_json(
             is_proc_macro: info.proc_macro.unwrap_or(false),
             proc_macro_dylib_path,
             proc_macro_cwd: Some(project_root.clone()),
-            target: None,
+            target: rustc_target.cloned(),
         };
         crates.push(crate_info);
     }

--- a/integrations/rust-project/src/cli/develop.rs
+++ b/integrations/rust-project/src/cli/develop.rs
@@ -39,6 +39,7 @@ pub(crate) struct Develop {
     pub(crate) check_cycles: bool,
     pub(crate) invoked_by_ra: bool,
     pub(crate) include_all_buildfiles: bool,
+    pub(crate) rustc_target: Option<String>,
 }
 
 pub(crate) struct OutputCfg {
@@ -71,6 +72,7 @@ impl Develop {
             buck2_command,
             include_all_buildfiles,
             max_extra_targets,
+            rustc_target,
             ..
         } = command
         {
@@ -97,6 +99,7 @@ impl Develop {
                 check_cycles,
                 invoked_by_ra: false,
                 include_all_buildfiles,
+                rustc_target,
             };
             let max_extra_targets = max_extra_targets.unwrap_or(DEFAULT_EXTRA_TARGETS);
             let out = OutputCfg {
@@ -121,6 +124,7 @@ impl Develop {
             buck2_command,
             max_extra_targets,
             mode,
+            rustc_target,
             ..
         } = command
         {
@@ -148,6 +152,7 @@ impl Develop {
                 check_cycles: false,
                 invoked_by_ra: true,
                 include_all_buildfiles: false,
+                rustc_target,
             };
             let max_extra_targets = max_extra_targets.unwrap_or(DEFAULT_EXTRA_TARGETS);
             let out = OutputCfg {
@@ -280,6 +285,7 @@ impl Develop {
             buck,
             check_cycles,
             include_all_buildfiles,
+            rustc_target,
             ..
         } = self;
 
@@ -322,6 +328,7 @@ impl Develop {
             *include_all_buildfiles,
             global_extra_cfgs,
             first_party_extra_cfgs,
+            rustc_target.as_ref(),
         )
     }
 
@@ -360,6 +367,7 @@ pub(crate) fn develop_with_sysroot(
     include_all_buildfiles: bool,
     global_extra_cfgs: &[String],
     first_party_extra_cfgs: &[String],
+    rustc_target: Option<&String>,
 ) -> Result<ProjectJson, anyhow::Error> {
     info!(kind = "progress", "building generated code");
     let expanded_and_resolved = buck.expand_and_resolve(&targets, exclude_workspaces)?;
@@ -378,6 +386,7 @@ pub(crate) fn develop_with_sysroot(
         global_extra_cfgs,
         first_party_extra_cfgs,
         buck,
+        rustc_target,
     )?;
 
     Ok(rust_project)

--- a/integrations/rust-project/src/main.rs
+++ b/integrations/rust-project/src/main.rs
@@ -121,6 +121,9 @@ enum Command {
         /// Include a `build` section for every crate, including dependencies. Otherwise, `build` is only included for crates in the workspace.
         #[clap(long)]
         include_all_buildfiles: bool,
+
+        #[clap(long)]
+        rustc_target: Option<String>,
     },
     /// `DevelopJson` is a more limited, stripped down [`Command::Develop`].
     ///
@@ -150,6 +153,9 @@ enum Command {
 
         #[clap(long, default_value = "50", env = "RUST_PROJECT_EXTRA_TARGETS")]
         max_extra_targets: Option<usize>,
+
+        #[clap(long)]
+        rustc_target: Option<String>,
 
         args: JsonArguments,
     },

--- a/integrations/rust-project/src/sysroot.rs
+++ b/integrations/rust-project/src/sysroot.rs
@@ -93,6 +93,7 @@ pub(crate) fn resolve_buckconfig_sysroot(
         false,
         &[], // sysroot doesn't get any extra cfgs
         &[],
+        None,
     )?;
     for krate in &mut sysroot_project.crates {
         if let Some(display_name) = &mut krate.display_name {


### PR DESCRIPTION
Add a `--rustc-target` flag to `rust-project develop` and `rust-project develop-json` that will populate the `rust-project.json`s `target` fields with the given string. This is a requirement to get `cfg(arch =)` code to correctly resolve.