### PR TITLE
Add `-dynamic` when linking shared haskell_binary

### DIFF
--- a/examples/with_prelude/test_utils.bzl
+++ b/examples/with_prelude/test_utils.bzl
@@ -17,10 +17,8 @@ def assert_output(name, command, output):
 def haskell_library(deps = [], **kwargs):
     native.haskell_library(deps = deps + ["//third-party/haskell:base"], **kwargs)
 
-def haskell_binary(linker_flags = [], deps = [], **kwargs):
+def haskell_binary(deps = [], **kwargs):
     native.haskell_binary(
-        # Workaround for as yet not triaged runtime segfault.
-        linker_flags = linker_flags + ["-dynamic"] if host_info().os.is_macos else linker_flags,
         deps = deps + ["//third-party/haskell:base"],
         **kwargs,
     )

--- a/prelude/haskell/haskell.bzl
+++ b/prelude/haskell/haskell.bzl
@@ -1133,7 +1133,7 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
         sos_dir = "__{}__shared_libs_symlink_tree".format(ctx.attrs.name)
         rpath_ref = get_rpath_origin(get_cxx_toolchain_info(ctx).linker_info.type)
         rpath_ldflag = "-Wl,{}/{}".format(rpath_ref, sos_dir)
-        link.add("-optl", "-Wl,-rpath", "-optl", rpath_ldflag)
+        link.add("-dynamic", "-optl", "-Wl,-rpath", "-optl", rpath_ldflag)
         symlink_dir = create_shlib_symlink_tree(
             actions = ctx.actions,
             out = sos_dir,


### PR DESCRIPTION
This matches the behavior of Cabal when linking binaries. Without this flag, will GHC statically link every implicit dependency provided by the global package database. I've noticed a few strange behaviors caused by this, all involving `haskell_prebuilt_library`:

- `examples/with_prelude/haskell` segfaults on macOS. The binary contains both statically and dynamically linked copies of `rts`, but only the static copy is initialized. The dynamic copy comes via `//haskell:library` (`haskell_library` passes `-dynamic`). Linux symbol namespacing would merge the two, but macOS doesn't.

- if the global package database is limited to only `rts` (GHC is hard-coded to require this), linking fails on Linux using lld. Linking the static `rts` against a dynamic `base` would require creating copy relocations for read-only symbols in `base`.

- if the global package database is limited as above, any resulting binary would throw a runtime linker error on macOS. On macOS, GHC sets `-dead_strip_dylibs` to remove unused dylibs. During static linking, symbols required by `base` are removed and the `rts` dylib is stripped as dead code.

I can't find a reason for why the flag was originally excluded. Based on the issues it causes, including it seems like the correct behavior.