### PR TITLE
superconsole: styling tweaks and (hopefully?) improvements

### DIFF
--- a/app/buck2_client_ctx/src/console_interaction_stream.rs
+++ b/app/buck2_client_ctx/src/console_interaction_stream.rs
@@ -240,7 +240,7 @@ impl SuperConsoleToggle {
             SuperConsoleToggle::Dice => "DICE",
             SuperConsoleToggle::DebugEvents => "debug events",
             SuperConsoleToggle::TwoLinesMode => "two lines mode",
-            SuperConsoleToggle::DetailedRE => "detailed RE",
+            SuperConsoleToggle::DetailedRE => "network details",
             SuperConsoleToggle::Io => "I/O counters",
             SuperConsoleToggle::TargetConfigurations => "target configurations",
             SuperConsoleToggle::ExpandedProgress => "expanded progress",

--- a/app/buck2_client_ctx/src/console_interaction_stream.rs
+++ b/app/buck2_client_ctx/src/console_interaction_stream.rs
@@ -8,13 +8,19 @@
  * above-listed licenses.
  */
 
+use crossterm::event::Event;
+use crossterm::event::EventStream;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
+use futures::StreamExt;
 use strum::EnumIter;
 use superconsole::Stdin;
-use tokio::io::AsyncReadExt;
 
 pub struct ConsoleInteractionStream<'a> {
-    pub stdin: &'a mut Stdin,
+    _stdin: &'a mut Stdin,
     term: InteractiveTerminal,
+    events: EventStream,
 }
 
 impl<'a> ConsoleInteractionStream<'a> {
@@ -31,7 +37,11 @@ impl<'a> ConsoleInteractionStream<'a> {
             }
         };
 
-        Some(Self { stdin, term })
+        Some(Self {
+            _stdin: stdin,
+            term,
+            events: EventStream::new(),
+        })
     }
 }
 
@@ -206,6 +216,24 @@ pub enum SuperConsoleToggle {
     Char(char),
 }
 
+pub enum ConsoleInteraction {
+    Toggle(SuperConsoleToggle),
+    Key(ConsoleKey),
+    Resize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ConsoleKey {
+    Escape,
+    Up,
+    Down,
+    Left,
+    Right,
+    ShiftLeft,
+    ShiftRight,
+    Other,
+}
+
 impl SuperConsoleToggle {
     pub fn description(&self) -> &str {
         match self {
@@ -250,42 +278,91 @@ impl SuperConsoleToggle {
 
 #[async_trait::async_trait]
 pub trait SuperConsoleInteraction: Send + Sync {
-    async fn toggle(&mut self) -> buck2_error::Result<Option<SuperConsoleToggle>>;
+    async fn interaction(&mut self) -> buck2_error::Result<ConsoleInteraction>;
 }
 
 #[async_trait::async_trait]
 impl SuperConsoleInteraction for ConsoleInteractionStream<'_> {
-    async fn toggle(&mut self) -> buck2_error::Result<Option<SuperConsoleToggle>> {
-        match self.stdin.read_u8().await {
-            Ok(c) => {
-                let c: char = c.into();
-                let console_toggle = match c {
-                    'd' => Some(SuperConsoleToggle::Dice),
-                    'e' => Some(SuperConsoleToggle::DebugEvents),
-                    '2' => Some(SuperConsoleToggle::TwoLinesMode),
-                    'r' => Some(SuperConsoleToggle::DetailedRE),
-                    'i' => Some(SuperConsoleToggle::Io),
-                    'p' => Some(SuperConsoleToggle::TargetConfigurations),
-                    'x' => Some(SuperConsoleToggle::ExpandedProgress),
-                    'c' => Some(SuperConsoleToggle::Commands),
-                    '+' => Some(SuperConsoleToggle::IncrLines),
-                    '-' => Some(SuperConsoleToggle::DecrLines),
-                    'k' => Some(SuperConsoleToggle::IncreaseReplaySpeed),
-                    'j' => Some(SuperConsoleToggle::DecreaseReplaySpeed),
-                    'y' => Some(SuperConsoleToggle::PauseReplay),
-                    '?' | 'h' => Some(SuperConsoleToggle::Help),
-                    _ => Some(SuperConsoleToggle::Char(c)),
-                };
-                Ok(console_toggle)
-            }
-            // NOTE: An EOF here would be reported as "unexpected" because we asked for a u8.
-            Err(e)
-                if e.kind() == std::io::ErrorKind::UnexpectedEof
-                    || e.kind() == std::io::ErrorKind::WouldBlock =>
-            {
+    async fn interaction(&mut self) -> buck2_error::Result<ConsoleInteraction> {
+        loop {
+            let Some(event) = self.events.next().await else {
                 futures::future::pending().await
+            };
+            let event = event
+                .map_err(|e| buck2_error::Error::from(e).context("Error reading console event"))?;
+            match event {
+                Event::Key(key) => {
+                    // Windows emits a Release event (and, with the keyboard
+                    // enhancement protocol, a Repeat) for every physical
+                    // keypress; act only on Press so one keystroke fires once.
+                    match key.kind {
+                        KeyEventKind::Press => {}
+                        KeyEventKind::Repeat | KeyEventKind::Release => continue,
+                    }
+                    let interaction = match key.code {
+                        KeyCode::Char(c) => ConsoleInteraction::Toggle(match c {
+                            'd' => SuperConsoleToggle::Dice,
+                            'e' => SuperConsoleToggle::DebugEvents,
+                            '2' => SuperConsoleToggle::TwoLinesMode,
+                            'r' => SuperConsoleToggle::DetailedRE,
+                            'i' => SuperConsoleToggle::Io,
+                            'p' => SuperConsoleToggle::TargetConfigurations,
+                            'x' => SuperConsoleToggle::ExpandedProgress,
+                            'c' => SuperConsoleToggle::Commands,
+                            '+' => SuperConsoleToggle::IncrLines,
+                            '-' => SuperConsoleToggle::DecrLines,
+                            'k' => SuperConsoleToggle::IncreaseReplaySpeed,
+                            'j' => SuperConsoleToggle::DecreaseReplaySpeed,
+                            'y' => SuperConsoleToggle::PauseReplay,
+                            '?' | 'h' => SuperConsoleToggle::Help,
+                            c => SuperConsoleToggle::Char(c),
+                        }),
+                        KeyCode::Enter => {
+                            ConsoleInteraction::Toggle(SuperConsoleToggle::Char('\n'))
+                        }
+                        KeyCode::Tab => ConsoleInteraction::Toggle(SuperConsoleToggle::Char('\t')),
+                        KeyCode::Esc => ConsoleInteraction::Key(ConsoleKey::Escape),
+                        KeyCode::Up => ConsoleInteraction::Key(ConsoleKey::Up),
+                        KeyCode::Down => ConsoleInteraction::Key(ConsoleKey::Down),
+                        KeyCode::Left => ConsoleInteraction::Key(
+                            if key.modifiers.contains(KeyModifiers::SHIFT) {
+                                ConsoleKey::ShiftLeft
+                            } else {
+                                ConsoleKey::Left
+                            },
+                        ),
+                        KeyCode::Right => ConsoleInteraction::Key(
+                            if key.modifiers.contains(KeyModifiers::SHIFT) {
+                                ConsoleKey::ShiftRight
+                            } else {
+                                ConsoleKey::Right
+                            },
+                        ),
+                        KeyCode::Backspace
+                        | KeyCode::Home
+                        | KeyCode::End
+                        | KeyCode::PageUp
+                        | KeyCode::PageDown
+                        | KeyCode::BackTab
+                        | KeyCode::Delete
+                        | KeyCode::Insert
+                        | KeyCode::F(_)
+                        | KeyCode::Null
+                        | KeyCode::CapsLock
+                        | KeyCode::ScrollLock
+                        | KeyCode::NumLock
+                        | KeyCode::PrintScreen
+                        | KeyCode::Pause
+                        | KeyCode::Menu
+                        | KeyCode::KeypadBegin
+                        | KeyCode::Media(_)
+                        | KeyCode::Modifier(_) => ConsoleInteraction::Key(ConsoleKey::Other),
+                    };
+                    return Ok(interaction);
+                }
+                Event::Resize(..) => return Ok(ConsoleInteraction::Resize),
+                Event::FocusGained | Event::FocusLost | Event::Mouse(_) | Event::Paste(_) => {}
             }
-            Err(e) => Err(buck2_error::Error::from(e).context("Error reading char from console")),
         }
     }
 }
@@ -294,7 +371,7 @@ pub struct NoopSuperConsoleInteraction;
 
 #[async_trait::async_trait]
 impl SuperConsoleInteraction for NoopSuperConsoleInteraction {
-    async fn toggle(&mut self) -> buck2_error::Result<Option<SuperConsoleToggle>> {
+    async fn interaction(&mut self) -> buck2_error::Result<ConsoleInteraction> {
         futures::future::pending().await
     }
 }

--- a/app/buck2_client_ctx/src/events_ctx.rs
+++ b/app/buck2_client_ctx/src/events_ctx.rs
@@ -37,10 +37,10 @@ use tokio::runtime::Runtime;
 
 use crate::client_cpu_tracker::ClientCpuTracker;
 use crate::command_outcome::CommandOutcome;
+use crate::console_interaction_stream::ConsoleInteraction;
 use crate::console_interaction_stream::ConsoleInteractionStream;
 use crate::console_interaction_stream::NoopSuperConsoleInteraction;
 use crate::console_interaction_stream::SuperConsoleInteraction;
-use crate::console_interaction_stream::SuperConsoleToggle;
 use crate::daemon::client::BuckdClient;
 use crate::daemon::client::NoPartialResultHandler;
 use crate::daemon::client::tonic_status_to_error;
@@ -291,8 +291,8 @@ impl<'a> DaemonEventsCtx<'a> {
                     Some(event) = self.tailers.recv() => {
                         self.dispatch_tailer_event(event).await?;
                     }
-                    c = console_interaction.toggle() => {
-                        self.inner.handle_console_interaction(&c?).await?;
+                    interaction = console_interaction.interaction() => {
+                        self.inner.handle_console_interaction(&interaction?).await?;
                     }
                     tick = self.ticker.tick() => {
                         self.inner.tick(&tick).await?;
@@ -517,10 +517,12 @@ impl EventsCtx {
 
     async fn handle_console_interaction(
         &mut self,
-        toggle: &Option<SuperConsoleToggle>,
+        interaction: &ConsoleInteraction,
     ) -> buck2_error::Result<()> {
-        self.try_for_each_subscriber(|subscriber| subscriber.handle_console_interaction(toggle))
-            .await
+        self.try_for_each_subscriber(|subscriber| {
+            subscriber.handle_console_interaction(interaction)
+        })
+        .await
     }
 
     async fn handle_events(

--- a/app/buck2_client_ctx/src/subscribers/recorder.rs
+++ b/app/buck2_client_ctx/src/subscribers/recorder.rs
@@ -78,7 +78,7 @@ use crate::client_metadata::ClientMetadata;
 use crate::common::CommonBuildConfigurationOptions;
 use crate::common::CommonEventLogOptions;
 use crate::common::PreemptibleWhen;
-use crate::console_interaction_stream::SuperConsoleToggle;
+use crate::console_interaction_stream::ConsoleInteraction;
 use crate::exit_result::ExitResult;
 use crate::subscribers::classify_server_stderr::classify_server_stderr;
 use crate::subscribers::observer::ErrorObserver;
@@ -2515,12 +2515,13 @@ impl EventSubscriber for InvocationRecorder {
 
     async fn handle_console_interaction(
         &mut self,
-        c: &Option<SuperConsoleToggle>,
+        c: &ConsoleInteraction,
     ) -> buck2_error::Result<()> {
-        if let Some(c) = c {
-            self.tags
-                .push(format!("superconsole-toggle:{}", c.key()).to_owned())
-        }
+        let ConsoleInteraction::Toggle(c) = c else {
+            return Ok(());
+        };
+        self.tags
+            .push(format!("superconsole-toggle:{}", c.key()).to_owned());
         Ok(())
     }
 

--- a/app/buck2_client_ctx/src/subscribers/simpleconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/simpleconsole.rs
@@ -490,7 +490,7 @@ where
             }
         }
 
-        if let Some(re) = &self
+        if let Some(re) = self
             .observer()
             .re_state()
             .render_header(snapshots, DrawMode::Final)

--- a/app/buck2_client_ctx/src/subscribers/subscriber.rs
+++ b/app/buck2_client_ctx/src/subscribers/subscriber.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use buck2_events::BuckEvent;
 
-use crate::console_interaction_stream::SuperConsoleToggle;
+use crate::console_interaction_stream::ConsoleInteraction;
 use crate::exit_result::ExitResult;
 use crate::subscribers::observer::ErrorObserver;
 use crate::ticker::Tick;
@@ -38,7 +38,7 @@ pub trait EventSubscriber: Send {
     }
     async fn handle_console_interaction(
         &mut self,
-        _c: &Option<SuperConsoleToggle>,
+        _c: &ConsoleInteraction,
     ) -> buck2_error::Result<()> {
         Ok(())
     }

--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -48,6 +48,8 @@ use superconsole::style::StyledContent;
 use superconsole::style::Stylize;
 use tokio::sync::mpsc::Receiver;
 
+use crate::console_interaction_stream::ConsoleInteraction;
+use crate::console_interaction_stream::ConsoleKey;
 use crate::console_interaction_stream::SuperConsoleToggle;
 use crate::subscribers::console_output_limit::EmitResult;
 use crate::subscribers::emit_event::emit_event_if_relevant;
@@ -1083,131 +1085,155 @@ impl StatefulSuperConsoleImpl {
 
     async fn handle_console_interaction(
         &mut self,
-        c: &Option<SuperConsoleToggle>,
+        c: &ConsoleInteraction,
     ) -> buck2_error::Result<()> {
+        let c = match c {
+            ConsoleInteraction::Toggle(c) => c,
+            ConsoleInteraction::Key(key) => {
+                self.games_overlay.g_press_count = 0;
+                if self.games_overlay.active {
+                    use games::console::Control;
+
+                    match key {
+                        ConsoleKey::Escape => self.handle_games_control(Control::Escape),
+                        ConsoleKey::Up => self.handle_games_control(Control::Up),
+                        ConsoleKey::Down => self.handle_games_control(Control::Down),
+                        ConsoleKey::Left => self.handle_games_control(Control::Left),
+                        ConsoleKey::Right => self.handle_games_control(Control::Right),
+                        ConsoleKey::ShiftLeft => self.handle_games_control(Control::ShiftLeft),
+                        ConsoleKey::ShiftRight => self.handle_games_control(Control::ShiftRight),
+                        ConsoleKey::Other => {}
+                    }
+                }
+                return Ok(());
+            }
+            ConsoleInteraction::Resize => {
+                self.super_console.render(&BuckRootComponent {
+                    header: &self.header,
+                    state: &self.state,
+                    games_overlay: &self.games_overlay,
+                })?;
+                return Ok(());
+            }
+        };
+
         // When games overlay is active, route all input to games.
         if self.games_overlay.active {
-            if let Some(toggle) = c {
-                let raw_char = toggle.key();
-                let (first, second) = self.games_overlay.escape_state.feed(raw_char);
-                if let Some(control) = first {
-                    self.handle_games_control(control);
-                }
-                if let Some(control) = second {
-                    self.handle_games_control(control);
-                }
+            let raw_char = c.key();
+            let (first, second) = self.games_overlay.escape_state.feed(raw_char);
+            if let Some(control) = first {
+                self.handle_games_control(control);
+            }
+            if let Some(control) = second {
+                self.handle_games_control(control);
             }
             return Ok(());
         }
 
         // Games not active — check for 'g' activation sequence.
         match c {
-            Some(SuperConsoleToggle::Char('g')) => {
+            SuperConsoleToggle::Char('g') => {
                 self.games_overlay.g_press_count += 1;
                 if self.games_overlay.g_press_count >= 3 {
                     self.games_overlay.activate();
                 }
                 return Ok(());
             }
-            Some(_) => {
+            _ => {
                 // Any other recognized key resets the g counter.
                 self.games_overlay.g_press_count = 0;
             }
-            None => {}
         }
 
         // Normal toggle handling.
         match c {
-            Some(c) => match c {
-                SuperConsoleToggle::Dice => {
-                    self.toggle(c.description(), c.key(), |s| {
-                        &mut s.state.config.enable_dice
-                    })
+            SuperConsoleToggle::Dice => {
+                self.toggle(c.description(), c.key(), |s| {
+                    &mut s.state.config.enable_dice
+                })
+                .await?
+            }
+            SuperConsoleToggle::DebugEvents => {
+                self.toggle(c.description(), c.key(), |s| {
+                    &mut s.state.config.enable_debug_events
+                })
+                .await?
+            }
+            SuperConsoleToggle::TwoLinesMode => {
+                self.toggle(c.description(), c.key(), |s| &mut s.state.config.two_lines)
                     .await?
-                }
-                SuperConsoleToggle::DebugEvents => {
-                    self.toggle(c.description(), c.key(), |s| {
-                        &mut s.state.config.enable_debug_events
-                    })
+            }
+            SuperConsoleToggle::DetailedRE => {
+                self.toggle(c.description(), c.key(), |s| {
+                    &mut s.state.config.enable_detailed_re
+                })
+                .await?
+            }
+            SuperConsoleToggle::Io => {
+                self.toggle(c.description(), c.key(), |s| &mut s.state.config.enable_io)
                     .await?
+            }
+            SuperConsoleToggle::TargetConfigurations => {
+                self.toggle(c.description(), c.key(), |s| {
+                    &mut s.state.config.display_platform
+                })
+                .await?
+            }
+            SuperConsoleToggle::ExpandedProgress => {
+                self.toggle(c.description(), c.key(), |s| {
+                    &mut s.state.config.expanded_progress
+                })
+                .await?
+            }
+            SuperConsoleToggle::Commands => {
+                self.toggle(c.description(), c.key(), |s| {
+                    &mut s.state.config.enable_commands
+                })
+                .await?
+            }
+            SuperConsoleToggle::IncrLines => {
+                self.state.config.max_lines = self.state.config.max_lines.saturating_add(1)
+            }
+            SuperConsoleToggle::DecrLines => {
+                self.state.config.max_lines = self.state.config.max_lines.saturating_sub(1)
+            }
+            SuperConsoleToggle::IncreaseReplaySpeed => {
+                if let Some(message) = self.state.timekeeper.scale_speed(1.5).await {
+                    self.handle_stderr(&message).await?;
                 }
-                SuperConsoleToggle::TwoLinesMode => {
-                    self.toggle(c.description(), c.key(), |s| &mut s.state.config.two_lines)
-                        .await?
+            }
+            SuperConsoleToggle::DecreaseReplaySpeed => {
+                if let Some(message) = self.state.timekeeper.scale_speed(1.0 / 1.5).await {
+                    self.handle_stderr(&message).await?;
                 }
-                SuperConsoleToggle::DetailedRE => {
-                    self.toggle(c.description(), c.key(), |s| {
-                        &mut s.state.config.enable_detailed_re
-                    })
-                    .await?
+            }
+            SuperConsoleToggle::PauseReplay => {
+                if let Some(message) = self.state.timekeeper.toggle_pause().await {
+                    self.handle_stderr(&message).await?;
                 }
-                SuperConsoleToggle::Io => {
-                    self.toggle(c.description(), c.key(), |s| &mut s.state.config.enable_io)
-                        .await?
-                }
-                SuperConsoleToggle::TargetConfigurations => {
-                    self.toggle(c.description(), c.key(), |s| {
-                        &mut s.state.config.display_platform
-                    })
-                    .await?
-                }
-                SuperConsoleToggle::ExpandedProgress => {
-                    self.toggle(c.description(), c.key(), |s| {
-                        &mut s.state.config.expanded_progress
-                    })
-                    .await?
-                }
-                SuperConsoleToggle::Commands => {
-                    self.toggle(c.description(), c.key(), |s| {
-                        &mut s.state.config.enable_commands
-                    })
-                    .await?
-                }
-                SuperConsoleToggle::IncrLines => {
-                    self.state.config.max_lines = self.state.config.max_lines.saturating_add(1)
-                }
-                SuperConsoleToggle::DecrLines => {
-                    self.state.config.max_lines = self.state.config.max_lines.saturating_sub(1)
-                }
-                SuperConsoleToggle::IncreaseReplaySpeed => {
-                    if let Some(message) = self.state.timekeeper.scale_speed(1.5).await {
-                        self.handle_stderr(&message).await?;
-                    }
-                }
-                SuperConsoleToggle::DecreaseReplaySpeed => {
-                    if let Some(message) = self.state.timekeeper.scale_speed(1.0 / 1.5).await {
-                        self.handle_stderr(&message).await?;
-                    }
-                }
-                SuperConsoleToggle::PauseReplay => {
-                    if let Some(message) = self.state.timekeeper.toggle_pause().await {
-                        self.handle_stderr(&message).await?;
-                    }
-                }
-                SuperConsoleToggle::Help => {
-                    let help_message = SuperConsoleToggle::iter()
-                        .map(|t| format!("`{}` = toggle {}", t.key(), t.description()))
-                        .collect::<Vec<_>>()
-                        .join("\n");
+            }
+            SuperConsoleToggle::Help => {
+                let help_message = SuperConsoleToggle::iter()
+                    .map(|t| format!("`{}` = toggle {}", t.key(), t.description()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                self.handle_stderr(&format!(
+                    "Help:\n{}\n`g` x3 = games\nenv var {}=true disables interactive console",
+                    help_message, BUCK_NO_INTERACTIVE_CONSOLE
+                ))
+                .await?
+            }
+            SuperConsoleToggle::Char(_) => {
+                if !self.shown_interactive_console_message {
+                    self.shown_interactive_console_message = true;
                     self.handle_stderr(&format!(
-                        "Help:\n{}\n`g` x3 = games\nenv var {}=true disables interactive console",
-                        help_message, BUCK_NO_INTERACTIVE_CONSOLE
+                        "Buck2 has an interactive console; input is consumed. \
+                         Press `h` for help or set {}=true to disable.",
+                        BUCK_NO_INTERACTIVE_CONSOLE
                     ))
-                    .await?
+                    .await?;
                 }
-                SuperConsoleToggle::Char(_) => {
-                    if !self.shown_interactive_console_message {
-                        self.shown_interactive_console_message = true;
-                        self.handle_stderr(&format!(
-                            "Buck2 has an interactive console; input is consumed. \
-                             Press `h` for help or set {}=true to disable.",
-                            BUCK_NO_INTERACTIVE_CONSOLE
-                        ))
-                        .await?;
-                    }
-                }
-            },
-            None => {}
+            }
         }
 
         Ok(())
@@ -1448,7 +1474,7 @@ impl EventSubscriber for StatefulSuperConsole {
 
     async fn handle_console_interaction(
         &mut self,
-        c: &Option<SuperConsoleToggle>,
+        c: &ConsoleInteraction,
     ) -> buck2_error::Result<()> {
         if let Self::Running(super_console) = self {
             super_console.handle_console_interaction(c).await?;

--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -22,7 +22,9 @@ use buck2_event_observer::display;
 use buck2_event_observer::display::TargetDisplayOptions;
 use buck2_event_observer::display::display_file_watcher_end;
 use buck2_event_observer::event_observer::DebugEventObserverExtra;
+use buck2_event_observer::re_state::ReState;
 use buck2_event_observer::session_info::SessionInfo;
+use buck2_event_observer::two_snapshots::TwoSnapshots;
 use buck2_event_observer::unpack_event::VisitorError;
 use buck2_event_observer::unpack_event::unpack_event;
 use buck2_event_observer::verbosity::Verbosity;
@@ -547,6 +549,8 @@ impl Component for BuckRootComponent<'_> {
         draw.draw(
             &SessionInfoComponent {
                 session_info: self.state.session_info(),
+                re_state: self.state.simple_console.observer.re_state(),
+                two_snapshots: self.state.simple_console.observer.two_snapshots(),
             },
             mode,
         )?;
@@ -652,7 +656,7 @@ impl StatefulSuperConsole {
         config: SuperConsoleConfig,
         health_check_reports_receiver: Option<Receiver<Vec<DisplayReport>>>,
     ) -> buck2_error::Result<Self> {
-        let header = format!("Command: {command_name}.");
+        let header = format!("Command {command_name}");
         Ok(Self::Running(StatefulSuperConsoleImpl {
             header,
             state: SuperConsoleState::new(
@@ -757,6 +761,14 @@ impl SuperConsoleState {
 
     pub fn session_info(&self) -> &SessionInfo {
         self.simple_console.observer.session_info()
+    }
+
+    pub fn re_state(&self) -> &ReState {
+        self.simple_console.observer.re_state()
+    }
+
+    pub fn two_snapshots(&self) -> &TwoSnapshots {
+        self.simple_console.observer.two_snapshots()
     }
 
     pub fn tick(&mut self, tick: Tick) {
@@ -1842,9 +1854,9 @@ mod tests {
         } else {
             assert_frame_contains(&frame, "Build ID:");
         }
-        assert_frame_contains(&frame, "Network:");
-        assert_frame_contains(&frame, "(reSessionID-123)");
-        assert_frame_contains(&frame, "Remaining");
+        assert_frame_contains(&frame, "RE session:");
+        assert_frame_contains(&frame, "reSessionID-123");
+        assert_frame_contains(&frame, "Loading targets");
 
         console
             .handle_command_result(&buck2_cli_proto::CommandResult { result: None })
@@ -1864,8 +1876,13 @@ mod tests {
             legacy_dice: false,
         };
 
+        let re_state = ReState::new();
+        let two_snapshots = TwoSnapshots::default();
+
         let full = SessionInfoComponent {
             session_info: &info,
+            re_state: &re_state,
+            two_snapshots: &two_snapshots,
         }
         .draw_unchecked(
             Dimensions {
@@ -1881,6 +1898,8 @@ mod tests {
 
         let multiline = SessionInfoComponent {
             session_info: &info,
+            re_state: &re_state,
+            two_snapshots: &two_snapshots,
         }
         .draw_unchecked(
             Dimensions {
@@ -1897,6 +1916,8 @@ mod tests {
 
         let too_small = SessionInfoComponent {
             session_info: &info,
+            re_state: &re_state,
+            two_snapshots: &two_snapshots,
         }
         .draw_unchecked(
             Dimensions {
@@ -1907,6 +1928,77 @@ mod tests {
         )?;
 
         assert_eq!(too_small.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_session_info_network() -> buck2_error::Result<()> {
+        let info = SessionInfo {
+            trace_id: TraceId::null(),
+            test_session: None,
+            legacy_dice: false,
+        };
+
+        let mut re_state = ReState::new();
+        re_state.add_re_session(&buck2_data::RemoteExecutionSessionCreated {
+            session_id: "reSessionID-123".to_owned(),
+            experiment_name: "".to_owned(),
+            persistent_cache_mode: None,
+        });
+        re_state.update(&buck2_data::Snapshot::default());
+
+        let mut two_snapshots = TwoSnapshots::default();
+        let start = std::time::SystemTime::UNIX_EPOCH;
+        two_snapshots.update(start, &buck2_data::Snapshot::default());
+        two_snapshots.update(
+            start + std::time::Duration::from_secs(10),
+            &buck2_data::Snapshot {
+                re_upload_bytes: 10 * 1024 * 1024,
+                re_download_bytes: 1024 * 1024 * 1024,
+                http_download_bytes: 512 * 1024 * 1024,
+                ..Default::default()
+            },
+        );
+
+        let component = SessionInfoComponent {
+            session_info: &info,
+            re_state: &re_state,
+            two_snapshots: &two_snapshots,
+        };
+
+        let normal = component
+            .draw_unchecked(
+                Dimensions {
+                    width: 80,
+                    height: 10,
+                },
+                DrawMode::Normal,
+            )?
+            .fmt_for_test()
+            .to_string();
+        assert!(
+            normal.contains(
+                "RE session: reSessionID-123\nNetwork:    up    10MiB 1.0MiB/s\n            down 1.5GiB 154MiB/s"
+            ),
+            "unexpected render:\n{normal}"
+        );
+
+        let final_render = component
+            .draw_unchecked(
+                Dimensions {
+                    width: 80,
+                    height: 10,
+                },
+                DrawMode::Final,
+            )?
+            .fmt_for_test()
+            .to_string();
+        assert!(
+            final_render
+                .contains("RE session: reSessionID-123\nNetwork:    up 10MiB  down 1.5GiB"),
+            "unexpected render:\n{final_render}"
+        );
 
         Ok(())
     }

--- a/app/buck2_client_ctx/src/subscribers/superconsole/header.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/header.rs
@@ -21,6 +21,8 @@ use superconsole::Dimensions;
 use superconsole::DrawMode;
 use superconsole::Line;
 use superconsole::Lines;
+use superconsole::Span;
+use superconsole::style::Stylize;
 
 use crate::subscribers::superconsole::SuperConsoleState;
 use crate::subscribers::superconsole::common::HeaderLineComponent;
@@ -202,11 +204,54 @@ enum Style {
     ExtraCompact,
 }
 
+const PHASE_WIDTH: usize = 19;
+
 impl Style {
+    fn remaining_width(&self) -> usize {
+        match self {
+            Style::Normal(num_width) | Style::Compact(num_width) => 2 * *num_width + 1,
+            Style::ExtraCompact => 0,
+        }
+    }
+
+    fn running_width(&self) -> usize {
+        match self {
+            Style::Normal(num_width) | Style::Compact(num_width) => {
+                std::cmp::max(*num_width, "Running".len())
+            }
+            Style::ExtraCompact => 0,
+        }
+    }
+
+    fn render_table_header(&self, mode: DrawMode) -> Option<String> {
+        match self {
+            Style::Normal(_) | Style::Compact(_) => {
+                let mut line = format!(
+                    "{:<PHASE_WIDTH$} {:>remaining_width$}",
+                    "Phase",
+                    "Remaining",
+                    remaining_width = self.remaining_width()
+                );
+                match mode {
+                    DrawMode::Normal => {
+                        line += &format!(
+                            "   {:>running_width$}",
+                            "Running",
+                            running_width = self.running_width()
+                        );
+                    }
+                    DrawMode::Final => {}
+                }
+                Some(line)
+            }
+            Style::ExtraCompact => None,
+        }
+    }
+
     fn render(
         &self,
         mode: DrawMode,
-        header: &str,
+        phase: &str,
         mut pending: u64,
         total: u64,
         running_str: &str,
@@ -217,34 +262,34 @@ impl Style {
         }
         let mut line = match self {
             Style::Normal(num_width) | Style::Compact(num_width) => format!(
-                "{header} Remaining {pending:>num_width$}/{total:<num_width$}",
-                header = header,
+                "{phase:<PHASE_WIDTH$} {pending:>num_width$}/{total:>num_width$}",
+                phase = phase,
                 pending = pending,
                 total = total,
                 num_width = *num_width
             ),
             Style::ExtraCompact => {
-                format!("{header} Remaining {pending}/{total}",)
+                format!("{phase} {pending}/{total}",)
             }
         };
 
         if let DrawMode::Normal = mode {
             line += &match self {
                 Style::Normal(_) | Style::Compact(_) => {
-                    format!(" (running: {running_str})",)
+                    format!("   {running_str}",)
                 }
                 Style::ExtraCompact => {
-                    format!(" ({running_num})",)
+                    format!("   running {running_num}",)
                 }
             };
         }
         line
     }
 
-    fn display_num(&self, num: u64) -> String {
+    fn display_running_num(&self, num: u64) -> String {
         match self {
-            Style::Normal(num_width) | Style::Compact(num_width) => {
-                format!("{num:num_width$}")
+            Style::Normal(_) | Style::Compact(_) => {
+                format!("{num:running_width$}", running_width = self.running_width())
             }
             Style::ExtraCompact => format!("{num}"),
         }
@@ -253,52 +298,25 @@ impl Style {
 
 impl ProgressHeader<'_> {
     fn render_loads(&self, style: Style, mode: DrawMode) -> String {
-        // Always use 20-char header for alignment with "Running validations."
         style.render(
             mode,
-            "Loading targets.    ",
+            "Loading targets",
             self.phase_stats.loads.pending(),
             self.phase_stats.loads.started,
-            &style.display_num(self.phase_stats.loads.running),
+            &style.display_running_num(self.phase_stats.loads.running),
             self.phase_stats.loads.running,
         )
     }
 
-    fn render_loads_extra(&self) -> String {
-        let mut msgs = Vec::new();
-        if self.progress_stats.dirs_read > 0 {
-            msgs.push(format!("{} dirs read", self.progress_stats.dirs_read));
-        }
-        if self.progress_stats.targets > 0 {
-            msgs.push(format!("{} targets declared", self.progress_stats.targets));
-        }
-        msgs.join(", ")
-    }
-
     fn render_analyses(&self, style: Style, mode: DrawMode) -> String {
-        // Always use 20-char header for alignment with "Running validations."
         style.render(
             mode,
-            "Analyzing targets.  ",
+            "Analyzing targets",
             self.phase_stats.analyses.pending(),
             self.phase_stats.analyses.started,
-            &style.display_num(self.phase_stats.analyses.running),
+            &style.display_running_num(self.phase_stats.analyses.running),
             self.phase_stats.analyses.running,
         )
-    }
-
-    fn render_analyses_extra(&self) -> String {
-        let mut msgs = Vec::new();
-        if self.progress_stats.actions_declared > 0 {
-            msgs.push(format!("{} actions", self.progress_stats.actions_declared));
-        }
-        if self.progress_stats.artifacts_declared > 0 {
-            msgs.push(format!(
-                "{} artifacts declared",
-                self.progress_stats.artifacts_declared
-            ));
-        }
-        msgs.join(", ")
     }
 
     fn render_actions(&self, style: Style, mode: DrawMode) -> String {
@@ -308,43 +326,30 @@ impl ProgressHeader<'_> {
         if self.progress_stats.running_local > 0 || self.action_stats.local_actions > 0 {
             running.push(format!(
                 "{} local",
-                style.display_num(self.progress_stats.running_local),
+                style.display_running_num(self.progress_stats.running_local),
             ));
         }
         if self.progress_stats.running_remote > 0 || self.action_stats.remote_actions > 0 {
             running.push(format!(
                 "{} remote",
-                style.display_num(self.progress_stats.running_remote),
+                style.display_running_num(self.progress_stats.running_remote),
             ));
         }
 
         let running_str = if running.is_empty() {
-            style.display_num(0)
+            style.display_running_num(0)
         } else {
             running.join(", ")
         };
 
-        // Always use 20-char header for alignment with "Running validations."
         style.render(
             mode,
-            "Executing actions.  ",
+            "Executing actions",
             phase_stats.pending(),
             phase_stats.started,
             &running_str,
             phase_stats.running,
         )
-    }
-
-    fn render_actions_extra(&self) -> String {
-        let exec_time_ms = self.progress_stats.exec_time_ms;
-        if exec_time_ms > 0 {
-            format!(
-                "{} exec time total",
-                fmt_duration::fmt_duration(Duration::from_millis(exec_time_ms)),
-            )
-        } else {
-            String::new()
-        }
     }
 
     fn render_actions_stats(&self, style: Style) -> String {
@@ -392,29 +397,13 @@ impl ProgressHeader<'_> {
         }
     }
 
-    fn render_actions_stats_extra(&self) -> String {
-        let exec_time_ms = self.progress_stats.exec_time_ms;
-        let cached_exec_time_ms = self.progress_stats.cached_exec_time_ms;
-
-        if cached_exec_time_ms > 0 {
-            format!(
-                "{} exec time cached ({}%)",
-                fmt_duration::fmt_duration(Duration::from_millis(cached_exec_time_ms)),
-                cached_exec_time_ms * 100 / std::cmp::max(exec_time_ms, 1)
-            )
-        } else {
-            String::new()
-        }
-    }
-
     fn render_validations(&self, style: Style, mode: DrawMode) -> String {
-        // "Running validations." is 20 chars - no padding needed
         style.render(
             mode,
-            "Running validations.",
+            "Running validations",
             self.phase_stats.validations.pending(),
             self.phase_stats.validations.started,
-            &style.display_num(self.phase_stats.validations.running),
+            &style.display_running_num(self.phase_stats.validations.running),
             self.phase_stats.validations.running,
         )
     }
@@ -424,6 +413,23 @@ impl Component for ProgressHeader<'_> {
     type Error = buck2_error::Error;
 
     fn draw_unchecked(&self, dimensions: Dimensions, mode: DrawMode) -> buck2_error::Result<Lines> {
+        fn truncate_to_char_boundary(line: &mut String, max_len: usize) {
+            if line.len() <= max_len {
+                return;
+            }
+
+            let new_len = match line
+                .char_indices()
+                .map(|(idx, _)| idx)
+                .take_while(|idx| *idx <= max_len)
+                .last()
+            {
+                Some(idx) => idx,
+                None => return line.clear(),
+            };
+            line.truncate(new_len);
+        }
+
         fn digits_len(v: u64) -> usize {
             (v.checked_ilog10().unwrap_or(0) + 1) as usize
         }
@@ -443,10 +449,10 @@ impl Component for ProgressHeader<'_> {
 
         let num_width = std::cmp::max(5, digits_len(max_total));
 
-        let header_width = "Executing actions.  Remaining _/_ (running: _ local, _ remote)  ".len()
-            + 4 * (num_width - 1);
+        let header_width =
+            "Executing actions   _/_         _ local,   _ remote  ".len() + 4 * (num_width - 1);
 
-        let elapsed = format!("Time elapsed: {}", &self.time_elapsed);
+        let elapsed = format!("elapsed {}", &self.time_elapsed);
 
         // During normal drawing, the elapsed time is in the last row at the end. In the final rendering it gets its own line and is on the left.
         let inline_elapsed = match mode {
@@ -464,62 +470,101 @@ impl Component for ProgressHeader<'_> {
             Style::ExtraCompact
         };
 
-        let mut main = Vec::new();
+        let mut main: Vec<(String, bool)> = Vec::new();
         let mut extra = Vec::new();
 
+        if let Some(table_header) = style.render_table_header(mode) {
+            main.push((table_header, true));
+            match style {
+                Style::Normal(_) => extra.push("Details".to_owned()),
+                Style::Compact(_) | Style::ExtraCompact => extra.push(String::new()),
+            }
+        }
+
         if loads.started > 0 {
-            main.push(self.render_loads(style, mode));
+            main.push((self.render_loads(style, mode), false));
             if let Style::Normal(..) = style {
-                extra.push(self.render_loads_extra());
+                let mut msgs = Vec::new();
+                if self.progress_stats.dirs_read > 0 {
+                    msgs.push(format!("{} dirs read", self.progress_stats.dirs_read));
+                }
+                if self.progress_stats.targets > 0 {
+                    msgs.push(format!("{} targets declared", self.progress_stats.targets));
+                }
+                extra.push(msgs.join(", "));
             } else {
                 extra.push(String::new());
             }
         }
 
         if analysis.started > 0 {
-            main.push(self.render_analyses(style, mode));
+            main.push((self.render_analyses(style, mode), false));
             if let Style::Normal(..) = style {
-                extra.push(self.render_analyses_extra());
+                let mut msgs = Vec::new();
+                if self.progress_stats.actions_declared > 0 {
+                    msgs.push(format!("{} actions", self.progress_stats.actions_declared));
+                }
+                if self.progress_stats.artifacts_declared > 0 {
+                    msgs.push(format!(
+                        "{} artifacts declared",
+                        self.progress_stats.artifacts_declared
+                    ));
+                }
+                extra.push(msgs.join(", "));
             } else {
                 extra.push(String::new());
             }
         }
 
         if actions.started == 0 {
-            main.push(self.header.to_owned());
+            main.push((self.header.to_owned(), false));
             extra.push(String::new());
         } else {
-            main.push(self.render_actions(style, mode));
+            main.push((self.render_actions(style, mode), false));
             if let Style::Normal(..) = style {
-                extra.push(self.render_actions_extra());
+                let exec_time_ms = self.progress_stats.exec_time_ms;
+                if exec_time_ms > 0 {
+                    extra.push(format!(
+                        "{} exec time total",
+                        fmt_duration::fmt_duration(Duration::from_millis(exec_time_ms)),
+                    ));
+                } else {
+                    extra.push(String::new());
+                }
             } else {
                 extra.push(String::new());
             }
 
             // Show validation progress if validation has started (before the header/stats line)
             if validations.started > 0 {
-                main.push(self.render_validations(style, mode));
+                main.push((self.render_validations(style, mode), false));
                 extra.push(String::new());
             }
 
-            // Use 20-char padding when validations are shown (to align with "Running validations.")
-            // otherwise use 18-char padding (original)
-            let header_pad = if validations.started > 0 { 20 } else { 18 };
-            main.push(format!(
-                // typically aligns this with "Remaining:" in the line above, but a long header would push it over, which is okay
-                "{:<header_pad$} {}",
-                self.header,
-                self.render_actions_stats(if dimensions.width > 90 {
-                    Style::Normal(num_width)
-                } else {
-                    style
-                })
-            ));
-            if let Style::Normal(..) = style {
-                extra.push(self.render_actions_stats_extra());
+            main.push((self.header.to_owned(), false));
+            let mut stats = self.render_actions_stats(if dimensions.width > 90 {
+                Style::Normal(num_width)
             } else {
-                extra.push(String::new());
+                style
+            });
+            if let Style::Normal(..) = style {
+                let exec_time_ms = self.progress_stats.exec_time_ms;
+                let cached_exec_time_ms = self.progress_stats.cached_exec_time_ms;
+                let stats_extra = if cached_exec_time_ms > 0 {
+                    format!(
+                        "{} exec time cached ({}%)",
+                        fmt_duration::fmt_duration(Duration::from_millis(cached_exec_time_ms)),
+                        cached_exec_time_ms * 100 / std::cmp::max(exec_time_ms, 1)
+                    )
+                } else {
+                    String::new()
+                };
+                if !stats.is_empty() && !stats_extra.is_empty() {
+                    stats.push_str("  ");
+                }
+                stats.push_str(&stats_extra);
             }
+            extra.push(stats);
         }
 
         assert!(!extra.is_empty());
@@ -532,7 +577,7 @@ impl Component for ProgressHeader<'_> {
         // As long as there is less than `extra_preferred_width` space, the extra column will go immediately after the main column,
         // once it's wider than that we'll right align it.
 
-        let main_width = main.iter().map(String::len).max().unwrap();
+        let main_width = main.iter().map(|(line, _)| line.len()).max().unwrap();
 
         let extra_preferred_width = long_middle_len + 20;
         let extra_width = extra.iter().map(String::len).max().unwrap();
@@ -556,25 +601,44 @@ impl Component for ProgressHeader<'_> {
 
         let mut lines = Vec::new();
         for i in 0..main.len() {
-            let mut line = format!("{:<pad_to$}{}", main[i], extra[i], pad_to = pad_to);
+            let (main_line, is_table_header) = &main[i];
+            let mut line = if extra[i].is_empty() {
+                main_line.to_owned()
+            } else {
+                format!("{:<pad_to$}{}", main_line, extra[i], pad_to = pad_to)
+            };
 
-            if i == main.len() - 1 {
+            if i == main.len() - 1 && !inline_elapsed.is_empty() {
                 let wanted_len = dimensions.width.saturating_sub(inline_elapsed.len() + 2);
                 if line.len() > wanted_len {
-                    // If we're going to have to truncate the extra column for the elapsed time, just drop it in this row.
-                    line = main[i].to_owned();
+                    let compact_line = match extra[i].is_empty() {
+                        true => main_line.to_owned(),
+                        false => format!("{main_line}  {}", extra[i]),
+                    };
+                    if compact_line.len() <= wanted_len {
+                        line = compact_line;
+                    } else {
+                        // If we're going to have to truncate the extra column for the elapsed time, just drop it in this row.
+                        line = main_line.to_owned();
+                    }
                 }
 
                 if line.len() < wanted_len {
                     line += &" ".repeat(wanted_len - line.len());
                 } else {
-                    line.truncate(wanted_len);
+                    truncate_to_char_boundary(&mut line, wanted_len);
                 }
                 line += "  ";
                 line += inline_elapsed;
             }
 
-            lines.push(Line::unstyled(&line)?);
+            let line = line.trim_end().to_owned();
+
+            if *is_table_header {
+                lines.push(Line::from_iter([Span::new_styled_lossy(line.bold())]));
+            } else {
+                lines.push(Line::unstyled(&line)?);
+            }
         }
 
         if let DrawMode::Final = mode {
@@ -591,7 +655,6 @@ mod tests {
 
     use buck2_error::conversion::from_any_with_tag;
     use buck2_event_observer::progress::BuildProgressPhaseStatsItem;
-    use itertools::Itertools;
 
     use super::*;
 
@@ -723,80 +786,83 @@ mod tests {
 
         let expected = indoc::indoc!(
             r#"
-                Loading targets.     Remaining
-                Analyzing targets.   Remaining
-                Executing actions.   Remaining
-                Running validations. Remaining
-                header     Time elapsed: 1234s
+                Loading targets 11000/11111   
+                Analyzing targets 22000/22222 
+                Executing actions 33000/33333 
+                Running validations 44000/4444
+                header           elapsed 1234s
 
-                Loading targets.     Remaining 11000/111
-                Analyzing targets.   Remaining 22000/222
-                Executing actions.   Remaining 33000/333
-                Running validations. Remaining 44000/444
-                header               Time elapsed: 1234s
+                Loading targets 11000/11111   running 11
+                Analyzing targets 22000/22222   running 
+                Executing actions 33000/33333   running 
+                Running validations 44000/44444   runnin
+                header  Cache hits 37%     elapsed 1234s
 
-                Loading targets.     Remaining 11000/11111 (11)
-                Analyzing targets.   Remaining 22000/22222 (22)
-                Executing actions.   Remaining 33000/33333 (100)
-                Running validations. Remaining 44000/44444 (44)
-                header               Cache hits 37%      Time elapsed: 1234s
+                Loading targets 11000/11111   running 11
+                Analyzing targets 22000/22222   running 22
+                Executing actions 33000/33333   running 100
+                Running validations 44000/44444   running 44
+                header  Cache hits 37%                         elapsed 1234s
 
-                Loading targets.     Remaining 11000/11111 (11)
-                Analyzing targets.   Remaining 22000/22222 (22)
-                Executing actions.   Remaining 33000/33333 (100)
-                Running validations. Remaining 44000/44444 (44)
-                header               Cache hits 37%                          Time elapsed: 1234s
+                <span bold>Phase                 Remaining   Running</span>
+                Loading targets     11000/11111        11
+                Analyzing targets   22000/22222        22
+                Executing actions   33000/33333        55 local,      66 remote
+                Running validations 44000/44444        44
+                header  100 local, 122 remote, 133 cache (37%)                     elapsed 1234s
 
-                Loading targets.     Remaining 11000/11111 (running:    11)
-                Analyzing targets.   Remaining 22000/22222 (running:    22)
-                Executing actions.   Remaining 33000/33333 (running:    55 local,    66 remote)
-                Running validations. Remaining 44000/44444 (running:    44)
-                header               Finished 100 local, 122 remote, 133 cache (37% hit)         Time elapsed: 1234s
+                <span bold>Phase                 Remaining   Running</span>
+                Loading targets     11000/11111        11
+                Analyzing targets   22000/22222        22
+                Executing actions   33000/33333        55 local,      66 remote
+                Running validations 44000/44444        44
+                header  Finished 100 local, 122 remote, 133 cache (37% hit)                            elapsed 1234s
 
-                Loading targets.     Remaining 11000/11111 (running:    11)
-                Analyzing targets.   Remaining 22000/22222 (running:    22)
-                Executing actions.   Remaining 33000/33333 (running:    55 local,    66 remote)
-                Running validations. Remaining 44000/44444 (running:    44)
-                header               Finished 100 local, 122 remote, 133 cache (37% hit)                                      Time elapsed: 1234s
+                <span bold>Phase                 Remaining   Running                        Details</span>
+                Loading targets     11000/11111        11                        111 dirs read, 22222 targets declared
+                Analyzing targets   22000/22222        22                        3333333 actions, 4444444 artifacts declared
+                Executing actions   33000/33333        55 local,      66 remote  2:09:37.0s exec time total
+                Running validations 44000/44444        44
+                header  Finished 100 local, 122 remote, 133 cache (37% hit)  11:06.0s exec time cached (8%)                         elapsed 1234s
 
-                Loading targets.     Remaining 11000/11111 (running:    11)                      111 dirs read, 22222 targets declared
-                Analyzing targets.   Remaining 22000/22222 (running:    22)                      3333333 actions, 4444444 artifacts declared
-                Executing actions.   Remaining 33000/33333 (running:    55 local,    66 remote)  2:09:37.0s exec time total
-                Running validations. Remaining 44000/44444 (running:    44)
-                header               Finished 100 local, 122 remote, 133 cache (37% hit)                                       Time elapsed: 1234s
+                <span bold>Phase                 Remaining   Running                        Details</span>
+                Loading targets     11000/11111        11                        111 dirs read, 22222 targets declared
+                Analyzing targets   22000/22222        22                        3333333 actions, 4444444 artifacts declared
+                Executing actions   33000/33333        55 local,      66 remote  2:09:37.0s exec time total
+                Running validations 44000/44444        44
+                header  Finished 100 local, 122 remote, 133 cache (37% hit)  11:06.0s exec time cached (8%)                          elapsed 1234s
 
-                Loading targets.     Remaining 11000/11111 (running:    11)                      111 dirs read, 22222 targets declared
-                Analyzing targets.   Remaining 22000/22222 (running:    22)                      3333333 actions, 4444444 artifacts declared
-                Executing actions.   Remaining 33000/33333 (running:    55 local,    66 remote)  2:09:37.0s exec time total
-                Running validations. Remaining 44000/44444 (running:    44)
-                header               Finished 100 local, 122 remote, 133 cache (37% hit)         11:06.0s exec time cached (8%)          Time elapsed: 1234s
+                <span bold>Phase                 Remaining   Running                        Details</span>
+                Loading targets     11000/11111        11                        111 dirs read, 22222 targets declared
+                Analyzing targets   22000/22222        22                        3333333 actions, 4444444 artifacts declared
+                Executing actions   33000/33333        55 local,      66 remote  2:09:37.0s exec time total
+                Running validations 44000/44444        44
+                header  Finished 100 local, 122 remote, 133 cache (37% hit)  11:06.0s exec time cached (8%)                                    elapsed 1234s
 
-                Loading targets.     Remaining 11000/11111 (running:    11)                                111 dirs read, 22222 targets declared
-                Analyzing targets.   Remaining 22000/22222 (running:    22)                                3333333 actions, 4444444 artifacts declared
-                Executing actions.   Remaining 33000/33333 (running:    55 local,    66 remote)            2:09:37.0s exec time total
-                Running validations. Remaining 44000/44444 (running:    44)
-                header               Finished 100 local, 122 remote, 133 cache (37% hit)                   11:06.0s exec time cached (8%)                    Time elapsed: 1234s
+                <span bold>Phase                 Remaining   Running                        Details</span>
+                Loading targets     11000/11111        11                        111 dirs read, 22222 targets declared
+                Analyzing targets   22000/22222        22                        3333333 actions, 4444444 artifacts declared
+                Executing actions   33000/33333        55 local,      66 remote  2:09:37.0s exec time total
+                Running validations 44000/44444        44
+                header  Finished 100 local, 122 remote, 133 cache (37% hit)  11:06.0s exec time cached (8%)                                                        elapsed 1234s
 
-                Loading targets.     Remaining 0/11111
-                Analyzing targets.   Remaining 0/22222
-                Executing actions.   Remaining 0/33333
-                Running validations. Remaining 0/44444
-                header               Cache hits 37%
-                Time elapsed: 1234s
+                Loading targets 0/11111
+                Analyzing targets 0/22222
+                Executing actions 0/33333
+                Running validations 0/44444
+                header                       Cache hits 37%
+                elapsed 1234s
 
-                Loading targets.     Remaining     0/11111                                111 dirs read, 22222 targets declared
-                Analyzing targets.   Remaining     0/22222                                3333333 actions, 4444444 artifacts declared
-                Executing actions.   Remaining     0/33333                                2:09:37.0s exec time total
-                Running validations. Remaining     0/44444
-                header               Finished 100 local, 122 remote, 133 cache (37% hit)  11:06.0s exec time cached (8%)
-                Time elapsed: 1234s
+                <span bold>Phase                 Remaining                      Details</span>
+                Loading targets         0/11111                      111 dirs read, 22222 targets declared
+                Analyzing targets       0/22222                      3333333 actions, 4444444 artifacts declared
+                Executing actions       0/33333                      2:09:37.0s exec time total
+                Running validations     0/44444
+                header                                               Finished 100 local, 122 remote, 133 cache (37% hit)  11:06.0s exec time cached (8%)
+                elapsed 1234s
 
         "#
         );
-
-        // copy-paste is easier if we don't need to worry about getting trailing spaces right
-        let expected = expected.lines().map(str::trim_end).join("\n");
-        let all_output = all_output.lines().map(str::trim_end).join("\n");
 
         // don't use pretty_assertions here because we mostly just want to copy-paste the golden
         assert!(

--- a/app/buck2_client_ctx/src/subscribers/superconsole/session_info.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/session_info.rs
@@ -10,7 +10,12 @@
 
 use std::iter;
 
+use buck2_event_observer::humanized::HumanizedBytes;
+use buck2_event_observer::humanized::HumanizedBytesPerSecond;
+use buck2_event_observer::re_state::NetworkStats;
+use buck2_event_observer::re_state::ReState;
 use buck2_event_observer::session_info::SessionInfo;
+use buck2_event_observer::two_snapshots::TwoSnapshots;
 use superconsole::Component;
 use superconsole::Dimensions;
 use superconsole::DrawMode;
@@ -21,6 +26,8 @@ use superconsole::Span;
 /// This component is used to display session information for a command e.g. RE session ID
 pub struct SessionInfoComponent<'s> {
     pub session_info: &'s SessionInfo,
+    pub re_state: &'s ReState,
+    pub two_snapshots: &'s TwoSnapshots,
 }
 
 impl Component for SessionInfoComponent<'_> {
@@ -29,7 +36,7 @@ impl Component for SessionInfoComponent<'_> {
     fn draw_unchecked(
         &self,
         dimensions: Dimensions,
-        _mode: DrawMode,
+        mode: DrawMode,
     ) -> buck2_error::Result<Lines> {
         let mut headers = Lines::new();
         let mut ids = vec![];
@@ -46,6 +53,51 @@ impl Component for SessionInfoComponent<'_> {
         if let Some(buck2_data::TestSessionInfo { info, .. }) = &self.session_info.test_session {
             headers.push(Line::unstyled("Test UI:")?);
             ids.push(Span::new_unstyled(info)?);
+        }
+        if let Some(session_id) = &self.re_state.session_id {
+            headers.push(Line::unstyled("RE session:")?);
+            ids.push(Span::new_unstyled(session_id)?);
+        }
+        if let Some(NetworkStats {
+            re_upload_bytes,
+            re_upload_bytes_per_second,
+            download_bytes,
+            download_bytes_per_second,
+        }) = self.re_state.network_stats(self.two_snapshots)
+        {
+            match mode {
+                DrawMode::Normal => {
+                    let rate = |bytes_per_second: u64| {
+                        if bytes_per_second == 0 {
+                            " ".repeat(HumanizedBytesPerSecond::FIXED_WIDTH_WIDTH)
+                        } else {
+                            HumanizedBytesPerSecond::fixed_width(bytes_per_second).to_string()
+                        }
+                    };
+                    headers.push(Line::unstyled("Network:")?);
+                    ids.push(Span::new_unstyled(format!(
+                        "{:<4} {} {}",
+                        "up",
+                        HumanizedBytes::fixed_width(re_upload_bytes),
+                        rate(re_upload_bytes_per_second),
+                    ))?);
+                    headers.push(Line::default());
+                    ids.push(Span::new_unstyled(format!(
+                        "{:<4} {} {}",
+                        "down",
+                        HumanizedBytes::fixed_width(download_bytes),
+                        rate(download_bytes_per_second),
+                    ))?);
+                }
+                DrawMode::Final => {
+                    headers.push(Line::unstyled("Network:")?);
+                    ids.push(Span::new_unstyled(format!(
+                        "up {}  down {}",
+                        HumanizedBytes::new(re_upload_bytes),
+                        HumanizedBytes::new(download_bytes),
+                    ))?);
+                }
+            }
         }
         if self.session_info.legacy_dice {
             headers.push(Line::unstyled("Note:")?);

--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
@@ -87,6 +87,14 @@ impl TimedListBody<'_> {
             write!(aux, " + {remaining_children}").expect("Write to String is not fallible");
         }
 
+        // Escalate the row color on time in the current stage, and only while
+        // actively executing -- total elapsed is mostly queueing under contention.
+        let style_age = if display::is_active_execution_stage(&child_info.event) {
+            child_info_elapsed
+        } else {
+            Duration::ZERO
+        };
+
         TimedRow::new(
             0,
             root_event.label,
@@ -94,7 +102,7 @@ impl TimedListBody<'_> {
             root_event.category,
             Some(aux),
             fmt_duration::fmt_duration(info_elapsed),
-            info_elapsed,
+            style_age,
             self.cutoffs,
         )
     }
@@ -367,7 +375,7 @@ mod tests {
         let expected = [
 
             "────────────────────────────────────────",
-            "test<span fg=dark_grey> · </span><span fg=dark_yellow>speak of the devil</span>           <span fg=dark_grey>3.0s</span>",
+            "test<span fg=dark_grey> · </span>speak of the devil           <span fg=dark_grey>3.0s</span>",
             "foo<span fg=dark_grey> · </span>speak of the devil            <span fg=dark_grey>1.0s</span>",
         ].iter().map(|l| format!("{l}\n")).join("");
 
@@ -501,7 +509,7 @@ mod tests {
 
             let expected = [
                 "────────────────────────────────────────────────────────────",
-                "pkg:target<span fg=dark_grey> [</span><span fg=dark_red>category identifier</span><span fg=dark_grey>]</span>                       <span fg=dark_grey>10.0s</span>",
+                "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span>                       <span fg=dark_grey>10.0s</span>",
             ].iter().map(|l| format!("{l}\n")).join("");
 
             pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);
@@ -520,7 +528,7 @@ mod tests {
 
             let expected = [
                 "────────────────────────────────────────────────────────────",
-                "pkg:target<span fg=dark_grey> [</span><span fg=dark_red>category identifier</span><span fg=dark_grey>]</span>                       <span fg=dark_grey>10.0s</span>",
+                "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span>                       <span fg=dark_grey>10.0s</span>",
             ]
             .iter()
             .map(|l| format!("{l}\n"))
@@ -592,7 +600,7 @@ mod tests {
         )?;
         let expected = [
             "────────────────────────────────────────────────────────────────────────────────",
-            "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span> <span fg=dark_red>prepare         5.0s</span>                      <span fg=dark_grey>10.0s</span>",
+            "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span> <span fg=dark_grey>prepare         5.0s</span>                      <span fg=dark_grey>10.0s</span>",
         ]
         .iter()
         .map(|l| format!("{l}\n"))
@@ -644,8 +652,11 @@ mod tests {
         )?;
         let expected = [
             "────────────────────────────────────────────────────────────────────────────────",
-            "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span> <span fg=dark_red>prepare         5.0s + 1</span>                  <span fg=dark_grey>10.0s</span>",
-        ].iter().map(|l| format!("{l}\n")).join("");
+            "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span> <span fg=dark_grey>prepare         5.0s + 1</span>                  <span fg=dark_grey>10.0s</span>",
+        ]
+        .iter()
+        .map(|l| format!("{l}\n"))
+        .join("");
 
         pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);
 

--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
@@ -501,7 +501,7 @@ mod tests {
 
             let expected = [
                 "────────────────────────────────────────────────────────────",
-                "pkg:target<span fg=dark_grey> · </span><span fg=dark_red>action (category identifier)</span>              <span fg=dark_grey>10.0s</span>",
+                "pkg:target<span fg=dark_grey> [</span><span fg=dark_red>category identifier</span><span fg=dark_grey>]</span>                       <span fg=dark_grey>10.0s</span>",
             ].iter().map(|l| format!("{l}\n")).join("");
 
             pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);
@@ -520,7 +520,7 @@ mod tests {
 
             let expected = [
                 "────────────────────────────────────────────────────────────",
-                "pkg:target<span fg=dark_grey> · </span><span fg=dark_red>action (category identifier)</span>              <span fg=dark_grey>10.0s</span>",
+                "pkg:target<span fg=dark_grey> [</span><span fg=dark_red>category identifier</span><span fg=dark_grey>]</span>                       <span fg=dark_grey>10.0s</span>",
             ]
             .iter()
             .map(|l| format!("{l}\n"))
@@ -592,8 +592,11 @@ mod tests {
         )?;
         let expected = [
             "────────────────────────────────────────────────────────────────────────────────",
-            "pkg:target<span fg=dark_grey> · </span>action (category identifier) <span fg=dark_red>prepare         5.0s</span>             <span fg=dark_grey>10.0s</span>",
-        ].iter().map(|l| format!("{l}\n")).join("");
+            "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span> <span fg=dark_red>prepare         5.0s</span>                      <span fg=dark_grey>10.0s</span>",
+        ]
+        .iter()
+        .map(|l| format!("{l}\n"))
+        .join("");
 
         pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);
 
@@ -641,7 +644,7 @@ mod tests {
         )?;
         let expected = [
             "────────────────────────────────────────────────────────────────────────────────",
-            "pkg:target<span fg=dark_grey> · </span>action (category identifier) <span fg=dark_red>prepare         5.0s + 1</span>         <span fg=dark_grey>10.0s</span>",
+            "pkg:target<span fg=dark_grey> [</span>category identifier<span fg=dark_grey>]</span> <span fg=dark_red>prepare         5.0s + 1</span>                  <span fg=dark_grey>10.0s</span>",
         ].iter().map(|l| format!("{l}\n")).join("");
 
         pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);

--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
@@ -21,13 +21,12 @@ use superconsole::Dimensions;
 use superconsole::DrawMode;
 use superconsole::Line;
 use superconsole::Lines;
-use superconsole::Span;
 use superconsole::components::DrawVertical;
-use superconsole::style::Stylize;
 
 use self::table_builder::Table;
 use crate::subscribers::superconsole::SuperConsoleState;
 use crate::subscribers::superconsole::timed_list::table_builder::Row;
+use crate::subscribers::superconsole::timed_list::table_builder::SummaryRow;
 use crate::subscribers::superconsole::timed_list::table_builder::TimedRow;
 
 mod table_builder;
@@ -66,40 +65,34 @@ impl TimedListBody<'_> {
         let info = root.info();
         let child_info = single_child.info();
 
-        // always display the event and subaction
-        let mut event_string = format!(
-            "{} [{}",
-            display::display_event(
-                &info.event,
-                TargetDisplayOptions::for_console(display_platform)
-            )?,
-            display::display_event(
-                &child_info.event,
-                TargetDisplayOptions::for_console(display_platform)
-            )?
-        );
+        let root_event = display::display_event(
+            &info.event,
+            TargetDisplayOptions::for_console(display_platform),
+        )?;
+        let child_event = display::display_event(
+            &child_info.event,
+            TargetDisplayOptions::for_console(display_platform),
+        )?;
 
         let child_info_elapsed = self.state.timekeeper.duration_since(child_info.start);
         let info_elapsed = self.state.timekeeper.duration_since(info.start);
         let subaction_ratio = child_info_elapsed.as_secs_f64() / info_elapsed.as_secs_f64();
 
-        // but only display the time of the subaction if it differs significantly.
+        let mut aux = child_event.to_string();
         if subaction_ratio < DISPLAY_SUBACTION_CUTOFF {
-            let subaction_time = fmt_duration::fmt_duration(child_info_elapsed);
-            event_string.push(' ');
-            event_string.push_str(&subaction_time);
+            aux.push(' ');
+            aux.push_str(&fmt_duration::fmt_duration(child_info_elapsed));
         }
-
         if remaining_children > 0 {
-            write!(event_string, " + {remaining_children}")
-                .expect("Write to String is not fallible");
+            write!(aux, " + {remaining_children}").expect("Write to String is not fallible");
         }
 
-        event_string.push(']');
-
-        TimedRow::text(
+        TimedRow::new(
             0,
-            event_string,
+            root_event.label,
+            root_event.detail,
+            root_event.category,
+            Some(aux),
             fmt_duration::fmt_duration(info_elapsed),
             info_elapsed,
             self.cutoffs,
@@ -163,28 +156,30 @@ impl Component for TimedListBody<'_> {
         let mut builder = Table::new();
 
         let mut first_not_rendered = None;
+        let mut visible_roots = 0;
 
-        for root in &mut roots {
+        while let Some(root) = roots.next() {
             let rows = self.draw_root(&root)?;
+            let hidden_roots_after_this = roots.len();
+            let reserved_summary_rows = if hidden_roots_after_this > 0 { 1 } else { 0 };
 
-            if builder.len() + rows.len() >= max_lines {
+            if builder.len() + rows.len() + reserved_summary_rows > max_lines {
                 first_not_rendered = Some(root);
                 break;
             }
 
             builder.rows.extend(rows.into_iter().map(Row::from));
+            visible_roots += 1;
         }
 
-        // Add remaining unshown tasks, if any.
-        let more = roots.len() as u64 + first_not_rendered.map_or(0, |_| 1);
+        let more = roots.len() + first_not_rendered.map_or(0, |_| 1);
 
         if more > 0 {
-            let remaining = format!("... and {more} more currently executing");
-            builder.rows.push(
-                std::iter::once(Span::new_styled(remaining.italic())?)
-                    .collect::<Line>()
-                    .into(),
-            );
+            let total = visible_roots + more;
+            builder.rows.push(Row::Summary(SummaryRow {
+                visible_roots,
+                total_roots: total,
+            }));
         }
 
         builder.draw(dimensions, mode)
@@ -371,9 +366,9 @@ mod tests {
         )?;
         let expected = [
 
-            "----------------------------------------",
-            "<span fg=dark_yellow>test -- speak of the devil</span>          <span fg=dark_yellow>3.0s</span>",
-            "foo -- speak of the devil           1.0s",
+            "────────────────────────────────────────",
+            "test<span fg=dark_grey> · </span><span fg=dark_yellow>speak of the devil</span>           <span fg=dark_grey>3.0s</span>",
+            "foo<span fg=dark_grey> · </span>speak of the devil            <span fg=dark_grey>1.0s</span>",
         ].iter().map(|l| format!("{l}\n")).join("");
 
         pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);
@@ -454,9 +449,9 @@ mod tests {
             DrawMode::Normal,
         )?;
         let expected = [
-            "----------------------------------------",
-            "e1 -- speak of the devil            1.0s",
-            "<span italic>... and 2 more currently executing</span>",
+            "────────────────────────────────────────",
+            "e1<span fg=dark_grey> · </span>speak of the devil             <span fg=dark_grey>1.0s</span>",
+            "<span fg=dark_grey italic>1/3 running actions shown</span>",
         ]
         .iter()
         .map(|l| format!("{l}\n"))
@@ -505,8 +500,8 @@ mod tests {
             )?;
 
             let expected = [
-                "------------------------------------------------------------",
-                "<span fg=dark_red>pkg:target -- action (category identifier)</span>             <span fg=dark_red>10.0s</span>",
+                "────────────────────────────────────────────────────────────",
+                "pkg:target<span fg=dark_grey> · </span><span fg=dark_red>action (category identifier)</span>              <span fg=dark_grey>10.0s</span>",
             ].iter().map(|l| format!("{l}\n")).join("");
 
             pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);
@@ -524,8 +519,8 @@ mod tests {
             )?;
 
             let expected = [
-                "------------------------------------------------------------",
-                "<span italic>... and 1 more currently executing</span>",
+                "────────────────────────────────────────────────────────────",
+                "pkg:target<span fg=dark_grey> · </span><span fg=dark_red>action (category identifier)</span>              <span fg=dark_grey>10.0s</span>",
             ]
             .iter()
             .map(|l| format!("{l}\n"))
@@ -596,8 +591,8 @@ mod tests {
             DrawMode::Normal,
         )?;
         let expected = [
-            "--------------------------------------------------------------------------------",
-            "<span fg=dark_red>pkg:target -- action (category identifier) [prepare 5.0s]</span>                  <span fg=dark_red>10.0s</span>",
+            "────────────────────────────────────────────────────────────────────────────────",
+            "pkg:target<span fg=dark_grey> · </span>action (category identifier) <span fg=dark_red>prepare         5.0s</span>             <span fg=dark_grey>10.0s</span>",
         ].iter().map(|l| format!("{l}\n")).join("");
 
         pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);
@@ -645,8 +640,8 @@ mod tests {
             DrawMode::Normal,
         )?;
         let expected = [
-            "--------------------------------------------------------------------------------",
-            "<span fg=dark_red>pkg:target -- action (category identifier) [prepare 5.0s + 1]</span>              <span fg=dark_red>10.0s</span>",
+            "────────────────────────────────────────────────────────────────────────────────",
+            "pkg:target<span fg=dark_grey> · </span>action (category identifier) <span fg=dark_red>prepare         5.0s + 1</span>         <span fg=dark_grey>10.0s</span>",
         ].iter().map(|l| format!("{l}\n")).join("");
 
         pretty_assertions::assert_eq!(output.fmt_for_test().to_string(), expected);

--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
@@ -202,7 +202,7 @@ impl Component for TimedListHeader {
         dimensions: Dimensions,
         _mode: DrawMode,
     ) -> buck2_error::Result<Lines> {
-        Ok(Lines(vec![Line::unstyled(&"-".repeat(dimensions.width))?]))
+        Ok(Lines(vec![Line::unstyled(&"─".repeat(dimensions.width))?]))
     }
 }
 

--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list/table_builder.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list/table_builder.rs
@@ -28,9 +28,13 @@ use superconsole::style::style;
 use crate::subscribers::superconsole::timed_list::Cutoffs;
 use crate::subscribers::superconsole::timekeeper::Timekeeper;
 
+const ACTION_DETAIL_MIN_WIDTH: usize = 9;
+const ACTION_KIND_WIDTH: usize = 16;
+
 #[derive(Debug, Clone, From)]
 pub(crate) enum Row {
     Timed(TimedRow),
+    Summary(SummaryRow),
     Line(Line),
 }
 
@@ -62,34 +66,48 @@ impl Component for Table {
             .rows
             .iter()
             .cloned()
-            .map(|row| {
-                match row {
-                    Row::Timed(row) => {
-                        let mut label = row.event;
-                        let time = row.time;
-                        let time_len = time.len();
-                        let padding = 1;
-                        let maximum_label_width = width.saturating_sub(time_len + padding);
-                        let original_label_len = label.len();
-                        let will_be_truncated = original_label_len > maximum_label_width;
-                        if will_be_truncated {
-                            // make space for ellipses
-                            let style = label.iter().last().unwrap().style;
-                            label.truncate_line(maximum_label_width.saturating_sub(3));
-                            label.push(Span::new_styled_lossy(StyledContent::new(
-                                style,
-                                "...".to_owned(),
-                            )));
-                        }
-
-                        // add extra padding to compensate for missing spaces between label and time
-                        label.pad_right(width.saturating_sub(time_len + label.len()));
-                        let mut combined = label;
-                        combined.extend(time);
-                        combined
+            .map(|row| match row {
+                Row::Timed(row) => {
+                    let TimedRow {
+                        mut primary,
+                        detail,
+                        time,
+                        aux,
+                    } = row;
+                    let sep = 1;
+                    let available_before_time = width.saturating_sub(sep + time.len());
+                    if primary.len() > available_before_time {
+                        truncate_line_with_ellipsis(&mut primary, available_before_time);
                     }
-                    Row::Line(line) => line,
+
+                    let mut combined = primary;
+                    if let Some(mut detail) = detail {
+                        let detail_width = available_before_time.saturating_sub(combined.len());
+                        if detail_width > 0 {
+                            truncate_line_with_ellipsis(&mut detail, detail_width);
+                            combined.extend(detail);
+                        }
+                    }
+
+                    if let Some(mut aux) = aux {
+                        let aux_width = available_before_time.saturating_sub(combined.len() + sep);
+                        if aux_width > 0 {
+                            truncate_line_with_ellipsis(&mut aux, aux_width);
+                            combined.push(Span::padding(sep));
+                            combined.extend(aux);
+                        }
+                    }
+
+                    if combined.len() < available_before_time {
+                        combined.push(Span::padding(available_before_time - combined.len()));
+                    }
+                    combined.push(Span::padding(sep));
+                    combined.extend(time);
+                    truncate_line_with_ellipsis(&mut combined, width);
+                    combined
                 }
+                Row::Summary(row) => row.line(),
+                Row::Line(line) => line,
             })
             .collect();
 
@@ -97,10 +115,43 @@ impl Component for Table {
     }
 }
 
+fn truncate_line_with_ellipsis(line: &mut Line, width: usize) {
+    if line.len() <= width {
+        return;
+    }
+
+    let Some(style) = line.iter().last().map(|span| span.style) else {
+        return;
+    };
+    let ellipsis = ".".repeat(width.min(3));
+    line.truncate_line(width.saturating_sub(ellipsis.len()));
+    if !ellipsis.is_empty() {
+        line.push(Span::new_styled_lossy(StyledContent::new(style, ellipsis)));
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SummaryRow {
+    pub(crate) visible_roots: usize,
+    pub(crate) total_roots: usize,
+}
+
+impl SummaryRow {
+    fn line(&self) -> Line {
+        let summary = format!(
+            "{}/{} running actions shown",
+            self.visible_roots, self.total_roots
+        );
+        Line::from_iter([Span::new_styled_lossy(summary.dark_grey().italic())])
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct TimedRow {
-    event: Line,
+    primary: Line,
+    detail: Option<Line>,
     time: Line,
+    aux: Option<Line>,
 }
 
 impl TimedRow {
@@ -117,36 +168,158 @@ impl TimedRow {
         )?;
         let elapsed = timekeeper.duration_since(span.start);
         let time = fmt_duration::fmt_duration(elapsed);
-        Self::text(padding, event, time, elapsed, cutoffs)
+        Self::new(
+            padding,
+            event.label,
+            event.detail,
+            event.category,
+            None,
+            time,
+            elapsed,
+            cutoffs,
+        )
     }
 
-    pub(crate) fn text(
+    pub(crate) fn new(
         padding: usize,
-        event: String,
+        label: Option<String>,
+        detail: String,
+        category: Option<String>,
+        aux: Option<String>,
         time: String,
         age: Duration,
         cutoffs: &Cutoffs,
     ) -> buck2_error::Result<Self> {
-        Self::styled(padding, style(event), style(time), age, cutoffs)
-    }
+        let mut primary = Vec::new();
+        let has_aux = aux.is_some();
+        if padding > 0 {
+            primary.push(Span::padding(padding));
+        }
 
-    pub(crate) fn styled(
-        padding: usize,
-        event: StyledContent<String>,
-        time: StyledContent<String>,
-        age: Duration,
-        cutoffs: &Cutoffs,
-    ) -> buck2_error::Result<Self> {
-        let event = Span::new_styled(styled_for_delay(event, age, cutoffs))?;
-
-        let line = if padding > 0 {
-            Line::from_iter([Span::padding(padding), event])
-        } else {
-            Line::from_iter([event])
+        let detail = match label {
+            Some(label) => {
+                primary.push(Span::new_styled(style(label))?);
+                let age = if has_aux { Duration::ZERO } else { age };
+                Some(
+                    DetailCell {
+                        text: detail,
+                        category,
+                        has_aux,
+                        age,
+                    }
+                    .line(cutoffs)?,
+                )
+            }
+            None => {
+                primary.push(Span::new_styled(styled_for_delay(
+                    style(detail),
+                    age,
+                    cutoffs,
+                ))?);
+                None
+            }
         };
 
-        let time = Line::from_iter([Span::new_styled(styled_for_delay(time, age, cutoffs))?]);
-        Ok(Self { event: line, time })
+        let aux = match aux {
+            Some(text) => Some(AuxCell { text, age }.line(cutoffs)?),
+            None => None,
+        };
+
+        let primary = Line::from_iter(primary);
+        let time = Line::from_iter([Span::new_styled(style(time).dark_grey())?]);
+        Ok(Self {
+            primary,
+            detail,
+            time,
+            aux,
+        })
+    }
+}
+
+struct DetailCell {
+    text: String,
+    category: Option<String>,
+    has_aux: bool,
+    age: Duration,
+}
+
+impl DetailCell {
+    fn line(self, cutoffs: &Cutoffs) -> buck2_error::Result<Line> {
+        let Self {
+            text,
+            category,
+            has_aux,
+            age,
+        } = self;
+        let mut spans = Vec::new();
+        let Some(category) = category else {
+            spans.push(Span::new_styled(style(" · ".to_owned()).dark_grey())?);
+            spans.push(Span::new_styled(styled_for_delay(
+                style(text),
+                age,
+                cutoffs,
+            ))?);
+            return Ok(Line::from_iter(spans));
+        };
+
+        let rest = text
+            .strip_prefix(&category)
+            .filter(|rest| rest.is_empty() || rest.starts_with(' '));
+        let Some(rest) = rest else {
+            spans.push(Span::new_styled(style(" · ".to_owned()).dark_grey())?);
+            spans.push(Span::new_styled(styled_for_delay(
+                style(text),
+                age,
+                cutoffs,
+            ))?);
+            return Ok(Line::from_iter(spans));
+        };
+
+        spans.push(Span::new_styled(style(" [".to_owned()).dark_grey())?);
+        spans.push(Span::new_styled(styled_for_delay(
+            style(category),
+            age,
+            cutoffs,
+        ))?);
+        if !rest.is_empty() {
+            let rest = match rest.trim().parse::<u64>() {
+                Ok(num) => format!(" {num:>2}"),
+                Err(_) => rest.to_owned(),
+            };
+            spans.push(Span::new_styled(styled_for_delay(
+                style(rest),
+                age,
+                cutoffs,
+            ))?);
+        }
+        spans.push(Span::new_styled(style("]".to_owned()).dark_grey())?);
+
+        let detail_width = spans.iter().map(|span| span.len()).sum::<usize>();
+        if has_aux && detail_width < ACTION_DETAIL_MIN_WIDTH {
+            spans.push(Span::padding(ACTION_DETAIL_MIN_WIDTH - detail_width));
+        }
+
+        Ok(Line::from_iter(spans))
+    }
+}
+
+struct AuxCell {
+    text: String,
+    age: Duration,
+}
+
+impl AuxCell {
+    fn line(self, cutoffs: &Cutoffs) -> buck2_error::Result<Line> {
+        let Self { text, age } = self;
+        let text = match text.split_once(' ') {
+            Some((kind, rest)) => format!("{kind:<ACTION_KIND_WIDTH$}{rest}"),
+            None => text,
+        };
+        Ok(Line::from_iter([Span::new_styled(styled_for_delay(
+            style(text).dark_grey(),
+            age,
+            cutoffs,
+        ))?]))
     }
 }
 
@@ -179,5 +352,192 @@ fn styled_for_delay(
         content.dark_yellow()
     } else {
         content.dark_red()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use superconsole::Component;
+
+    use crate::subscribers::superconsole::timed_list::Cutoffs;
+    use crate::subscribers::superconsole::timed_list::table_builder::Row;
+    use crate::subscribers::superconsole::timed_list::table_builder::Table;
+    use crate::subscribers::superconsole::timed_list::table_builder::TimedRow;
+
+    const CUTOFFS: Cutoffs = Cutoffs {
+        inform: Duration::from_secs(1000),
+        warn: Duration::from_secs(2000),
+        _notable: Duration::ZERO,
+    };
+
+    #[test]
+    fn timed_row_keeps_target_before_metadata() -> buck2_error::Result<()> {
+        let label = "root//third-party/rust:tikv-jemalloc-sys-0.6-buildscript";
+        let mut table = Table::new();
+        table.rows.push(Row::Timed(TimedRow::new(
+            0,
+            None,
+            label.to_owned(),
+            None,
+            Some("local_execute 10.4s".to_owned()),
+            "1:47.6s".to_owned(),
+            Duration::ZERO,
+            &CUTOFFS,
+        )?));
+
+        let output = table.draw(
+            superconsole::Dimensions {
+                width: 72,
+                height: 1,
+            },
+            superconsole::DrawMode::Normal,
+        )?;
+        let output = output.fmt_for_test().to_string();
+        let expected = concat!(
+            "root//third-party/rust:tikv-jemalloc-sys-0.6-buildscript ",
+            "<span fg=dark_grey>loca...</span> ",
+            "<span fg=dark_grey>1:47.6s</span>\n",
+        );
+
+        pretty_assertions::assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn timed_row_keeps_time_suffix_when_target_is_truncated() -> buck2_error::Result<()> {
+        let mut table = Table::new();
+        table.rows.push(Row::Timed(TimedRow::new(
+            0,
+            None,
+            "root//third-party/rust:tikv-jemalloc-sys-0.6-buildscript".to_owned(),
+            None,
+            Some("local_execute 10.4s".to_owned()),
+            "1:47.6s".to_owned(),
+            Duration::ZERO,
+            &CUTOFFS,
+        )?));
+
+        let output = table.draw(
+            superconsole::Dimensions {
+                width: 36,
+                height: 1,
+            },
+            superconsole::DrawMode::Normal,
+        )?;
+        let output = output.fmt_for_test().to_string();
+        let expected = concat!(
+            "root//third-party/rust:ti... ",
+            "<span fg=dark_grey>1:47.6s</span>\n",
+        );
+
+        pretty_assertions::assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn timed_row_truncates_aux_before_event_or_time() -> buck2_error::Result<()> {
+        let label = "root//third-party/rust:short-target";
+        let mut table = Table::new();
+        table.rows.push(Row::Timed(TimedRow::new(
+            0,
+            None,
+            label.to_owned(),
+            None,
+            Some("local_execute 10.4s".to_owned()),
+            "1:47.6s".to_owned(),
+            Duration::ZERO,
+            &CUTOFFS,
+        )?));
+
+        let output = table.draw(
+            superconsole::Dimensions {
+                width: 56,
+                height: 1,
+            },
+            superconsole::DrawMode::Normal,
+        )?;
+        let output = output.fmt_for_test().to_string();
+        let expected = concat!(
+            "root//third-party/rust:short-target ",
+            "<span fg=dark_grey>local_exe...</span> ",
+            "<span fg=dark_grey>1:47.6s</span>\n",
+        );
+
+        pretty_assertions::assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn timed_row_delineates_action_category() -> buck2_error::Result<()> {
+        let mut table = Table::new();
+        table.rows.push(Row::Timed(TimedRow::new(
+            0,
+            Some("root//third-party/rust:zerocopy".to_owned()),
+            "download_file crate".to_owned(),
+            Some("download_file".to_owned()),
+            None,
+            "12.0s".to_owned(),
+            Duration::ZERO,
+            &CUTOFFS,
+        )?));
+
+        let output = table.draw(
+            superconsole::Dimensions {
+                width: 80,
+                height: 1,
+            },
+            superconsole::DrawMode::Normal,
+        )?;
+        let output = output.fmt_for_test().to_string();
+        let expected = concat!(
+            "root//third-party/rust:zerocopy",
+            "<span fg=dark_grey> [</span>download_file crate<span fg=dark_grey>]</span>",
+            "                      ",
+            "<span fg=dark_grey>12.0s</span>\n",
+        );
+
+        pretty_assertions::assert_eq!(output, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn timed_row_colors_child_action_not_parent_target() -> buck2_error::Result<()> {
+        let mut table = Table::new();
+        table.rows.push(Row::Timed(TimedRow::new(
+            0,
+            Some("root//third-party/rust:serde_bytes-0.11".to_owned()),
+            "deps 0".to_owned(),
+            Some("deps".to_owned()),
+            Some("local_execute 0.1s".to_owned()),
+            "12.6s".to_owned(),
+            Duration::from_secs(3000),
+            &CUTOFFS,
+        )?));
+
+        let output = table.draw(
+            superconsole::Dimensions {
+                width: 120,
+                height: 1,
+            },
+            superconsole::DrawMode::Normal,
+        )?;
+        let output = output.fmt_for_test().to_string();
+        let expected = concat!(
+            "root//third-party/rust:serde_bytes-0.11",
+            "<span fg=dark_grey> [</span>deps  0<span fg=dark_grey>]</span> ",
+            "<span fg=dark_red>local_execute   0.1s</span>",
+            "                                             ",
+            "<span fg=dark_grey>12.6s</span>\n",
+        );
+
+        pretty_assertions::assert_eq!(output, expected);
+
+        Ok(())
     }
 }

--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list/table_builder.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list/table_builder.rs
@@ -168,6 +168,13 @@ impl TimedRow {
         )?;
         let elapsed = timekeeper.duration_since(span.start);
         let time = fmt_duration::fmt_duration(elapsed);
+        // Escalate the row color on time in the current stage, and only while
+        // actively executing -- total elapsed is mostly queueing under contention.
+        let style_age = if display::is_active_execution_stage(&span.event) {
+            elapsed
+        } else {
+            Duration::ZERO
+        };
         Self::new(
             padding,
             event.label,
@@ -175,7 +182,7 @@ impl TimedRow {
             event.category,
             None,
             time,
-            elapsed,
+            style_age,
             cutoffs,
         )
     }

--- a/app/buck2_cmd_log_client/src/what_up.rs
+++ b/app/buck2_cmd_log_client/src/what_up.rs
@@ -163,6 +163,8 @@ impl WhatUpCommand {
                 draw.draw(
                     &SessionInfoComponent {
                         session_info: self.state.session_info(),
+                        re_state: self.state.re_state(),
+                        two_snapshots: self.state.two_snapshots(),
                     },
                     mode,
                 )?;

--- a/app/buck2_event_observer/src/display.rs
+++ b/app/buck2_event_observer/src/display.rs
@@ -189,11 +189,61 @@ pub fn display_action_key(
     }
 }
 
-pub fn display_action_name_opt(name: Option<&ActionName>) -> String {
-    match name {
-        Some(name) if name.identifier.is_empty() => name.category.clone(),
-        Some(name) => format!("{} {}", name.category, name.identifier),
-        _ => "unknown".to_owned(),
+fn action_key_leaf_name(action_key: &ActionKey) -> buck2_error::Result<&str> {
+    let ActionKey {
+        owner: Some(owner), ..
+    } = action_key
+    else {
+        return Err(ParseEventError::MissingActionOwner.into());
+    };
+
+    match owner {
+        action_key::Owner::TargetLabel(ConfiguredTargetLabel {
+            label: Some(TargetLabel { package: _, name }),
+            configuration: _,
+            execution_configuration: _,
+        })
+        | action_key::Owner::TestTargetLabel(ConfiguredTargetLabel {
+            label: Some(TargetLabel { package: _, name }),
+            configuration: _,
+            execution_configuration: _,
+        })
+        | action_key::Owner::LocalResourceSetup(ConfiguredTargetLabel {
+            label: Some(TargetLabel { package: _, name }),
+            configuration: _,
+            execution_configuration: _,
+        }) => Ok(name.as_str()),
+        action_key::Owner::TargetLabel(ConfiguredTargetLabel {
+            label: None,
+            configuration: _,
+            execution_configuration: _,
+        })
+        | action_key::Owner::TestTargetLabel(ConfiguredTargetLabel {
+            label: None,
+            configuration: _,
+            execution_configuration: _,
+        })
+        | action_key::Owner::LocalResourceSetup(ConfiguredTargetLabel {
+            label: None,
+            configuration: _,
+            execution_configuration: _,
+        }) => Err(ParseEventError::InvalidConfiguredTargetLabel.into()),
+        action_key::Owner::BxlKey(BxlFunctionKey {
+            label: Some(BxlFunctionLabel { bxl_path: _, name }),
+        }) => Ok(name.as_str()),
+        action_key::Owner::BxlKey(BxlFunctionKey { label: None }) => {
+            Err(ParseEventError::MissingBxlFunctionLabel.into())
+        }
+        action_key::Owner::AnonTarget(AnonTarget {
+            name: Some(TargetLabel { package: _, name }),
+            execution_configuration: _,
+            hash: _,
+        }) => Ok(name.as_str()),
+        action_key::Owner::AnonTarget(AnonTarget {
+            name: None,
+            execution_configuration: _,
+            hash: _,
+        }) => Err(ParseEventError::InvalidAnonTarget.into()),
     }
 }
 
@@ -283,12 +333,21 @@ pub fn display_event(
         let res: buck2_error::Result<_> = match data {
             Data::ActionExecution(action) => match &action.key {
                 Some(key) => {
-                    let string = display_action_key(key, opts)?;
-                    let action_descriptor = display_action_name_opt(action.name.as_ref());
-                    Ok(EventDisplay::labeled(
-                        string,
-                        format!("action ({action_descriptor})"),
-                    ))
+                    let target = display_action_key(key, opts)?;
+                    let event = match action.name.as_ref() {
+                        Some(name) => {
+                            let detail = if name.identifier.is_empty()
+                                || name.identifier.as_str() == action_key_leaf_name(key)?
+                            {
+                                name.category.clone()
+                            } else {
+                                format!("{} {}", name.category, name.identifier)
+                            };
+                            EventDisplay::labeled_action(target, detail, name.category.clone())
+                        }
+                        None => EventDisplay::labeled(target, "unknown"),
+                    };
+                    Ok(event)
                 }
                 None => Err(ParseEventError::MissingActionKey.into()),
             },
@@ -1225,7 +1284,77 @@ impl<'a> CriticalPathEntryDisplay<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::UNIX_EPOCH;
+
+    use buck2_data::SpanStartEvent;
+    use buck2_events::BuckEvent;
+    use buck2_events::span::SpanId;
+    use buck2_wrapper_common::invocation_id::TraceId;
+
     use super::*;
+
+    fn action_execution_event(identifier: &str) -> BuckEvent {
+        BuckEvent::new(
+            UNIX_EPOCH,
+            TraceId::new(),
+            Some(SpanId::next()),
+            None,
+            SpanStartEvent {
+                data: Some(
+                    buck2_data::ActionExecutionStart {
+                        key: Some(buck2_data::ActionKey {
+                            id: Default::default(),
+                            owner: Some(buck2_data::action_key::Owner::TargetLabel(
+                                buck2_data::ConfiguredTargetLabel {
+                                    label: Some(buck2_data::TargetLabel {
+                                        package: "pkg".into(),
+                                        name: "target".into(),
+                                    }),
+                                    configuration: Some(buck2_data::Configuration {
+                                        full_name: "cfg".into(),
+                                    }),
+                                    execution_configuration: None,
+                                },
+                            )),
+                            key: String::new(),
+                        }),
+                        name: Some(buck2_data::ActionName {
+                            category: "category".into(),
+                            identifier: identifier.into(),
+                        }),
+                        kind: buck2_data::ActionKind::NotSet as i32,
+                    }
+                    .into(),
+                ),
+            }
+            .into(),
+        )
+    }
+
+    #[test]
+    fn action_event_display_hides_identifier_matching_target_leaf() -> buck2_error::Result<()> {
+        let event = action_execution_event("target");
+        let display = display_event(&event, TargetDisplayOptions::for_console(true))?;
+
+        assert_eq!(display.label.as_deref(), Some("pkg:target (cfg)"));
+        assert_eq!(display.detail, "category");
+        assert_eq!(display.category.as_deref(), Some("category"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn action_event_display_keeps_identifier_different_from_target_leaf() -> buck2_error::Result<()>
+    {
+        let event = action_execution_event("other");
+        let display = display_event(&event, TargetDisplayOptions::for_console(true))?;
+
+        assert_eq!(display.label.as_deref(), Some("pkg:target (cfg)"));
+        assert_eq!(display.detail, "category other");
+        assert_eq!(display.category.as_deref(), Some("category"));
+
+        Ok(())
+    }
 
     #[test]
     fn removes_color_characters() {

--- a/app/buck2_event_observer/src/display.rs
+++ b/app/buck2_event_observer/src/display.rs
@@ -705,6 +705,61 @@ pub fn display_executor_stage(
     Some(label)
 }
 
+/// Whether `event` is an executor stage that is actively running the action,
+/// rather than queueing, fetching from cache/RE, or materializing inputs.
+///
+/// Gates the slow-action coloring so the warning reflects slow work, not time
+/// spent waiting for a local slot or for inputs under contention.
+pub fn is_active_execution_stage(event: &BuckEvent) -> bool {
+    let buck2_data::buck_event::Data::SpanStart(start) = event.data() else {
+        return false;
+    };
+    let Some(Data::ExecutorStage(info)) = start.data.as_ref() else {
+        return false;
+    };
+    let Some(stage) = info.stage.as_ref() else {
+        return false;
+    };
+
+    use buck2_data::executor_stage_start::Stage;
+    match stage {
+        Stage::Local(local) => {
+            use buck2_data::local_stage::Stage as Local;
+            match local.stage.as_ref() {
+                Some(Local::Execute(..)) | Some(Local::WorkerExecute(..)) => true,
+                Some(Local::Queued(..))
+                | Some(Local::MaterializeInputs(..))
+                | Some(Local::PrepareOutputs(..))
+                | Some(Local::AcquireLocalResource(..))
+                | Some(Local::WorkerInit(..))
+                | Some(Local::WorkerQueued(..))
+                | Some(Local::WorkerWait(..))
+                | None => false,
+            }
+        }
+        Stage::Re(re) => {
+            use buck2_data::re_stage::Stage as Re;
+            match re.stage.as_ref() {
+                Some(Re::Execute(..)) => true,
+                Some(Re::Download(..))
+                | Some(Re::Queue(..))
+                | Some(Re::QueueOverQuota(..))
+                | Some(Re::QueueAcquiringDependencies(..))
+                | Some(Re::QueueNoWorkerAvailable(..))
+                | Some(Re::QueueCancelled(..))
+                | Some(Re::WorkerDownload(..))
+                | Some(Re::WorkerUpload(..))
+                | Some(Re::Unknown(..))
+                | Some(Re::MaterializeFailedInputs(..))
+                | Some(Re::BeforeActionExecution(..))
+                | Some(Re::AfterActionExecution(..))
+                | None => false,
+            }
+        }
+        Stage::Prepare(..) | Stage::CacheQuery(..) | Stage::CacheHit(..) => false,
+    }
+}
+
 #[derive(buck2_error::Error, Debug)]
 #[buck2(tag = Input)]
 enum ParseEventError {

--- a/app/buck2_event_observer/src/display.rs
+++ b/app/buck2_event_observer/src/display.rs
@@ -218,8 +218,62 @@ pub fn display_action_identity(
     Ok(format!("{key_string}{action_string}"))
 }
 
+/// A rendered span event, split into the entity it acts on (`label`) and what is
+/// happening to it (`detail`).
+///
+/// Keeping the two apart lets the console style and lay them out independently —
+/// e.g. leave the target plain and color the action — instead of re-parsing a
+/// flattened `"{label} -- {detail}"` string.
+pub struct EventDisplay {
+    pub label: Option<String>,
+    pub detail: String,
+    pub category: Option<String>,
+}
+
+impl EventDisplay {
+    fn bare(detail: impl Into<String>) -> Self {
+        Self {
+            label: None,
+            detail: detail.into(),
+            category: None,
+        }
+    }
+
+    fn labeled(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            label: Some(label.into()),
+            detail: detail.into(),
+            category: None,
+        }
+    }
+
+    fn labeled_action(
+        label: impl Into<String>,
+        detail: impl Into<String>,
+        category: impl Into<String>,
+    ) -> Self {
+        Self {
+            label: Some(label.into()),
+            detail: detail.into(),
+            category: Some(category.into()),
+        }
+    }
+}
+
+impl fmt::Display for EventDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.label {
+            Some(label) => write!(f, "{label} -- {}", self.detail),
+            None => write!(f, "{}", self.detail),
+        }
+    }
+}
+
 /// Formats event payloads for display.
-pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_error::Result<String> {
+pub fn display_event(
+    event: &BuckEvent,
+    opts: TargetDisplayOptions,
+) -> buck2_error::Result<EventDisplay> {
     let res: buck2_error::Result<_> = try {
         let data = match event.data() {
             buck2_data::buck_event::Data::SpanStart(start) => start.data.as_ref().unwrap(),
@@ -231,7 +285,10 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                 Some(key) => {
                     let string = display_action_key(key, opts)?;
                     let action_descriptor = display_action_name_opt(action.name.as_ref());
-                    Ok(format!("{string} -- action ({action_descriptor})"))
+                    Ok(EventDisplay::labeled(
+                        string,
+                        format!("action ({action_descriptor})"),
+                    ))
                 }
                 None => Err(ParseEventError::MissingActionKey.into()),
             },
@@ -256,12 +313,15 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                         Ok(&build.path)
                     }
                 }?;
-                Ok(format!("{key} -- materializing `{path}`"))
+                Ok(EventDisplay::labeled(
+                    key,
+                    format!("materializing `{path}`"),
+                ))
             }
             Data::Analysis(analysis) => match &analysis.target {
                 Some(target) => {
                     let target = display_analysis_target(target, opts)?;
-                    Ok(format!("{target} -- running analysis"))
+                    Ok(EventDisplay::labeled(target, "running analysis"))
                 }
                 None => Err(ParseEventError::MissingConfiguredTargetLabel.into()),
             },
@@ -271,17 +331,23 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                     .as_ref()
                     .ok_or_else(|| internal_error!("analysis stage is missing"))?;
                 let stage = display_analysis_stage(stage);
-                Ok(stage.into())
+                Ok(EventDisplay::bare(stage))
             }
-            Data::AnalysisResolveQueries(resolve_queries) => Ok(format!(
-                "{} -- analysis queries",
+            Data::AnalysisResolveQueries(resolve_queries) => Ok(EventDisplay::labeled(
                 display_configured_target_label_opt(
                     resolve_queries.standard_target.as_ref(),
-                    opts
-                )?
+                    opts,
+                )?,
+                "analysis queries",
             )),
-            Data::LoadPackage(load) => Ok(format!("{} -- loading package file tree", load.path)),
-            Data::Load(load) => Ok(format!("{} -- evaluating build file", load.module_id)),
+            Data::LoadPackage(load) => Ok(EventDisplay::labeled(
+                load.path.clone(),
+                "loading package file tree",
+            )),
+            Data::Load(load) => Ok(EventDisplay::labeled(
+                load.module_id.clone(),
+                "evaluating build file",
+            )),
             Data::ExecutorStage(info) => {
                 let stage = info
                     .stage
@@ -289,11 +355,11 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                     .ok_or_else(|| internal_error!("executor stage is missing"))?;
                 let stage = display_executor_stage(stage)
                     .ok_or_else(|| internal_error!("unknown executor stage"))?;
-                Ok(stage.into())
+                Ok(EventDisplay::bare(stage))
             }
-            Data::TestDiscovery(discovery) => Ok(format!(
-                "Test {} -- discovering tests",
-                discovery.suite_name
+            Data::TestDiscovery(discovery) => Ok(EventDisplay::labeled(
+                format!("Test {}", discovery.suite_name),
+                "discovering tests",
             )),
             Data::TestRun(start) => match &start.suite {
                 Some(suite) => {
@@ -308,16 +374,19 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                             )
                         }
                     };
-                    Ok(format!("Test {} -- {}", suite.suite_name, tests))
+                    Ok(EventDisplay::labeled(
+                        format!("Test {}", suite.suite_name),
+                        tests,
+                    ))
                 }
                 None => Err(ParseEventError::MissingSuiteName.into()),
             },
             Data::CommandCritical(..) => Err(ParseEventError::UnexpectedEvent.into()),
             Data::Command(..) => Err(ParseEventError::UnexpectedEvent.into()),
-            Data::FileWatcher(x) => Ok(format!(
+            Data::FileWatcher(x) => Ok(EventDisplay::bare(format!(
                 "Syncing file changes via {}",
                 display_file_watcher(x.provider)
-            )),
+            ))),
             Data::MatchDepFiles(buck2_data::MatchDepFilesStart {
                 checking_filtered_inputs,
                 remote_cache,
@@ -332,32 +401,40 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                 } else {
                     "partial"
                 };
-                Ok(format!("dep_files({detail},{location})"))
+                Ok(EventDisplay::bare(format!(
+                    "dep_files({detail},{location})"
+                )))
             }
-            Data::SharedTask(buck2_data::SharedTaskStart { owner_trace_id }) => Ok(format!(
-                "Waiting on task from another command: {owner_trace_id}"
-            )),
-            Data::CacheUpload(_) => Ok("upload (action)".to_owned()),
-            Data::DepFileUpload(_) => Ok("upload (dep_file)".to_owned()),
-            Data::CreateOutputSymlinks(..) => Ok("Creating output symlinks".to_owned()),
-            Data::InstallEventInfo(info) => Ok(format!(
+            Data::SharedTask(buck2_data::SharedTaskStart { owner_trace_id }) => {
+                Ok(EventDisplay::bare(format!(
+                    "Waiting on task from another command: {owner_trace_id}"
+                )))
+            }
+            Data::CacheUpload(_) => Ok(EventDisplay::bare("upload (action)")),
+            Data::DepFileUpload(_) => Ok(EventDisplay::bare("upload (dep_file)")),
+            Data::CreateOutputSymlinks(..) => Ok(EventDisplay::bare("Creating output symlinks")),
+            Data::InstallEventInfo(info) => Ok(EventDisplay::bare(format!(
                 "Sending {} at path {}",
                 info.artifact_name, info.file_path
-            )),
-            Data::DiceStateUpdate(..) => Ok("Syncing changes to graph".to_owned()),
-            Data::Materialization(..) => Ok("materializing".to_owned()),
+            ))),
+            Data::DiceStateUpdate(..) => Ok(EventDisplay::bare("Syncing changes to graph")),
+            Data::Materialization(..) => Ok(EventDisplay::bare("materializing")),
             Data::DiceCriticalSection(..) => Err(ParseEventError::UnexpectedEvent.into()),
-            Data::DiceBlockConcurrentCommand(cmd) => Ok(format!(
+            Data::DiceBlockConcurrentCommand(cmd) => Ok(EventDisplay::bare(format!(
                 "Waiting for command [{}] to finish",
                 truncate(&cmd.cmd_args, 200),
-            )),
-            Data::DiceSynchronizeSection(..) => Ok("Synchronizing buck2 internal state".to_owned()),
-            Data::DiceCleanup(..) => Ok("Cleaning up graph state".to_owned()),
+            ))),
+            Data::DiceSynchronizeSection(..) => {
+                Ok(EventDisplay::bare("Synchronizing buck2 internal state"))
+            }
+            Data::DiceCleanup(..) => Ok(EventDisplay::bare("Cleaning up graph state")),
             Data::ExclusiveCommandWait(buck2_data::ExclusiveCommandWaitStart { command_name }) => {
                 if let Some(name) = command_name {
-                    Ok(format!("Waiting for command [{name}] to finish"))
+                    Ok(EventDisplay::bare(format!(
+                        "Waiting for command [{name}] to finish"
+                    )))
                 } else {
-                    Ok("Waiting for dice".to_owned())
+                    Ok(EventDisplay::bare("Waiting for dice"))
                 }
             }
             Data::DeferredPreparationStage(prep) => {
@@ -367,7 +444,9 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                     .as_ref()
                     .ok_or_else(|| internal_error!("Missing `stage`"))?
                 {
-                    Stage::MaterializedArtifacts(_) => Ok("local_materialize_inputs".to_owned()),
+                    Stage::MaterializedArtifacts(_) => {
+                        Ok(EventDisplay::bare("local_materialize_inputs"))
+                    }
                 }
             }
             Data::DynamicLambda(lambda) => {
@@ -385,29 +464,33 @@ pub fn display_event(event: &BuckEvent, opts: TargetDisplayOptions) -> buck2_err
                     Owner::AnonTarget(anon_target) => display_anon_target(anon_target),
                 }?;
 
-                Ok(format!("{label} -- dynamic analysis"))
+                Ok(EventDisplay::labeled(label, "dynamic analysis"))
             }
-            Data::BxlExecution(execution) => {
-                Ok(format!("Executing BXL script `{}`", execution.name))
-            }
-            Data::BxlDiceInvocation(..) => Ok("Waiting for graph computations".to_owned()),
-            Data::ReUpload(..) => Ok("re_upload".to_owned()),
-            Data::ConnectToInstaller(buck2_data::ConnectToInstallerStart { tcp_port }) => {
-                Ok(format!("Connecting to installer on port {tcp_port}"))
-            }
-            Data::Fake(fake) => Ok(format!("{} -- speak of the devil", fake.caramba)),
+            Data::BxlExecution(execution) => Ok(EventDisplay::bare(format!(
+                "Executing BXL script `{}`",
+                execution.name
+            ))),
+            Data::BxlDiceInvocation(..) => Ok(EventDisplay::bare("Waiting for graph computations")),
+            Data::ReUpload(..) => Ok(EventDisplay::bare("re_upload")),
+            Data::ConnectToInstaller(buck2_data::ConnectToInstallerStart { tcp_port }) => Ok(
+                EventDisplay::bare(format!("Connecting to installer on port {tcp_port}")),
+            ),
+            Data::Fake(fake) => Ok(EventDisplay::labeled(
+                fake.caramba.clone(),
+                "speak of the devil",
+            )),
             Data::LocalResources(res) => {
                 let target = display_configured_target_label_opt(res.target_label.as_ref(), opts)?;
-                Ok(format!("{target} -- Local resources setup"))
+                Ok(EventDisplay::labeled(target, "Local resources setup"))
             }
-            Data::ReleaseLocalResources(..) => Ok("Releasing local resources".to_owned()),
+            Data::ReleaseLocalResources(..) => Ok(EventDisplay::bare("Releasing local resources")),
             Data::BxlEnsureArtifacts(..) => Err(ParseEventError::UnexpectedEvent.into()),
-            Data::ActionErrorHandlerExecution(..) => {
-                Ok("Running error handler on action failure".to_owned())
-            }
-            Data::CqueryUniverseBuild(..) => Ok("Building cquery universe".to_owned()),
+            Data::ActionErrorHandlerExecution(..) => Ok(EventDisplay::bare(
+                "Running error handler on action failure",
+            )),
+            Data::CqueryUniverseBuild(..) => Ok(EventDisplay::bare("Building cquery universe")),
             Data::ComputeDetailedAggregatedMetrics(..) => {
-                Ok("Computing detailed aggregated metrics".to_owned())
+                Ok(EventDisplay::bare("Computing detailed aggregated metrics"))
             }
         };
 

--- a/app/buck2_event_observer/src/re_state.rs
+++ b/app/buck2_event_observer/src/re_state.rs
@@ -8,18 +8,82 @@
  * above-listed licenses.
  */
 
+use std::fmt;
+
 use buck2_data::Snapshot;
 use superconsole::DrawMode;
 use superconsole::Line;
 use superconsole::Lines;
+use superconsole::Span;
+use superconsole::style::Stylize;
 
 use crate::humanized::HumanizedBytes;
 use crate::humanized::HumanizedBytesPerSecond;
 use crate::two_snapshots::TwoSnapshots;
 
 pub struct ReState {
-    session_id: Option<String>,
+    pub session_id: Option<String>,
     first_snapshot: Option<buck2_data::Snapshot>,
+}
+
+/// Traffic the command has moved, measured against its first snapshot.
+///
+/// Downloads aggregate RE and HTTP; uploads are RE only.
+pub struct NetworkStats {
+    pub re_upload_bytes: u64,
+    pub re_upload_bytes_per_second: u64,
+    pub download_bytes: u64,
+    pub download_bytes_per_second: u64,
+}
+
+pub struct ReHeaderLine<'a> {
+    stats: Option<NetworkStats>,
+    session_id: Option<&'a str>,
+    draw_mode: DrawMode,
+}
+
+impl fmt::Display for ReHeaderLine<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Network:")?;
+        let mut separator = " ";
+        if let Some(stats) = &self.stats {
+            match self.draw_mode {
+                DrawMode::Normal => write!(
+                    f,
+                    "{separator}up {} {}  down {} {}",
+                    HumanizedBytes::new(stats.re_upload_bytes),
+                    BytesPerSecond(stats.re_upload_bytes_per_second),
+                    HumanizedBytes::new(stats.download_bytes),
+                    BytesPerSecond(stats.download_bytes_per_second),
+                )?,
+                DrawMode::Final => write!(
+                    f,
+                    "{separator}up {}  down {}",
+                    HumanizedBytes::new(stats.re_upload_bytes),
+                    HumanizedBytes::new(stats.download_bytes),
+                )?,
+            }
+            separator = "  ";
+        }
+        if let Some(session_id) = self.session_id {
+            write!(f, "{separator}session {session_id}")?;
+        }
+        Ok(())
+    }
+}
+
+/// A transfer rate that renders as empty when zero, so idle directions stay blank
+/// in the header instead of showing `0 B/s`.
+struct BytesPerSecond(u64);
+
+impl fmt::Display for BytesPerSecond {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0 == 0 {
+            Ok(())
+        } else {
+            write!(f, "{}", HumanizedBytesPerSecond::new(self.0))
+        }
+    }
 }
 
 impl ReState {
@@ -44,88 +108,72 @@ impl ReState {
         &self.first_snapshot
     }
 
+    /// Returns [`None`] until snapshots exist, and for commands that have moved no bytes.
+    pub fn network_stats(&self, two_snapshots: &TwoSnapshots) -> Option<NetworkStats> {
+        let (Some(first), Some((_, last))) = (&self.first_snapshot, &two_snapshots.last) else {
+            return None;
+        };
+
+        if last.re_upload_bytes == 0 && last.re_download_bytes == 0 && last.http_download_bytes == 0
+        {
+            return None;
+        }
+
+        let re_upload_bytes = last.re_upload_bytes.checked_sub(first.re_upload_bytes)?;
+        let re_download_bytes = last
+            .re_download_bytes
+            .checked_sub(first.re_download_bytes)?;
+        let http_download_bytes = last
+            .http_download_bytes
+            .checked_sub(first.http_download_bytes)?;
+
+        Some(NetworkStats {
+            re_upload_bytes,
+            re_upload_bytes_per_second: two_snapshots
+                .re_upload_bytes_per_second()
+                .unwrap_or_default(),
+            download_bytes: re_download_bytes + http_download_bytes,
+            download_bytes_per_second: two_snapshots
+                .re_download_bytes_per_second()
+                .unwrap_or_default()
+                + two_snapshots
+                    .http_download_bytes_per_second()
+                    .unwrap_or_default(),
+        })
+    }
+
     pub fn render_header(
         &self,
         two_snapshots: &TwoSnapshots,
         draw_mode: DrawMode,
-    ) -> Option<String> {
-        let mut parts = Vec::new();
-
-        if let (Some(first), Some((_, last))) = (&self.first_snapshot, &two_snapshots.last) {
-            if last.re_upload_bytes > 0
-                || last.re_download_bytes > 0
-                || last.http_download_bytes > 0
-            {
-                let re_upload_bytes = last.re_upload_bytes.checked_sub(first.re_upload_bytes)?;
-                let re_download_bytes = last
-                    .re_download_bytes
-                    .checked_sub(first.re_download_bytes)?;
-                let http_download_bytes = last
-                    .http_download_bytes
-                    .checked_sub(first.http_download_bytes)?;
-
-                let part = match draw_mode {
-                    DrawMode::Normal => {
-                        fn format_byte_per_second(bytes_per_second: u64) -> String {
-                            if bytes_per_second == 0 {
-                                " ".repeat(HumanizedBytesPerSecond::FIXED_WIDTH_WIDTH)
-                            } else {
-                                HumanizedBytesPerSecond::fixed_width(bytes_per_second).to_string()
-                            }
-                        }
-
-                        let re_upload_bytes_per_second = two_snapshots
-                            .re_upload_bytes_per_second()
-                            .unwrap_or_default();
-                        let re_download_bytes_per_second = two_snapshots
-                            .re_download_bytes_per_second()
-                            .unwrap_or_default();
-                        let http_download_bytes_per_second = two_snapshots
-                            .http_download_bytes_per_second()
-                            .unwrap_or_default();
-                        format!(
-                            "Up: {} {}  Down: {} {}",
-                            HumanizedBytes::fixed_width(re_upload_bytes),
-                            format_byte_per_second(re_upload_bytes_per_second),
-                            HumanizedBytes::fixed_width(re_download_bytes + http_download_bytes),
-                            format_byte_per_second(
-                                re_download_bytes_per_second + http_download_bytes_per_second
-                            ),
-                        )
-                    }
-                    DrawMode::Final => {
-                        format!(
-                            "Up: {}  Down: {}",
-                            HumanizedBytes::new(re_upload_bytes),
-                            HumanizedBytes::new(re_download_bytes + http_download_bytes),
-                        )
-                    }
-                };
-                parts.push(part);
-            }
-        }
-
-        if let Some(session_id) = self.session_id.as_ref() {
-            parts.push(format!("({})", session_id.to_owned()));
-        }
-
-        if parts.is_empty() {
+    ) -> Option<ReHeaderLine<'_>> {
+        let stats = self.network_stats(two_snapshots);
+        let session_id = self.session_id.as_deref();
+        if stats.is_none() && session_id.is_none() {
             return None;
         }
-
-        Some(format!("Network: {}", parts.join("  ")))
+        Some(ReHeaderLine {
+            stats,
+            session_id,
+            draw_mode,
+        })
     }
 
-    fn render_detailed_item_no_progress_stats(
+    fn render_network_stat(
         &self,
         name: &str,
-        stat: u64,
-    ) -> buck2_error::Result<Option<Line>> {
-        let line = format!(
-            "{name:<20}: \
-            {stat:>5} bytes"
-        );
-        Ok(Some(Line::unstyled(&line)?))
+        bytes: u64,
+        bytes_per_second: u64,
+        draw_mode: DrawMode,
+    ) -> buck2_error::Result<Line> {
+        let mut stat = HumanizedBytes::new(bytes).to_string();
+        if let DrawMode::Normal = draw_mode {
+            if bytes_per_second > 0 {
+                stat.push(' ');
+                stat.push_str(&HumanizedBytesPerSecond::new(bytes_per_second).to_string());
+            }
+        }
+        Ok(Line::unstyled(&format!("{name:<20}: {stat:>5}"))?)
     }
 
     fn render_detailed_items(
@@ -171,8 +219,34 @@ impl ReState {
         Ok(Some(Line::unstyled(&line)?))
     }
 
-    fn render_detailed(&self, two_snapshots: &TwoSnapshots) -> buck2_error::Result<Vec<Line>> {
+    fn render_detailed(
+        &self,
+        two_snapshots: &TwoSnapshots,
+        draw_mode: DrawMode,
+    ) -> buck2_error::Result<Vec<Line>> {
         let mut r = Vec::new();
+        if self.session_id.is_some() || self.network_stats(two_snapshots).is_some() {
+            r.push(Line::from_iter([Span::new_styled_lossy(
+                "Network".to_owned().bold(),
+            )]));
+        }
+        if let Some(session_id) = self.session_id.as_ref() {
+            r.push(Line::unstyled(&format!("{:<20}: {session_id}", "session"))?);
+        }
+        if let Some(stats) = self.network_stats(two_snapshots) {
+            r.push(self.render_network_stat(
+                "up",
+                stats.re_upload_bytes,
+                stats.re_upload_bytes_per_second,
+                draw_mode,
+            )?);
+            r.push(self.render_network_stat(
+                "down",
+                stats.download_bytes,
+                stats.download_bytes_per_second,
+                draw_mode,
+            )?);
+        }
         if let (Some(first), Some((_, last))) = (&self.first_snapshot, &two_snapshots.last) {
             r.extend(self.render_detailed_items(
                 "re_uploads",
@@ -217,10 +291,12 @@ impl ReState {
                 last.re_get_digest_expirations_finished_with_error,
             )?);
             // TODO(raulgarcia4): Add some in-progress-stats for http metrics as well.
-            r.extend(self.render_detailed_item_no_progress_stats(
-                "http_download_bytes",
-                last.http_download_bytes - first.http_download_bytes,
-            )?);
+            let http_download_bytes = last.http_download_bytes - first.http_download_bytes;
+            r.push(Line::unstyled(&format!(
+                "{:<20}: \
+                {:>5} bytes",
+                "http_download_bytes", http_download_bytes
+            ))?);
 
             r.extend(self.render_local_cache_stat(
                 "local_artifact_cache",
@@ -239,14 +315,9 @@ impl ReState {
         detailed: bool,
         draw_mode: DrawMode,
     ) -> buck2_error::Result<Lines> {
-        let header = match self.render_header(two_snapshots, draw_mode) {
-            Some(header) => header,
-            None => return Ok(Lines::new()),
-        };
-        let mut lines = vec![Line::unstyled(&header)?];
         if detailed {
-            lines.extend(self.render_detailed(two_snapshots)?);
+            return Ok(Lines(self.render_detailed(two_snapshots, draw_mode)?));
         }
-        Ok(Lines(lines))
+        Ok(Lines::new())
     }
 }


### PR DESCRIPTION
Hi folks! I recently starting using Buck2 again (I didn't realize how much I missed it until I developed a moderately complicated build!). Anyways, I had some spare cycles and polished the superconsole TUI to be more consistent and bring out the latent tabular design. Screenshot of this in Ghostty below:

<img width="1202" height="959" alt="Screenshot 2026-07-03 at 6 29 44 PM" src="https://github.com/user-attachments/assets/ed7654f5-1c73-4051-89d9-b641a5e5a616" />

Here are the concrete changes:
1. The horizontal timed list separator is now drawn as a continuous line, using a box-drawing character (`─`, U+2500) instead of the hyphen.
2. Slow actions are colored by by active-execution stage, not total elapsed time. The red/yellow escalation is now keyed off on time executing within a stage, rather than the entire action. I'm not currently using remote caching _or_ execution, so a lot of actions would become red _way_ too often. As without remote execution/caching, most tasks are simply waiting in a queue, the (valuable!) yellow/red tinting lost all meaning due to its frequency and overuse.
3. Terminal resize events are now handled: subscribers get a `ConsoleInteraction` (consisting of toggle, key, resize), which is now used to immediately redraw the superconsole.
4. Restyled progress header. Few things:
    1. the phase lines now are now a table with a bold header row. Per-phase columns are moved into aligned columns.
    2. the network and session info are anchored to the top and remain there the entire build.
5. Superconsole spans are deduped and modeled using a `EventDisplay { label, detail,
category }` instead of a pre-flatted string like 1`"{label} -- {detail}"`. The rough before/after is below. Here are some notable changes:
    1. the target label is user's main terminal text color, the category/identifier are in surrounded in dimmed brackets, derived from the main color. The elapsed time and non-action are also dimmed, they are separated using a dimmed `·` separator.
    2. stage names are padded to a fixed width so their times align on a column basis.
    3. Truncation is per-cell using ellipses. The time column will *never* go away, but as the terminal window gets smaller, certain bits of data will be ellipsed. First, the subaction column, then the detail, then the target.
   4. Age-based warning colors only apply to the action, not the full row.
6. The action category is deduplicated against the target label. Actions that repeat the target's label now just show the category, identifiers that differ stay. This means an action that'd previously render like `pkg:foo [copy foo]` would now render as `pkg:foo [copy]`.

Before:
```
pkg:target -- action (category identifier) [prepare 5.0s]   10.0s
```

After:
```
pkg:target [category identifier] prepare         5.0s       10.0s
```

I don't recall how importing a PR into a phrabricator diff works, but these commits all should build independently.