### PR TITLE
fix: Enable more crates to build on windows

### DIFF
--- a/prelude/rust/tools/from_any_dir.py
+++ b/prelude/rust/tools/from_any_dir.py
@@ -51,6 +51,19 @@ def main():
     cc = list(filter(lambda arg: arg != "-Wl,-lomp", cc))
 
     os.chdir(args.cwd)
+    if os.name == "nt":
+        # os.exec* on Windows is a non-blocking _P_OVERLAY spawn: the parent
+        # process exits 0 immediately while the child (e.g. cl.bat / lib.bat)
+        # runs detached. A cc-rs buildscript then sees the compiler/archiver
+        # "succeed" with no object/archive produced yet, and fails at the
+        # hard-link of the never-created lib. Spawn and WAIT for the real exit
+        # code instead. (os.spawnv uses the same CRT launch that os.execl does,
+        # so it runs the .bat the same way -- just synchronously.)
+        try:
+            sys.exit(os.spawnv(os.P_WAIT, cc[0], cc))
+        except Exception:
+            print(f"spawn failed: {pformat(cc)}", file=sys.stderr)
+            raise
     try:
         os.execl(cc[0], cc[0], *cc[1:])
     except Exception:

--- a/prelude/utils/cmd_script.bzl
+++ b/prelude/utils/cmd_script.bzl
@@ -47,11 +47,21 @@ def cmd_script(
             has_content_based_path = has_content_based_path,
         )
     elif language == ScriptLanguage("bat"):
+        output = actions.declare_output("{}.bat".format(name), has_content_based_path = has_content_based_path)
+        # Resolve the wrapped command's artifact paths relative to the script's
+        # own location (%~dp0) rather than the process cwd. Otherwise a wrapper
+        # like cl.bat -- which invokes a repo-root-relative run_msvc_tool.py with
+        # no `cd` -- breaks when called from a different directory, e.g. through
+        # the rust buildscript from_any_dir shim, which chdir's to the
+        # buildscript's cwd before running $CC. The script deliberately does NOT
+        # cd, so any relative paths in the caller-supplied %* still resolve
+        # against the caller's cwd (as the from_any_dir shim requires).
+        positioned = cmd_args(cmd, relative_to = (output, 1), absolute_prefix = "%~dp0", **cmd_kwargs)
         wrapper, _ = actions.write(
-            actions.declare_output("{}.bat".format(name), has_content_based_path = has_content_based_path),
+            output,
             [
                 "@echo off",
-                cmd_args(cmd_args(shell_quoted, delimiter = "^\n "), format = "{} %*\n"),
+                cmd_args(cmd_args(positioned, delimiter = "^\n "), format = "{} %*\n"),
             ],
             allow_args = True,
             has_content_based_path = has_content_based_path,


### PR DESCRIPTION
Rust crates whose `build.rs` compiles C via `cc-rs` (wasmtime, secp256k1-sys, zstd-sys, …) fail on Windows with a misleading `cc-rs: Could not copy or create a hard-link to the generated lib file`. Two Windows-only prelude bugs cause it:

1. **`rust/tools/from_any_dir.py`** used `os.execl`, which on Windows is a non-blocking `_P_OVERLAY` spawn — the `$CC`/`$AR` shim returns 0 while `cl.bat`/`lib.bat` run detached, so cc-rs sees success with no output. Use `os.spawnv(os.P_WAIT)` on `nt`.

2. **`utils/cmd_script.bzl`** `.bat` wrappers invoke a repo-root-relative `run_msvc_tool.py` with no `cd`, so they break when `from_any_dir` chdir's to the buildscript cwd (`can't open file` → exit 2, which also makes cc-rs's family detection fall back to GNU). Resolve the payload via `%~dp0`, like `command_alias.bzl`. No `cd`, so caller-supplied `%*` still resolve against the caller's cwd.

Bug 1 masked Bug 2; both are needed. POSIX is unaffected (there `$CC` is a real compiler, not a `.bat` wrapper). Verified on `windows-latest`: a wasmtime build script that failed before now builds.

Testing proof: windows x86 build here: https://github.com/gilescope/buck2-fixups/pull/65

(AI assisted by Claude 4.8)