### PR TITLE
Skip -ffile-prefix-map for assembler targets

### DIFF
--- a/prelude/cxx/compile.bzl
+++ b/prelude/cxx/compile.bzl
@@ -1963,8 +1963,9 @@ def _mk_argsfiles(
             # The precompile_args field overrides these.
             return
 
-        if _get_category(ext) == "asm_compile":
-            # Assemblers (NASM, MASM, gas) don't understand -ffile-prefix-map.
+        if compiler_info.compiler_type in ("nasm", "windows_ml64"):
+            # NASM/MASM don't understand -ffile-prefix-map. .s/.sx/.S go through the gcc/clang
+            # driver (as_compiler_info) and do accept these flags.
             return
 
         # Put file_prefix_args in argsfile, make sure they do not appear when evaluating $(cxxppflags)

--- a/prelude/cxx/compile.bzl
+++ b/prelude/cxx/compile.bzl
@@ -1963,6 +1963,10 @@ def _mk_argsfiles(
             # The precompile_args field overrides these.
             return
 
+        if _get_category(ext) == "asm_compile":
+            # Assemblers (NASM, MASM, gas) don't understand -ffile-prefix-map.
+            return
+
         # Put file_prefix_args in argsfile, make sure they do not appear when evaluating $(cxxppflags)
         # to avoid "argument too long" errors
         file_prefix_args = headers_tag.tag_artifacts(preprocessor.set.project_as_args("file_prefix_args"))


### PR DESCRIPTION
Skip `-ffile-prefix-map` flags for assembler targets (NASM, MASM, gas) which don't understand this compiler option