### PR TITLE
github: add a workflow to manually create a timestamped release

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -64,6 +64,38 @@
             "path": "rust-project-x86_64-unknown-linux-musl"
           }
         }
+      },
+      "starlark_fmt": {
+        "platforms": {
+          "macos-aarch64": {
+            "regex": "^starlark_fmt-aarch64-apple-darwin.zst$",
+            "path": "starlark_fmt-aarch64-apple-darwin"
+          },
+          "windows-aarch64": {
+            "regex": "^starlark_fmt-aarch64-pc-windows-msvc.exe.zst$",
+            "path": "starlark_fmt-aarch64-pc-windows-msvc.exe"
+          },
+          "linux-aarch64": {
+            "regex": "^starlark_fmt-aarch64-unknown-linux-musl.zst$",
+            "path": "starlark_fmt-aarch64-unknown-linux-musl"
+          },
+          "linux-riscv64": {
+            "regex": "^starlark_fmt-riscv64gc-unknown-linux-gnu.zst$",
+            "path": "starlark_fmt-riscv64gc-unknown-linux-gnu"
+          },
+          "macos-x86_64": {
+            "regex": "^starlark_fmt-x86_64-apple-darwin.zst$",
+            "path": "starlark_fmt-x86_64-apple-darwin"
+          },
+          "windows-x86_64": {
+            "regex": "^starlark_fmt-x86_64-pc-windows-msvc.exe.zst$",
+            "path": "starlark_fmt-x86_64-pc-windows-msvc.exe"
+          },
+          "linux-x86_64": {
+            "regex": "^starlark_fmt-x86_64-unknown-linux-musl.zst$",
+            "path": "starlark_fmt-x86_64-unknown-linux-musl"
+          }
+        }
       }
     }
 }

--- a/.github/workflows/build_buck2.yml
+++ b/.github/workflows/build_buck2.yml
@@ -1,0 +1,158 @@
+name: Build `buck2`
+
+on:
+  workflow_call:
+    inputs:
+      buck2_version:
+        description: "Version string stamped into the binaries via BUCK2_SET_EXPLICIT_VERSION"
+        required: true
+        type: string
+      release_timestamp:
+        description: "Timestamp stamped into the binaries via BUCK2_RELEASE_TIMESTAMP"
+        required: true
+        type: string
+
+jobs:
+  get_prelude_hash:
+    name: Get the latest prelude hash
+    runs-on: ubuntu-latest
+    outputs:
+      prelude_hash: ${{ steps.get_latest_prelude_hash.outputs.prelude_hash }}
+    steps:
+      - name: Shallow clone buck2-prelude
+        run: git clone --depth=1 https://github.com/facebook/buck2-prelude
+      - name: Get latest commit hash into prelude_hash
+        id: get_latest_prelude_hash
+        run: |
+          mkdir artifacts/
+          cd buck2-prelude/
+          git rev-parse HEAD > ../artifacts/prelude_hash
+          echo "prelude_hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Upload prelude_hash
+        uses: actions/upload-artifact@v6
+        with:
+          path: artifacts/prelude_hash
+          name: prelude_hash
+
+  build:
+    needs:
+      - get_prelude_hash
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - os: 'ubuntu-26.04'
+            triple: 'aarch64-unknown-linux-gnu'
+            cross: true
+          - os: 'ubuntu-26.04'
+            triple: 'aarch64-unknown-linux-musl'
+            cross: true
+          - os: 'ubuntu-26.04'
+            triple: 'x86_64-unknown-linux-gnu'
+          - os: 'ubuntu-26.04'
+            triple: 'x86_64-unknown-linux-musl'
+            cross: true
+          - os: 'ubuntu-26.04'
+            triple: 'riscv64gc-unknown-linux-gnu'
+            cross: true
+          - os: 'macos-15'
+            triple: 'aarch64-apple-darwin'
+            cross: true
+          - os: 'macos-15'
+            triple: 'x86_64-apple-darwin'
+          - os: 'windows-2025'
+            triple: 'x86_64-pc-windows-msvc'
+            is_windows: true
+          - os: 'windows-11-arm'
+            triple: 'aarch64-pc-windows-msvc'
+            is_windows: true
+    runs-on: ${{ matrix.target.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: SebRollen/toml-action@v1.0.2
+        id: read_rust_toolchain
+        with:
+          file: 'rust-toolchain.toml'
+          field: 'toolchain.channel'
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.read_rust_toolchain.outputs.value }}
+          targets: ${{ matrix.target.triple }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: buck2-upload
+          key: ${{ matrix.target.triple }}
+      - uses: actions-rs/install@v0.1
+        if: matrix.target.cross
+        with:
+          crate: cross
+          version: latest
+      - name: Set variables
+        id: set_variables
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.target.is_windows }}" ]; then
+            echo "buck2_out=target/${{ matrix.target.triple }}/release/buck2.exe" >> "$GITHUB_OUTPUT"
+            echo "buck2_zst=artifacts/buck2-${{ matrix.target.triple }}.exe.zst" >> "$GITHUB_OUTPUT"
+            echo "buck2_rust_project_out=target/${{ matrix.target.triple }}/release/rust-project.exe" >> "$GITHUB_OUTPUT"
+            echo "buck2_rust_project_zst=artifacts/rust-project-${{ matrix.target.triple }}.exe.zst" >> "$GITHUB_OUTPUT"
+          else
+            echo "buck2_out=target/${{ matrix.target.triple }}/release/buck2" >> "$GITHUB_OUTPUT"
+            echo "buck2_zst=artifacts/buck2-${{ matrix.target.triple }}.zst" >> "$GITHUB_OUTPUT"
+            echo "buck2_rust_project_out=target/${{ matrix.target.triple }}/release/rust-project" >> "$GITHUB_OUTPUT"
+            echo "buck2_rust_project_zst=artifacts/rust-project-${{ matrix.target.triple }}.zst" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Build
+        shell: bash
+        env:
+          # BUCK2 prefixed variables used within the build to stamp in a version information
+          # BUCK2_SET_EXPLICIT_VERSION will populate the buck2 --version string
+          BUCK2_RELEASE_TIMESTAMP: ${{ inputs.release_timestamp }}
+          BUCK2_SET_EXPLICIT_VERSION: ${{ inputs.buck2_version }}
+          RUSTFLAGS: "--cfg tokio_unstable -C strip=debuginfo -C codegen-units=1"
+        run: |
+          # aarch64-linux builds need JEMALLOC_SYS_WITH_LG_PAGE=16
+          # this is for e.g. linux running on apple silicon with native 16k pages
+          if [[ "${{ matrix.target.triple }}" == aarch64-unknown-linux* ]]; then
+            export JEMALLOC_SYS_WITH_LG_PAGE=16
+          fi
+
+          if [ -n "${{ matrix.target.cross }}" ]; then
+            CARGO=cross
+          else
+            CARGO=cargo
+          fi
+          $CARGO build --release --bin buck2 --bin rust-project --target ${{ matrix.target.triple }}
+      - name: Sanity check with examples/with_prelude
+        if: ${{ !matrix.target.cross }}
+        shell: bash
+        run: |
+          BUCK2="$(pwd)/${{ steps.set_variables.outputs.buck2_out }}"
+          cd examples/with_prelude
+          # TODO: rust examples don't work on windows + arm64
+          if [[ "${{ matrix.target.triple }}" == "aarch64-pc-windows-msvc" ]]; then
+            TARGETS="cpp/... python/..."
+          else
+            TARGETS="rust/... cpp/... python/..."
+          fi
+          "$BUCK2" build $TARGETS -v=2
+        # TODO: investigate segmentation fault on windows-11-arm
+        continue-on-error: ${{ matrix.target.triple == 'aarch64-pc-windows-msvc' }}
+      - name: Install zstd
+        shell: pwsh
+        if: ${{ matrix.target.os == 'windows-11-arm' }}
+        run: choco install zstandard
+      - name: Move binary to artifacts/
+        shell: bash
+        run: |
+          mkdir artifacts
+          zstd -z ${{ steps.set_variables.outputs.buck2_out }} -o ${{ steps.set_variables.outputs.buck2_zst }}
+          zstd -z ${{ steps.set_variables.outputs.buck2_rust_project_out }} -o ${{ steps.set_variables.outputs.buck2_rust_project_zst }}
+      - name: Upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: buck2-${{ matrix.target.triple }}
+          path: artifacts/

--- a/.github/workflows/build_buck2.yml
+++ b/.github/workflows/build_buck2.yml
@@ -99,11 +99,15 @@ jobs:
             echo "buck2_zst=artifacts/buck2-${{ matrix.target.triple }}.exe.zst" >> "$GITHUB_OUTPUT"
             echo "buck2_rust_project_out=target/${{ matrix.target.triple }}/release/rust-project.exe" >> "$GITHUB_OUTPUT"
             echo "buck2_rust_project_zst=artifacts/rust-project-${{ matrix.target.triple }}.exe.zst" >> "$GITHUB_OUTPUT"
+            echo "starlark_fmt_out=target/${{ matrix.target.triple }}/release/starlark_fmt.exe" >> "$GITHUB_OUTPUT"
+            echo "starlark_fmt_zst=artifacts/starlark_fmt-${{ matrix.target.triple }}.exe.zst" >> "$GITHUB_OUTPUT"
           else
             echo "buck2_out=target/${{ matrix.target.triple }}/release/buck2" >> "$GITHUB_OUTPUT"
             echo "buck2_zst=artifacts/buck2-${{ matrix.target.triple }}.zst" >> "$GITHUB_OUTPUT"
             echo "buck2_rust_project_out=target/${{ matrix.target.triple }}/release/rust-project" >> "$GITHUB_OUTPUT"
             echo "buck2_rust_project_zst=artifacts/rust-project-${{ matrix.target.triple }}.zst" >> "$GITHUB_OUTPUT"
+            echo "starlark_fmt_out=target/${{ matrix.target.triple }}/release/starlark_fmt" >> "$GITHUB_OUTPUT"
+            echo "starlark_fmt_zst=artifacts/starlark_fmt-${{ matrix.target.triple }}.zst" >> "$GITHUB_OUTPUT"
           fi
       - name: Build
         shell: bash
@@ -125,7 +129,7 @@ jobs:
           else
             CARGO=cargo
           fi
-          $CARGO build --release --bin buck2 --bin rust-project --target ${{ matrix.target.triple }}
+          $CARGO build --release --bin buck2 --bin rust-project --bin starlark_fmt --target ${{ matrix.target.triple }}
       - name: Sanity check with examples/with_prelude
         if: ${{ !matrix.target.cross }}
         shell: bash
@@ -151,6 +155,7 @@ jobs:
           mkdir artifacts
           zstd -z ${{ steps.set_variables.outputs.buck2_out }} -o ${{ steps.set_variables.outputs.buck2_zst }}
           zstd -z ${{ steps.set_variables.outputs.buck2_rust_project_out }} -o ${{ steps.set_variables.outputs.buck2_rust_project_zst }}
+          zstd -z ${{ steps.set_variables.outputs.starlark_fmt_out }} -o ${{ steps.set_variables.outputs.starlark_fmt_zst }}
       - name: Upload
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Manually release `buck2`
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  set_version_info:
+    name: Define the version info for this release
+    runs-on: ubuntu-latest
+    outputs:
+      buck2_version: ${{ steps.define_version_info.outputs.buck2_version }}
+      release_timestamp: ${{ steps.define_version_info.outputs.release_timestamp }}
+      tag: ${{ steps.define_version_info.outputs.tag }}
+    steps:
+      - name: Define version info
+        id: define_version_info
+        run: |
+          # Git tags cannot contain ':', so use '.' between the time components
+          tag=$(date -u +%Y-%m-%d-%H.%M.%S)
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "buck2_version=$tag-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+      - name: Display version info
+        run: |
+          echo "tag: ${{ steps.define_version_info.outputs.tag }}"
+          echo "buck2_version: ${{ steps.define_version_info.outputs.buck2_version }}"
+
+  build:
+    name: Build `buck2`
+    needs:
+      - set_version_info
+    uses: ./.github/workflows/build_buck2.yml
+    with:
+      buck2_version: ${{ needs.set_version_info.outputs.buck2_version }}
+      release_timestamp: ${{ needs.set_version_info.outputs.release_timestamp }}
+
+  release:
+    name: Release the new tag
+    needs:
+      - set_version_info
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      # Publish a new tag and upload all artifacts from the build
+      - uses: ./.github/actions/publish_tag
+        with:
+          tag: ${{ needs.set_version_info.outputs.tag }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: facebook/dotslash-publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          config: .github/dotslash-config.json
+          tag: ${{ needs.set_version_info.outputs.tag }}

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -22,156 +22,19 @@ jobs:
       - name: Display version info
         run: echo ${{ steps.define_version_info.outputs.buck2_version }}
 
-  get_prelude_hash:
-    name: Get the latest prelude hash
-    runs-on: ubuntu-latest
-    outputs:
-      prelude_hash: ${{ steps.get_latest_prelude_hash.outputs.prelude_hash }}
-    steps:
-      - name: Shallow clone buck2-prelude
-        run: git clone --depth=1 https://github.com/facebook/buck2-prelude
-      - name: Get latest commit hash into prelude_hash
-        id: get_latest_prelude_hash
-        run: |
-          mkdir artifacts/
-          cd buck2-prelude/
-          git rev-parse HEAD > ../artifacts/prelude_hash
-          echo "prelude_hash=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Upload prelude_hash
-        uses: actions/upload-artifact@v6
-        with:
-          path: artifacts/prelude_hash
-          name: prelude_hash
-
   build:
+    name: Build `buck2`
     needs:
-      - get_prelude_hash
       - set_version_info
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - os: 'ubuntu-26.04'
-            triple: 'aarch64-unknown-linux-gnu'
-            cross: true
-          - os: 'ubuntu-26.04'
-            triple: 'aarch64-unknown-linux-musl'
-            cross: true
-          - os: 'ubuntu-26.04'
-            triple: 'x86_64-unknown-linux-gnu'
-          - os: 'ubuntu-26.04'
-            triple: 'x86_64-unknown-linux-musl'
-            cross: true
-          - os: 'ubuntu-26.04'
-            triple: 'riscv64gc-unknown-linux-gnu'
-            cross: true
-          - os: 'macos-15'
-            triple: 'aarch64-apple-darwin'
-            cross: true
-          - os: 'macos-15'
-            triple: 'x86_64-apple-darwin'
-          - os: 'windows-2025'
-            triple: 'x86_64-pc-windows-msvc'
-            is_windows: true
-          - os: 'windows-11-arm'
-            triple: 'aarch64-pc-windows-msvc'
-            is_windows: true
-    runs-on: ${{ matrix.target.os }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: SebRollen/toml-action@v1.0.2
-        id: read_rust_toolchain
-        with:
-          file: 'rust-toolchain.toml'
-          field: 'toolchain.channel'
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ steps.read_rust_toolchain.outputs.value }}
-          targets: ${{ matrix.target.triple }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: buck2-upload
-          key: ${{ matrix.target.triple }}
-      - uses: actions-rs/install@v0.1
-        if: matrix.target.cross
-        with:
-          crate: cross
-          version: latest
-      - name: Set variables
-        id: set_variables
-        shell: bash
-        run: |
-          if [ -n "${{ matrix.target.is_windows }}" ]; then
-            echo "buck2_out=target/${{ matrix.target.triple }}/release/buck2.exe" >> "$GITHUB_OUTPUT"
-            echo "buck2_zst=artifacts/buck2-${{ matrix.target.triple }}.exe.zst" >> "$GITHUB_OUTPUT"
-            echo "buck2_rust_project_out=target/${{ matrix.target.triple }}/release/rust-project.exe" >> "$GITHUB_OUTPUT"
-            echo "buck2_rust_project_zst=artifacts/rust-project-${{ matrix.target.triple }}.exe.zst" >> "$GITHUB_OUTPUT"
-          else
-            echo "buck2_out=target/${{ matrix.target.triple }}/release/buck2" >> "$GITHUB_OUTPUT"
-            echo "buck2_zst=artifacts/buck2-${{ matrix.target.triple }}.zst" >> "$GITHUB_OUTPUT"
-            echo "buck2_rust_project_out=target/${{ matrix.target.triple }}/release/rust-project" >> "$GITHUB_OUTPUT"
-            echo "buck2_rust_project_zst=artifacts/rust-project-${{ matrix.target.triple }}.zst" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Build
-        shell: bash
-        env:
-          # BUCK2 prefixed variables used within the build to stamp in a version information
-          # BUCK2_SET_EXPLICIT_VERSION will populate the buck2 --version string
-          BUCK2_RELEASE_TIMESTAMP: ${{ github.event.repository.updated_at }}
-          BUCK2_SET_EXPLICIT_VERSION: ${{ needs.set_version_info.outputs.buck2_version }}
-          RUSTFLAGS: "--cfg tokio_unstable -C strip=debuginfo -C codegen-units=1"
-        run: |
-          # aarch64-linux builds need JEMALLOC_SYS_WITH_LG_PAGE=16
-          # this is for e.g. linux running on apple silicon with native 16k pages
-          if [[ "${{ matrix.target.triple }}" == aarch64-unknown-linux* ]]; then
-            export JEMALLOC_SYS_WITH_LG_PAGE=16
-          fi
-
-          if [ -n "${{ matrix.target.cross }}" ]; then
-            CARGO=cross
-          else
-            CARGO=cargo
-          fi
-          $CARGO build --release --bin buck2 --bin rust-project --target ${{ matrix.target.triple }}
-      - name: Sanity check with examples/with_prelude
-        if: ${{ !matrix.target.cross }}
-        shell: bash
-        run: |
-          BUCK2="$(pwd)/${{ steps.set_variables.outputs.buck2_out }}"
-          cd examples/with_prelude
-          # TODO: rust examples don't work on windows + arm64
-          if [[ "${{ matrix.target.triple }}" == "aarch64-pc-windows-msvc" ]]; then
-            TARGETS="cpp/... python/..."
-          else
-            TARGETS="rust/... cpp/... python/..."
-          fi
-          "$BUCK2" build $TARGETS -v=2
-        # TODO: investigate segmentation fault on windows-11-arm
-        continue-on-error: ${{ matrix.target.triple == 'aarch64-pc-windows-msvc' }}
-      - name: Install zstd
-        shell: pwsh
-        if: ${{ matrix.target.os == 'windows-11-arm' }}
-        run: choco install zstandard
-      - name: Move binary to artifacts/
-        shell: bash
-        run: |
-          mkdir artifacts
-          zstd -z ${{ steps.set_variables.outputs.buck2_out }} -o ${{ steps.set_variables.outputs.buck2_zst }}
-          zstd -z ${{ steps.set_variables.outputs.buck2_rust_project_out }} -o ${{ steps.set_variables.outputs.buck2_rust_project_zst }}
-      - name: Upload
-        uses: actions/upload-artifact@v6
-        with:
-          name: buck2-${{ matrix.target.triple }}
-          path: artifacts/
+    uses: ./.github/workflows/build_buck2.yml
+    with:
+      buck2_version: ${{ needs.set_version_info.outputs.buck2_version }}
+      release_timestamp: ${{ github.event.repository.updated_at }}
 
   release_latest:
     name: Release `latest` tag
     needs:
       - build
-      - get_prelude_hash
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -210,7 +73,8 @@ jobs:
           url="https://api.github.com/repos/$GITHUB_REPOSITORY/tags"
           curl --retry 5 -fsSL "$url" -o tags.txt
           tags=$(cat tags.txt |  jq -r ".[].name")
-          tags_count=$(echo "$tags" | grep -c "${{ steps.get_date.outputs.month }}" || true)
+          # Anchor the match so manual timestamped releases (YYYY-MM-DD-HH.MM.SS) don't count
+          tags_count=$(echo "$tags" | grep -c "^${{ steps.get_date.outputs.month }}-[0-9][0-9]$" || true)
           echo "tags_count=$tags_count" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
       - id: check_if_we_need_to_tag


### PR DESCRIPTION
Add a workflow_dispatch workflow that publishes a release tagged with the
current UTC date and time (to the second), including dotslash files. The
build steps shared with the existing push-triggered workflow are extracted
into a reusable workflow.

This is especially useful on forks to manually create releases from
unmerged changes, without having to wait for changes to land upstream.
