### PR TITLE
Remove outdated note about cross-platform builds

### DIFF
--- a/docs/about/why.md
+++ b/docs/about/why.md
@@ -143,7 +143,5 @@ There are also some things that aren't quite yet finished:
 
 - There are not yet mechanisms to build in release mode (that should be achieved
   by modifying the toolchain).
-- Windows/Mac builds are still in progress; open-source code is mostly tested on
-  Linux.
 
 If none of that puts you off, [give Buck2 a go](../getting_started/index.md)!


### PR DESCRIPTION
As documented [here](https://buck2.build/docs/getting_started/install/), every release contains artifacts for Windows and macOS.

I'd strongly recommend going through the docs to remove such outdated information because it's tainting AI model responses even with RAG/live search e.g. https://chatgpt.com/share/6a1e4148-95cc-83ea-b8ff-ba182f2fbb89