### PR TITLE
github: don't run build-and-test twice for branches with pull requests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,8 @@
 name: Build and test
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch: # allows manual triggering
 


### PR DESCRIPTION
The workflow triggers on both push and pull_request without a branch filter, so pushing to a branch that has an open pull request runs every job twice: once for the push event and once for the pull_request event.

Restrict the push trigger to the main branch. Pull requests still run via the pull_request event and main still runs post-merge CI; branches without a pull request can be run manually via workflow_dispatch.