### PR TITLE
docs: fix typos in BXL and modifiers how-to guides

### DIFF
--- a/docs/bxl/how_tos/how_to_cache_and_share_operations.md
+++ b/docs/bxl/how_tos/how_to_cache_and_share_operations.md
@@ -71,7 +71,7 @@ def _bxl_main_impl(bxl_ctx: bxl.Context):
     ...
 ```
 
-Now you have a anon target and the the output of this anon target will be cached
+Now you have an anon target and the output of this anon target will be cached
 using a cache key composed of its attributes, target platform, and any bxl
 script modifiers.
 

--- a/docs/users/how_tos/modifiers_setup.md
+++ b/docs/users/how_tos/modifiers_setup.md
@@ -38,7 +38,7 @@ It supports a few configuration points:
 - `extra_data` is used for logging/validation by Meta's internal modifier
   implementation.
 
-As you can see, `aliases` is the the only value that one would commonly want to
+As you can see, `aliases` is the only value that one would commonly want to
 configure, and it might make sense to call `set_cfg_constructor` with different
 `aliases` values in different `PACKAGE` files, if some aliases only make sense
 in specific projects (e.g. because they have custom configuration constraints).


### PR DESCRIPTION
Small documentation typo fixes in two how-to guides:

- `docs/bxl/how_tos/how_to_cache_and_share_operations.md`: `a anon` → `an anon`, and removed a duplicated `the` ("the the output").
- `docs/users/how_tos/modifiers_setup.md`: removed a duplicated `the` ("the the only value").

Docs-only, no behavioral change.