### PR TITLE
buck2_server: Implement Git revision data

### DIFF
--- a/app/buck2_client_ctx/src/subscribers/recorder.rs
+++ b/app/buck2_client_ctx/src/subscribers/recorder.rs
@@ -238,6 +238,7 @@ pub struct InvocationRecorder {
     active_networks_kinds: StdBuckHashSet<i32>,
     target_cfg: Option<TargetCfg>,
     hg_revision: Option<String>,
+    git_revision: Option<String>,
     has_local_changes: Option<bool>,
     version_control_errors: Vec<String>,
     concurrent_commands: bool,
@@ -459,6 +460,7 @@ impl InvocationRecorder {
             active_networks_kinds: StdBuckHashSet::default(),
             target_cfg: None,
             hg_revision: None,
+            git_revision: None,
             has_local_changes: None,
             version_control_errors: Vec::new(),
             concurrent_commands: false,
@@ -1166,6 +1168,7 @@ impl InvocationRecorder {
                 .collect(),
             target_cfg: self.target_cfg.take(),
             hg_revision: self.hg_revision.take(),
+            git_revision: self.git_revision.take(),
             has_local_changes: self.has_local_changes.take(),
             version_control_errors: self.version_control_errors.drain(..).collect(),
             version_control_revision: None,
@@ -2213,6 +2216,7 @@ impl InvocationRecorder {
         revision: &buck2_data::VersionControlRevision,
     ) -> buck2_error::Result<()> {
         self.hg_revision = revision.hg_revision.clone().or(self.hg_revision.clone());
+        self.git_revision = revision.git_revision.clone().or(self.git_revision.clone());
         self.has_local_changes = revision.has_local_changes.or(self.has_local_changes);
         self.version_control_errors
             .extend(revision.command_error.clone());

--- a/app/buck2_cmd_log_client/src/summary.rs
+++ b/app/buck2_cmd_log_client/src/summary.rs
@@ -54,6 +54,7 @@ struct Stats {
     re_max_download_speeds: Vec<SlidingWindow>,
     re_max_upload_speeds: Vec<SlidingWindow>,
     hg_revision: Option<String>,
+    git_revision: Option<String>,
     has_local_changes: Option<bool>,
 }
 
@@ -120,6 +121,9 @@ impl Stats {
                         if let Some(ref revision) = vcs.hg_revision {
                             self.hg_revision = Some(revision.clone());
                         }
+                        if let Some(ref revision) = vcs.git_revision {
+                            self.git_revision = Some(revision.clone());
+                        }
                         if let Some(ref has_local_changes) = vcs.has_local_changes {
                             self.has_local_changes = Some(*has_local_changes);
                         }
@@ -152,6 +156,10 @@ impl Display for Stats {
 
         if let Some(hg_revision) = &self.hg_revision {
             writeln!(f, "- HG Revision: {hg_revision}")?;
+        }
+
+        if let Some(git_revision) = &self.git_revision {
+            writeln!(f, "- Git Revision: {git_revision}")?;
         }
 
         if let Some(has_local_changes) = self.has_local_changes {

--- a/app/buck2_data/data.proto
+++ b/app/buck2_data/data.proto
@@ -889,6 +889,8 @@ message VersionControlRevision {
   // Unset: Unknown state.
   optional bool has_local_changes = 2;
   optional string command_error = 3;
+  // 40 characters hash for git revision.
+  optional string git_revision = 4;
 }
 
 // Event sent during build commands
@@ -2784,6 +2786,8 @@ message InvocationRecord {
   optional bool has_local_changes = 107;
   // Errors encountered during version control operations.
   repeated string version_control_errors = 108;
+  // 40 characters hash for git revision.
+  optional string git_revision = 109;
 
   // Detailed per-backend RE stats.
   optional uint64 zdb_download_queries = 200;

--- a/app/buck2_server/src/version_control_revision.rs
+++ b/app/buck2_server/src/version_control_revision.rs
@@ -86,19 +86,13 @@ async fn create_revision_data(
 ) -> buck2_data::VersionControlRevision {
     let mut revision = buck2_data::VersionControlRevision::default();
     match repo_type(repo_root).await {
-        Ok(repo_vcs) => {
-            match repo_vcs {
-                RepoVcs::Hg => create_hg_data(&mut revision, revision_type, repo_root).await,
-                RepoVcs::Git => {
-                    // TODO(rajneeshl): Implement the git data
-                    // Add a message for now so we can actually tell if revision is null due to git
-                    revision.command_error = Some("Git revision data not implemented".to_owned());
-                }
-                RepoVcs::Unknown => {
-                    revision.command_error = Some("Unknown repository type".to_owned());
-                }
+        Ok(repo_vcs) => match repo_vcs {
+            RepoVcs::Hg => create_hg_data(&mut revision, revision_type, repo_root).await,
+            RepoVcs::Git => create_git_data(&mut revision, revision_type, repo_root).await,
+            RepoVcs::Unknown => {
+                revision.command_error = Some("Unknown repository type".to_owned());
             }
-        }
+        },
         Err(e) => {
             revision.command_error = Some(format!("Failed to get repository type: {e:#}"));
         }
@@ -184,6 +178,100 @@ async fn get_hg_status(revision: &mut buck2_data::VersionControlRevision) {
     };
 }
 
+async fn create_git_data(
+    revision: &mut buck2_data::VersionControlRevision,
+    revision_type: RevisionDataType,
+    repo_root: &AbsNormPathBuf,
+) {
+    match revision_type {
+        RevisionDataType::CurrentRevision => get_git_revision(revision, repo_root).await,
+        RevisionDataType::Status => get_git_status(revision, repo_root).await,
+    }
+}
+
+async fn get_git_revision(
+    revision: &mut buck2_data::VersionControlRevision,
+    repo_root: &AbsNormPathBuf,
+) {
+    // `git rev-parse HEAD` resolves the current commit hash. This handles
+    // packed refs, detached HEADs, etc. without us having to parse `.git`.
+    match run_git(repo_root, &["rev-parse", "HEAD"]).await {
+        Ok(stdout) => revision.git_revision = Some(stdout.trim().to_owned()),
+        Err(e) => revision.command_error = Some(e),
+    }
+}
+
+async fn get_git_status(
+    revision: &mut buck2_data::VersionControlRevision,
+    repo_root: &AbsNormPathBuf,
+) {
+    // `git status --porcelain` prints one line per change; empty output means
+    // there are no local changes. Note that this counts untracked files as local
+    // changes (they show up as `??` lines), matching the behavior of `hg status`.
+    match run_git(repo_root, &["status", "--porcelain"]).await {
+        Ok(stdout) => revision.has_local_changes = Some(!stdout.trim().is_empty()),
+        Err(e) => revision.command_error = Some(e),
+    }
+}
+
+/// Run a `git` command rooted at `repo_root`, returning its stdout on success or
+/// an error message describing the failure.
+async fn run_git(repo_root: &AbsNormPathBuf, args: &[&str]) -> Result<String, String> {
+    let Some(repo_root) = repo_root.as_path().to_str() else {
+        return Err(format!(
+            "Repository root is not valid utf8: {}",
+            repo_root.as_path().display()
+        ));
+    };
+
+    // `-C <repo_root>` makes git operate on the repository regardless of the
+    // daemon's current working directory.
+    let mut full_args = vec!["-C", repo_root];
+    full_args.extend_from_slice(args);
+
+    // `GIT_OPTIONAL_LOCKS=0` prevents git from taking the index lock or
+    // refreshing the index on disk, so we don't contend with a concurrent user
+    // `git` invocation (e.g. for `git status`).
+    let output = match reap_on_drop_command("git", &full_args, Some(&[("GIT_OPTIONAL_LOCKS", "0")]))
+    {
+        Ok(command) => command.output().await,
+        Err(e) => {
+            return Err(format!(
+                "reap_on_drop_command for `git {}` failed: {e}",
+                args.join(" ")
+            ));
+        }
+    };
+
+    let result = match output {
+        Ok(result) => result,
+        Err(e) => {
+            return Err(format!(
+                "Command `git {}` failed with error: {e:?}",
+                args.join(" ")
+            ));
+        }
+    };
+
+    if !result.status.success() {
+        let stderr = match std::str::from_utf8(&result.stderr) {
+            Ok(s) => s,
+            Err(e) => return Err(format!("git {} stderr is not utf8: {e}", args.join(" "))),
+        };
+        return Err(format!(
+            "Command `git {}` failed with error code {}; stderr: {}",
+            args.join(" "),
+            result.status,
+            stderr
+        ));
+    }
+
+    match std::str::from_utf8(&result.stdout) {
+        Ok(s) => Ok(s.to_owned()),
+        Err(e) => Err(format!("git {} stdout is not utf8: {e}", args.join(" "))),
+    }
+}
+
 async fn repo_type(repo_root: &AbsNormPathBuf) -> buck2_error::Result<&'static RepoVcs> {
     static REPO_TYPE: OnceCell<buck2_error::Result<RepoVcs>> = OnceCell::const_new();
     async fn repo_type_impl(repo_root: &AbsNormPathBuf) -> buck2_error::Result<RepoVcs> {
@@ -193,7 +281,10 @@ async fn repo_type(repo_root: &AbsNormPathBuf) -> buck2_error::Result<&'static R
         );
 
         let is_hg = hg_metadata.is_ok_and(|output| output.is_dir());
-        let is_git = git_metadata.is_ok_and(|output| output.is_dir());
+        // `.git` can be a symlink or a file with contents like:
+        //
+        //     gitdir: /home/dog/buck2/.git/worktrees/buck3
+        let is_git = git_metadata.is_ok();
 
         if is_hg {
             Ok(RepoVcs::Hg)


### PR DESCRIPTION
What it says on the tin, closes a long-standing TODO and helps with our telemetry.

TODO: Should we just reuse the `hg_revision` field for Git revisions? They _are_ also 40-character hashes...