### PR TITLE
starlark: make typecheck and lint work with bundled external cells

### DIFF
--- a/app/buck2_cmd_starlark_server/src/lint.rs
+++ b/app/buck2_cmd_starlark_server/src/lint.rs
@@ -15,11 +15,10 @@ use async_trait::async_trait;
 use buck2_cli_proto::ClientContext;
 use buck2_cmd_starlark_client::lint::StarlarkLintCommand;
 use buck2_common::dice::cells::HasCellResolver;
-use buck2_common::dice::data::HasIoProvider;
-use buck2_common::io::IoProvider;
+use buck2_common::file_ops::dice::DiceFileComputations;
+use buck2_common::file_ops::error::FileReadErrorContext;
 use buck2_core::cells::CellResolver;
 use buck2_core::cells::name::CellName;
-use buck2_error::internal_error;
 use buck2_hash::StdBuckHashMap;
 use buck2_hash::StdBuckHashSet;
 use buck2_interpreter::file_type::StarlarkFileType;
@@ -73,16 +72,15 @@ impl<'a> Cache<'a> {
 async fn lint_file(
     path: &StarlarkPath<'_>,
     cell_resolver: &CellResolver,
-    io: &dyn IoProvider,
     cache: &mut Cache<'_>,
 ) -> buck2_error::Result<Vec<Lint>> {
     let dialect = path.file_type().dialect(false);
     let proj_path = cell_resolver.resolve_path(path.path().as_ref().as_ref())?;
     let path_str = proj_path.to_string();
-    let content = io
-        .read_file_if_exists(proj_path)
-        .await?
-        .ok_or_else(|| internal_error!("File not found: `{path_str}`"))?;
+    let content =
+        DiceFileComputations::read_file(&mut cache.dice.clone(), path.path().as_ref().as_ref())
+            .await
+            .without_package_context_information()?;
     match AstModule::parse(&path_str, content.clone(), &dialect) {
         Ok(ast) => Ok(ast.lint(Some(&*cache.get_names(path).await?))),
         Err(err) => {
@@ -113,16 +111,15 @@ impl StarlarkServerSubcommand for StarlarkLintCommand {
         server_ctx
             .with_dice_ctx(|server_ctx, mut ctx| async move {
                 let cell_resolver = &ctx.get_cell_resolver().await?;
-                let io = &ctx.global_data().get_io_provider();
 
                 let mut stdout = stdout.as_writer();
                 let mut lint_count = 0;
                 let files =
-                    starlark_files(&mut ctx, &self.paths, server_ctx, cell_resolver, &**io).await?;
+                    starlark_files(&mut ctx, &self.paths, server_ctx, cell_resolver).await?;
                 let mut cache = Cache::new(&ctx);
 
                 for file in &files {
-                    let lints = lint_file(&file.borrow(), cell_resolver, &**io, &mut cache).await?;
+                    let lints = lint_file(&file.borrow(), cell_resolver, &mut cache).await?;
                     lint_count += lints.len();
                     for lint in lints {
                         writeln!(stdout, "{lint}")?;

--- a/app/buck2_cmd_starlark_server/src/typecheck.rs
+++ b/app/buck2_cmd_starlark_server/src/typecheck.rs
@@ -15,12 +15,10 @@ use async_trait::async_trait;
 use buck2_cli_proto::ClientContext;
 use buck2_cmd_starlark_client::typecheck::StarlarkTypecheckCommand;
 use buck2_common::dice::cells::HasCellResolver;
-use buck2_common::dice::data::HasIoProvider;
-use buck2_common::io::IoProvider;
-use buck2_core::cells::CellResolver;
+use buck2_common::file_ops::dice::DiceFileComputations;
+use buck2_common::file_ops::error::FileReadErrorContext;
 use buck2_core::cells::name::CellName;
 use buck2_error::buck2_error;
-use buck2_error::internal_error;
 use buck2_hash::StdBuckHashMap;
 use buck2_interpreter::file_type::StarlarkFileType;
 use buck2_interpreter::paths::module::OwnedStarlarkModulePath;
@@ -43,8 +41,6 @@ use crate::util::paths::starlark_files;
 struct Cache<'a> {
     // Things we have access to get information
     dice: &'a DiceTransaction,
-    io: &'a dyn IoProvider,
-    cell_resolver: &'a CellResolver,
     // Things we have access to write information
     stdout: &'a mut (dyn Write + Send + Sync),
     stderr: &'a mut (dyn Write + Send + Sync),
@@ -91,17 +87,11 @@ impl Cache<'_> {
     async fn run(&mut self, path: OwnedStarlarkPath) -> buck2_error::Result<Interface> {
         let path_ref = path.borrow();
         writeln!(self.stderr, "Type checking: {path_ref}")?;
-        let proj_path = self
-            .cell_resolver
-            .resolve_path(path_ref.path().as_ref().as_ref())?;
-        let path_str = proj_path.to_string();
-        let src = self
-            .io
-            .read_file_if_exists(proj_path)
-            .await?
-            .ok_or_else(|| internal_error!("File not found: `{path_str}`"))?;
 
         let mut dice = self.dice.clone();
+        let src = DiceFileComputations::read_file(&mut dice, path_ref.path().as_ref().as_ref())
+            .await
+            .without_package_context_information()?;
         let interp = dice
             .get_interpreter_calculator(OwnedStarlarkPath::new(path_ref))
             .await?;
@@ -154,17 +144,13 @@ impl StarlarkServerSubcommand for StarlarkTypecheckCommand {
         Ok(server_ctx
             .with_dice_ctx(|server_ctx, mut dice| async move {
                 let cell_resolver = &dice.get_cell_resolver().await?;
-                let io = &dice.global_data().get_io_provider();
 
                 let files =
-                    starlark_files(&mut dice, &self.paths, server_ctx, cell_resolver, &**io)
-                        .await?;
+                    starlark_files(&mut dice, &self.paths, server_ctx, cell_resolver).await?;
                 let mut stdout = stdout.as_writer();
                 let mut stderr = server_ctx.stderr()?;
                 let mut cache = Cache {
                     dice: &dice,
-                    io: &**io,
-                    cell_resolver,
                     stdout: &mut stdout,
                     stderr: &mut stderr,
                     oracle: StdBuckHashMap::default(),

--- a/app/buck2_cmd_starlark_server/src/util/paths.rs
+++ b/app/buck2_cmd_starlark_server/src/util/paths.rs
@@ -15,14 +15,12 @@ use buck2_client_ctx::path_arg::PathArg;
 use buck2_common::file_ops::dice::DiceFileComputations;
 use buck2_common::file_ops::metadata::FileType;
 use buck2_common::file_ops::metadata::RawPathMetadata;
-use buck2_common::io::IoProvider;
 use buck2_core::build_file_path::BuildFilePath;
 use buck2_core::bxl::BxlFilePath;
 use buck2_core::bzl::ImportPath;
 use buck2_core::cells::CellResolver;
-use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
+use buck2_core::cells::cell_path::CellPath;
 use buck2_core::package::PackageLabel;
-use buck2_fs::paths::file_name::FileName;
 use buck2_interpreter::paths::package::PackageFilePath;
 use buck2_interpreter::paths::path::OwnedStarlarkPath;
 use buck2_server_ctx::ctx::ServerCommandContextTrait;
@@ -33,23 +31,20 @@ use dupe::Dupe;
 #[buck2(tag = Input)]
 enum StarlarkFilesError {
     #[error("File not found, `{0}`")]
-    FileNotFound(ProjectRelativePathBuf),
+    FileNotFound(CellPath),
     #[error("Symlinks and other esoteric files are not supported, `{0}`")]
-    UnsupportedFileType(ProjectRelativePathBuf),
+    UnsupportedFileType(CellPath),
 }
 
 #[async_recursion]
 async fn starlark_file(
     ctx: &mut DiceComputations<'_>,
-    proj_path: ProjectRelativePathBuf,
+    cell_path: CellPath,
     // None = this file was given explicitly
     // Some = it was a directory traversal (and we know its type)
     recursive: Option<FileType>,
-    cell_resolver: &CellResolver,
-    io: &dyn IoProvider,
     files: &mut Vec<OwnedStarlarkPath>,
 ) -> buck2_error::Result<()> {
-    let cell_path = cell_resolver.get_cell_path(&proj_path);
     if recursive.is_some()
         && DiceFileComputations::is_ignored(ctx, cell_path.as_ref())
             .await?
@@ -61,36 +56,33 @@ async fn starlark_file(
 
     let typ = match &recursive {
         Some(typ) => typ.dupe(),
-        None => match io.read_path_metadata_if_exists(proj_path.clone()).await? {
-            None => {
-                return Err(StarlarkFilesError::FileNotFound(proj_path).into());
+        None => {
+            match DiceFileComputations::read_path_metadata_if_exists(ctx, cell_path.as_ref())
+                .await?
+            {
+                None => {
+                    return Err(StarlarkFilesError::FileNotFound(cell_path).into());
+                }
+                Some(RawPathMetadata::Directory) => FileType::Directory,
+                Some(RawPathMetadata::File(_)) => FileType::File,
+                Some(RawPathMetadata::Symlink { .. }) => FileType::Symlink,
             }
-            Some(RawPathMetadata::Directory) => FileType::Directory,
-            Some(RawPathMetadata::File(_)) => {
-                // It's a shame we throw away the digest we calculated, but not a huge deal (its cheap compared to parsing)
-                FileType::File
-            }
-            Some(RawPathMetadata::Symlink { .. }) => FileType::Symlink,
-        },
+        }
     };
 
     match typ {
         FileType::Directory => {
-            for x in io.read_dir(proj_path.clone()).await?.into_entries() {
-                let Ok(file_name) = FileName::new(&x.file_name) else {
-                    // Skip files which buck does not like:
-                    // this function works with `CellPath` values,
-                    // which cannot be constructed from paths not acceptable by buck.
-                    continue;
-                };
-                let mut child_path = proj_path.clone();
-                child_path.push(file_name);
-                starlark_file(ctx, child_path, Some(x.file_type), cell_resolver, io, files).await?;
+            for entry in DiceFileComputations::read_dir(ctx, cell_path.as_ref())
+                .await?
+                .included
+                .iter()
+            {
+                let child_path = cell_path.join(&entry.file_name);
+                starlark_file(ctx, child_path, Some(entry.file_type.dupe()), files).await?;
             }
         }
         FileType::File => {
-            // It's a shame we throw away the digest we calculated, but not a huge deal (its cheap compared to parsing)
-            let is_buildfile = match proj_path.file_name() {
+            let is_buildfile = match cell_path.path().file_name() {
                 None => false,
                 Some(file_name) => DiceFileComputations::buildfiles(ctx, cell_path.cell())
                     .await?
@@ -101,13 +93,13 @@ async fn starlark_file(
             if is_buildfile {
                 files.push(OwnedStarlarkPath::BuildFile(BuildFilePath::new(
                     PackageLabel::from_cell_path(cell_path.parent().unwrap())?,
-                    proj_path.file_name().unwrap().to_owned(),
+                    cell_path.path().file_name().unwrap().to_owned(),
                 )));
-            } else if proj_path.as_str().ends_with(".bxl") {
+            } else if cell_path.path().as_str().ends_with(".bxl") {
                 files.push(OwnedStarlarkPath::BxlFile(BxlFilePath::new(cell_path)?));
             } else if let Some(path) = PackageFilePath::from_file_path(cell_path.as_ref()) {
                 files.push(OwnedStarlarkPath::PackageFile(path));
-            } else if recursive.is_none() || proj_path.as_str().ends_with(".bzl") {
+            } else if recursive.is_none() || cell_path.path().as_str().ends_with(".bzl") {
                 // If a file was asked for explicitly, and is nothing else, treat it as .bzl file
                 // If it's not explicit, just ignore it (probably a source file)
                 files.push(OwnedStarlarkPath::LoadFile(ImportPath::new_same_cell(
@@ -117,7 +109,7 @@ async fn starlark_file(
         }
         FileType::Symlink | FileType::Unknown => {
             if recursive.is_none() {
-                return Err(StarlarkFilesError::UnsupportedFileType(proj_path).into());
+                return Err(StarlarkFilesError::UnsupportedFileType(cell_path).into());
             }
         }
     }
@@ -130,15 +122,13 @@ pub(crate) async fn starlark_files(
     paths: &[PathArg],
     context: &dyn ServerCommandContextTrait,
     cell_resolver: &CellResolver,
-    io: &dyn IoProvider,
 ) -> buck2_error::Result<Vec<OwnedStarlarkPath>> {
     let mut files = Vec::new();
 
     for path in paths {
         let path = path.resolve(context.working_dir_abs());
         let cell_path = cell_resolver.get_cell_path_from_abs_path(&path, context.project_root())?;
-        let proj_path = cell_resolver.resolve_path(cell_path.as_ref())?;
-        starlark_file(ctx, proj_path, None, cell_resolver, io, &mut files).await?;
+        starlark_file(ctx, cell_path, None, &mut files).await?;
     }
     Ok(files)
 }

--- a/tests/core/starlark_command/test_lint_and_typecheck.py
+++ b/tests/core/starlark_command/test_lint_and_typecheck.py
@@ -29,3 +29,16 @@ async def test_typecheck_fails(buck: Buck) -> None:
         buck.starlark("typecheck", "bad.bzl"),
         stderr_regex="Detected 2 errors",
     )
+
+
+@buck_test()
+async def test_typecheck_bundled_cell(buck: Buck) -> None:
+    # Files in bundled external cells do not exist on disk; check that they
+    # are read through the file ops that know how to materialize them.
+    await buck.starlark("typecheck", "uses_prelude.bzl")
+    await buck.starlark("typecheck", "nano_prelude/prelude.bzl")
+
+
+@buck_test()
+async def test_lint_bundled_cell(buck: Buck) -> None:
+    await buck.starlark("lint", "nano_prelude")

--- a/tests/core/starlark_command/test_lint_and_typecheck_data/.buckconfig
+++ b/tests/core/starlark_command/test_lint_and_typecheck_data/.buckconfig
@@ -1,2 +1,6 @@
 [cells]
   root = .
+  nano_prelude = nano_prelude
+
+[external_cells]
+  nano_prelude = bundled

--- a/tests/core/starlark_command/test_lint_and_typecheck_data/uses_prelude.bzl
+++ b/tests/core/starlark_command/test_lint_and_typecheck_data/uses_prelude.bzl
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+load("@nano_prelude//:asserts.bzl", "asserts")
+
+def check_asserts() -> None:
+    asserts.true(True)


### PR DESCRIPTION
The starlark typecheck and lint commands resolved each file to a
project-relative path and read it straight off disk via the IoProvider.
Files in bundled external cells (e.g. the bundled prelude) do not exist
on disk, so typechecking anything that loads from the prelude failed
with "File not found: prelude/prelude.bzl (internal error)".

Read file contents, path metadata, and directory listings through
DiceFileComputations instead, whose per-cell delegate knows how to
serve external cells, matching what the interpreter does when
evaluating these files. As a bonus, the DICE read_dir returns validated
file names, so the manual skip of buck-incompatible names goes away.
