### PR TITLE
github: fall back to standard runners on forks

### DIFF
--- a/.github/workflows/build-and-examples.yml
+++ b/.github/workflows/build-and-examples.yml
@@ -76,8 +76,11 @@ jobs:
         NATIVELINK_HEADER_RW_KEY_SECRET: ${{ secrets.NATIVELINK_HEADER_RW_KEY_SECRET }}
     - uses: ./.github/actions/setup_reindeer
     - uses: ./.github/actions/build_bootstrap
+  # The Meta-specific windows-8-core runner label does not exist on forks;
+  # fall back to the standard GitHub-hosted runner there so the job doesn't
+  # sit queued forever waiting for a runner that isn't available.
   windows-build-examples:
-    runs-on: windows-8-core
+    runs-on: ${{ github.repository_owner == 'facebook' && 'windows-8-core' || 'windows-latest' }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup_windows_env

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,8 +8,12 @@ permissions:
   contents: read
 
 jobs:
+  # Runner labels are repository (owner) specific, so the Meta larger runners
+  # (4-core-ubuntu, windows-8-core) don't exist on forks and jobs requesting
+  # them would sit queued forever waiting for a runner that isn't available.
+  # Fall back to the standard GitHub-hosted runners there.
   linux-build-and-test:
-    runs-on: 4-core-ubuntu
+    runs-on: ${{ github.repository_owner == 'facebook' && '4-core-ubuntu' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup_linux_env
@@ -26,7 +30,7 @@ jobs:
     - uses: ./.github/actions/build_debug
     - uses: ./.github/actions/run_test_py
   windows-build-and-test:
-    runs-on: windows-8-core
+    runs-on: ${{ github.repository_owner == 'facebook' && 'windows-8-core' || 'windows-latest' }}
     steps:
     - uses: actions/checkout@v6
     - uses: ./.github/actions/setup_windows_env


### PR DESCRIPTION
The linux-build-and-test, windows-build-and-test and
windows-build-examples jobs run on Meta's larger runners (4-core-ubuntu
and windows-8-core, added in #545 and #812 to speed up CI). Runner
labels are repository (owner) specific, so on forks these jobs sit
queued forever waiting for a runner that does not exist.

Select the runner label based on the repository owner so that forks
fall back to the standard GitHub-hosted runners and CI still runs
there, just slower. The larger runners currently use the same images as
ubuntu-latest and windows-latest, so forks build with the same OS and
toolchains as upstream.
