### PR TITLE
Remove unused feature from `buck2_interpreter`

### DIFF
--- a/app/buck2_interpreter/src/lib.rs
+++ b/app/buck2_interpreter/src/lib.rs
@@ -10,8 +10,6 @@
 
 //! Implements Buck's handling of target patterns and parsing of build files.
 
-#![feature(never_type)]
-
 pub mod allow_relative_paths;
 pub mod build_context;
 pub mod coerce;


### PR DESCRIPTION
Looks like this was missed in D108476986 / a8c552041dd9dafbfaf6f2585c58e5abca9715bb.