### PR TITLE
docs: fix duplicated-word typos in docs and code comments

### DIFF
--- a/app/buck2_build_api/src/build/build_report.rs
+++ b/app/buck2_build_api/src/build/build_report.rs
@@ -8,7 +8,7 @@
  * above-listed licenses.
  */
 
-//! Processing and reporting the the results of the build
+//! Processing and reporting the results of the build
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;

--- a/app/buck2_client/src/commands/bxl.rs
+++ b/app/buck2_client/src/commands/bxl.rs
@@ -84,7 +84,7 @@ pub struct BxlCommandOptions {
     /// If this flag is specified, user events are additionally written to user event log.
     /// Log format is JSONL, uncompressed if no known extensions are detected, or you can explicitly specify
     /// the compression via the file extension (ex: `.json-lines.gz` would be gzip compressed, `.json-lines.zst`
-    /// would be zstd compressed). Resulting log is is compatible with `buck2 log show-user`.
+    /// would be zstd compressed). Resulting log is compatible with `buck2 log show-user`.
     #[clap(value_name = "PATH", long = "user-event-log")]
     pub user_event_log: Option<PathArg>,
 

--- a/app/buck2_client/src/commands/query/uquery.rs
+++ b/app/buck2_client/src/commands/query/uquery.rs
@@ -95,7 +95,7 @@ pub struct UqueryCommand {
 
 #[async_trait(?Send)]
 impl StreamingCommand for UqueryCommand {
-    // FIXME: Figure out if we can replace this. We used to log this this way in Ingress :/
+    // FIXME: Figure out if we can replace this. We used to log this way in Ingress :/
     const COMMAND_NAME: &'static str = "query";
 
     async fn exec_impl(

--- a/app/buck2_core/src/configuration/constraints.rs
+++ b/app/buck2_core/src/configuration/constraints.rs
@@ -34,7 +34,7 @@ use crate::target::label::label::TargetLabel;
 #[display("{}", key)]
 pub struct ConstraintKey {
     pub key: TargetLabel,
-    // TODO(nero): remove Option when when we migrated to unified constraint rule
+    // TODO(nero): remove Option when we migrated to unified constraint rule
     pub default: Option<ConstraintValue>,
 }
 

--- a/app/buck2_core/src/fs/project.rs
+++ b/app/buck2_core/src/fs/project.rs
@@ -250,7 +250,7 @@ impl ProjectRoot {
         // because we should only resolve symlinks found in the past that point into the project,
         // but
         // * not symlink found inside the project that point outside of it
-        // * not even symlinks found in the project unless we need to to resolve ".."
+        // * not even symlinks found in the project unless we need to resolve ".."
 
         // There's no empty `AbsPathBuf`, so we need to write this somewhat weird
         let mut current_prefix: Option<AbsPathBuf> = None;

--- a/app/buck2_data/data.proto
+++ b/app/buck2_data/data.proto
@@ -2739,7 +2739,7 @@ message InvocationRecord {
   // The client has failed to connect to the daemon.
   optional bool daemon_connection_failure = 75;
   // Daemon was started by this command.
-  // Unset if the the command connected to existing daemon or did not start one.
+  // Unset if the command connected to existing daemon or did not start one.
   optional DaemonWasStartedReason daemon_was_started = 751;
   // Set if an event occurred that should trigger a command restart.
   optional bool should_restart = 752;

--- a/app/buck2_event_observer/src/what_ran.rs
+++ b/app/buck2_event_observer/src/what_ran.rs
@@ -38,7 +38,7 @@ pub struct WhatRanOptions {
     #[clap(long)]
     pub skip_local_executions: bool,
     #[clap(long)]
-    /// Regular expression to filter commands by given action category (i.e. type of of actions that are
+    /// Regular expression to filter commands by given action category (i.e. type of actions that are
     /// similar but operate on different inputs, such as invocations of a C++
     /// compiler (whose category would be `cxx_compile`)). Matches by full string.
     pub filter_category: Option<String>,

--- a/app/buck2_execute/src/execute/output.rs
+++ b/app/buck2_execute/src/execute/output.rs
@@ -248,7 +248,7 @@ impl CommandStdStreams {
                 Ok(StdStreamPair { stdout, stderr })
             }
             Self::Remote(remote) => {
-                // TODO (torozco): This assumes that the existing remote outputs we have have the
+                // TODO (torozco): This assumes that the existing remote outputs we have the
                 // same re use case as what we passed in. Lots of things make this assumption, but
                 // for the sake of being safe, check it.
                 if remote.use_case() != client.use_case {

--- a/app/buck2_execute_local/src/lib.rs
+++ b/app/buck2_execute_local/src/lib.rs
@@ -406,7 +406,7 @@ impl KillProcess for DefaultKillProcess {
     }
 }
 
-/// Unify the the behavior of using a relative path for the executable between Unix and Windows. On
+/// Unify the behavior of using a relative path for the executable between Unix and Windows. On
 /// UNIX, the path is understood to be relative to the cwd of the *spawned process*, whereas on
 /// Windows, it's relative ot the cwd of the *spawning* process.
 ///

--- a/app/buck2_node/src/nodes/frontend.rs
+++ b/app/buck2_node/src/nodes/frontend.rs
@@ -64,8 +64,8 @@ pub trait TargetGraphCalculation {
         package: PackageLabel,
     ) -> BoxFuture<'_, buck2_error::Result<Arc<EvaluationResult>>>;
 
-    /// For a TargetLabel, returns the TargetNode. This is really just part of the the interpreter
-    /// results for the the label's package, and so this is just a utility for accessing that, it
+    /// For a TargetLabel, returns the TargetNode. This is really just part of the interpreter
+    /// results for the label's package, and so this is just a utility for accessing that, it
     /// isn't separately cached.
     fn get_target_node<'a>(
         &'a mut self,

--- a/app/buck2_server/src/daemon/disk_state.rs
+++ b/app/buck2_server/src/daemon/disk_state.rs
@@ -130,7 +130,7 @@ pub(crate) async fn maybe_initialize_materializer_sqlite_db(
     )?;
 
     // Most things in the rest of `metadata` should go in the metadata sqlite table.
-    // TODO(scottcao): Narrow down what metadata we need and and insert them into the
+    // TODO(scottcao): Narrow down what metadata we need and insert them into the
     // metadata table before a feature rollout.
     let (db, load_result) = MaterializerStateSqliteDb::initialize(
         paths.materializer_state_path(),

--- a/app/buck2_server_commands/src/build/result_report.rs
+++ b/app/buck2_server_commands/src/build/result_report.rs
@@ -8,7 +8,7 @@
  * above-listed licenses.
  */
 
-//! Processing and reporting the the results of the build
+//! Processing and reporting the results of the build
 
 use std::cell::Cell;
 use std::collections::BTreeSet;

--- a/app/buck2_test/src/command.rs
+++ b/app/buck2_test/src/command.rs
@@ -1229,7 +1229,7 @@ impl<'a, 'e> TestDriver<'a, 'e> {
             // flatten it?
             let node = node.forward_target().unwrap_or(&node);
 
-            // Look up `tests` in the the target we're testing, and if we find any tests, add them to the test backlog.
+            // Look up `tests` in the target we're testing, and if we find any tests, add them to the test backlog.
             if !state.ignore_tests_attribute {
                 for test in node.tests() {
                     work.push(TestDriverTask::ConfigureTarget {

--- a/dice/dice/src/ctx.rs
+++ b/dice/dice/src/ctx.rs
@@ -37,7 +37,7 @@ use crate::versions::VersionNumber;
 pub(crate) struct DiceComputationsImpl<'a>(pub(crate) ModernComputeCtx<'a>);
 
 impl DiceComputationsImpl<'_> {
-    /// Gets all the result of of the given computation key.
+    /// Gets all the result of the given computation key.
     /// recorded as dependencies of the current computation for which this
     /// context is for.
     pub(crate) fn compute<'a, K>(

--- a/dice/dice/src/impls/ctx.rs
+++ b/dice/dice/src/impls/ctx.rs
@@ -157,7 +157,7 @@ impl DerefMut for BaseComputeCtx {
 }
 
 impl ModernComputeCtx<'_> {
-    /// Gets all the result of of the given computation key.
+    /// Gets all the result of the given computation key.
     /// recorded as dependencies of the current computation for which this
     /// context is for.
     pub(crate) fn compute<'a, K>(

--- a/docs/bxl/how_tos/basic_how_tos.md
+++ b/docs/bxl/how_tos/basic_how_tos.md
@@ -339,7 +339,7 @@ expecting the artifact to already have been materialized in further BXL
 computations, that would also result in errors.
 
 However, if you are not making any assumptions about the existence of these
-artifacts, you can use use
+artifacts, you can use
 [`get_path_without_materialization()`](../../../api/bxl#get_path_without_materialization),
 which accepts source, declared, or build artifacts. It does _not_ accept ensured
 artifacts (also see

--- a/docs/users/advanced/deferred_materialization.md
+++ b/docs/users/advanced/deferred_materialization.md
@@ -13,7 +13,7 @@ This can provide very substantial performance savings on builds that execute
 primarily on Remote Execution, since those builds become able to proceed without
 ever downloading any intermediary outputs.
 
-At Meta, despite very fast networks being used internally, this was was observed
+At Meta, despite very fast networks being used internally, this was observed
 to make real-world builds finish approximately 2.5 times faster.
 
 ## Pitfalls

--- a/integrations/rust-project/src/buck.rs
+++ b/integrations/rust-project/src/buck.rs
@@ -525,7 +525,7 @@ impl Buck {
 
     /// Invoke `buck` with the given subcommands.
     ///
-    /// This method should only be used with with buck commands that do not accept
+    /// This method should only be used with buck commands that do not accept
     /// configuration options, such as `root`. [`Buck::command`] should be preferred.
     fn command_without_config<I, S>(&self, subcommands: I) -> Command
     where

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -156,7 +156,7 @@ fn ttimestamp_from(ts: Option<::prost_types::Timestamp>) -> TTimestamp {
     }
 }
 
-/// Contains information queried from the the Remote Execution Capabilities service.
+/// Contains information queried from the Remote Execution Capabilities service.
 pub struct RECapabilities {
     /// Largest size of a message before being uploaded using bytestream service.
     /// 0 indicates no limit beyond constraint of underlying transport (which is unknown).

--- a/starlark-rust/starlark/src/collections.rs
+++ b/starlark-rust/starlark/src/collections.rs
@@ -17,7 +17,7 @@
 
 //! Defines [`SmallMap`] and [`SmallSet`] - collections with deterministic iteration and small memory footprint.
 //!
-//! These structures use vector backed storage if there are only a few elements, and and index
+//! These structures use vector backed storage if there are only a few elements, and index
 //! for larger collections. The API mirrors standard Rust collections.
 
 pub use starlark_map::Equivalent;

--- a/starlark-rust/starlark/src/values/layout/vtable.rs
+++ b/starlark-rust/starlark/src/values/layout/vtable.rs
@@ -71,7 +71,7 @@ use crate::values::traits::StarlarkValueVTableGet;
 #[derive(Copy, Clone, Dupe)]
 pub(crate) struct StarlarkValueRawPtr {
     /// Points to the end of `AValueHeader`.
-    /// May not be equal to to the start of `StarlarkValue` due to alignment.
+    /// May not be equal to the start of `StarlarkValue` due to alignment.
     pub(crate) ptr: *const (),
 }
 

--- a/starlark-rust/starlark/src/values/types/any_array.rs
+++ b/starlark-rust/starlark/src/values/types/any_array.rs
@@ -53,7 +53,7 @@ impl<T: Debug + 'static> AnyArray<T> {
     }
 
     /// This function is unsafe because it does not initialize content array,
-    /// but drops in in destructor.
+    /// but drops in destructor.
     pub(crate) unsafe fn new(len: usize) -> AnyArray<T> {
         AnyArray { len, content: [] }
     }

--- a/starlark-rust/starlark_lsp/src/definition.rs
+++ b/starlark-rust/starlark_lsp/src/definition.rs
@@ -253,7 +253,7 @@ impl LspModule {
         };
         let current_pos = std::cmp::min(line_span.begin() + col, line_span.end());
 
-        // Finalize the results after recursing down from and back up to the the top level scope.
+        // Finalize the results after recursing down from and back up to the top level scope.
         match Self::find_definition_in_scope(&scope, current_pos) {
             TempDefinition::Identifier(def) => self
                 .get_definition_location(def, &scope, current_pos)

--- a/starlark-rust/starlark_lsp/src/server.rs
+++ b/starlark-rust/starlark_lsp/src/server.rs
@@ -329,7 +329,7 @@ pub trait LspContext {
     ///
     /// `path` is the string representation in the `load()` statement. Its meaning is
     ///        implementation defined.
-    /// `current_file` is the the file that is including the `load()` statement, and should be used
+    /// `current_file` is the file that is including the `load()` statement, and should be used
     ///                if `path` is "relative" in a semantic sense.
     fn resolve_load(
         &self,


### PR DESCRIPTION
## Summary

Fixes accidental duplicated words ("the the", "use use", "when when", "of of", etc.) across user-facing documentation and code/doc comments. These are comment- and docs-only edits with no behavior change, so they are safe and self-contained.

## Changes (before → after)

| File | Before | After |
|------|--------|-------|
| `docs/users/advanced/deferred_materialization.md` | this **was was** observed | this **was** observed |
| `docs/bxl/how_tos/basic_how_tos.md` | you can **use use** | you can **use** |
| `app/buck2_data/data.proto` | Unset if **the the** command | Unset if **the** command |
| `app/buck2_test/src/command.rs` | in **the the** target | in **the** target |
| `app/buck2_execute_local/src/lib.rs` | Unify **the the** behavior | Unify **the** behavior |
| `app/buck2_core/src/configuration/constraints.rs` | **when when** we migrated | **when** we migrated |
| `app/buck2_core/src/fs/project.rs` | we need **to to** resolve | we need **to** resolve |
| `app/buck2_server/src/daemon/disk_state.rs` | we need **and and** insert | we need **and** insert |
| `app/buck2_execute/src/execute/output.rs` | outputs we **have have** | outputs we **have** |
| `app/buck2_event_observer/src/what_ran.rs` | **type of of** actions | **type of** actions |
| `app/buck2_client/src/commands/bxl.rs` | log **is is** compatible | log **is** compatible |
| `app/buck2_client/src/commands/query/uquery.rs` | log **this this** way | log **this** way |
| `app/buck2_node/src/nodes/frontend.rs` | part of **the the** interpreter / for **the the** label's | part of **the** interpreter / for **the** label's |
| `app/buck2_server_commands/src/build/result_report.rs` | reporting **the the** results | reporting **the** results |
| `app/buck2_build_api/src/build/build_report.rs` | reporting **the the** results | reporting **the** results |
| `remote_execution/oss/re_grpc/src/client.rs` | from **the the** Remote Execution | from **the** Remote Execution |
| `starlark-rust/starlark_lsp/src/definition.rs` | up to **the the** top level | up to **the** top level |
| `starlark-rust/starlark_lsp/src/server.rs` | is **the the** file | is **the** file |
| `starlark-rust/starlark/src/collections.rs` | **and and** index | **and** index |
| `starlark-rust/starlark/src/values/types/any_array.rs` | drops **in in** destructor | drops **in** destructor |
| `starlark-rust/starlark/src/values/layout/vtable.rs` | equal **to to** the start | equal **to** the start |
| `dice/dice/src/ctx.rs` | result **of of** the given | result **of** the given |
| `dice/dice/src/impls/ctx.rs` | result **of of** the given | result **of** the given |
| `integrations/rust-project/src/buck.rs` | used **with with** buck | used **with** buck |

## Notes

- Vendored / `@generated` files (e.g. the Bazel Remote Execution proto, `testcases/parse/rust.star`) and grammatically-valid repeats (e.g. "that that's the case", "and/or") were intentionally left untouched.
