### PR TITLE
starlark: typecheck against the implicit globals from the prelude

### DIFF
--- a/app/buck2_cmd_starlark_server/src/typecheck.rs
+++ b/app/buck2_cmd_starlark_server/src/typecheck.rs
@@ -67,9 +67,10 @@ impl Cache<'_> {
         match self.oracle.get(&(cell, path_type)) {
             Some(g) => Ok(g.dupe()),
             None => {
-                let globals = Environment::new(cell, path_type, &mut self.dice.clone())
-                    .await?
-                    .globals;
+                let env = Environment::new(cell, path_type, &mut self.dice.clone()).await?;
+                let globals = env
+                    .globals_with_implicit_symbols(path_type, self.dice)
+                    .await?;
                 self.oracle.insert((cell, path_type), globals.dupe());
                 Ok(globals)
             }

--- a/app/buck2_cmd_starlark_server/src/util/environment.rs
+++ b/app/buck2_cmd_starlark_server/src/util/environment.rs
@@ -11,6 +11,7 @@
 use buck2_core::bzl::ImportPath;
 use buck2_core::cells::build_file_cell::BuildFileCell;
 use buck2_core::cells::name::CellName;
+use buck2_error::conversion::from_any_with_tag;
 use buck2_hash::StdBuckHashSet;
 use buck2_interpreter::file_type::StarlarkFileType;
 use buck2_interpreter::import_paths::HasImportPaths;
@@ -18,7 +19,10 @@ use buck2_interpreter::load_module::INTERPRETER_CALCULATION_IMPL;
 use buck2_interpreter::load_module::InterpreterCalculation;
 use buck2_interpreter::prelude_path::PreludePath;
 use dice::DiceTransaction;
+use dupe::Dupe;
+use starlark::environment::FrozenModule;
 use starlark::environment::Globals;
+use starlark::environment::GlobalsBuilder;
 
 /// The environment in which a Starlark file is evaluated.
 pub(crate) struct Environment {
@@ -68,6 +72,51 @@ impl Environment {
         })
     }
 
+    /// The globals plus everything the interpreter injects into the module
+    /// scope before evaluation: the prelude's public symbols, and for BUCK
+    /// files the members of the prelude's `native` struct and the root
+    /// implicit import. The typechecker derives types from the actual values,
+    /// so rules get their attribute-based signatures.
+    pub(crate) async fn globals_with_implicit_symbols(
+        &self,
+        path_type: StarlarkFileType,
+        dice: &DiceTransaction,
+    ) -> buck2_error::Result<Globals> {
+        if self.prelude.is_none() && self.preload.is_none() {
+            return Ok(self.globals.dupe());
+        }
+        let mut dice = dice.clone();
+
+        let mut builder = GlobalsBuilder::new();
+        builder.frozen_heap().add_reference(self.globals.heap());
+        for (name, value) in self.globals.iter() {
+            builder.set(name, value);
+        }
+
+        if let Some(prelude) = &self.prelude {
+            let m = dice
+                .get_loaded_module_from_import_path(prelude.import_path())
+                .await?;
+            add_module_symbols(&mut builder, m.env())?;
+            if path_type == StarlarkFileType::Buck {
+                builder.frozen_heap().add_reference(m.env().frozen_heap());
+                for (name, value) in m.extra_globals_from_prelude_for_buck_files()? {
+                    builder.set(name, value);
+                }
+            }
+        }
+
+        // The root implicit import is only injected into BUCK files.
+        if path_type == StarlarkFileType::Buck
+            && let Some(preload) = &self.preload
+        {
+            let m = dice.get_loaded_module_from_import_path(preload).await?;
+            add_module_symbols(&mut builder, m.env())?;
+        }
+
+        Ok(builder.build())
+    }
+
     pub(crate) async fn get_names(
         &self,
         path_type: StarlarkFileType,
@@ -103,4 +152,19 @@ impl Environment {
 
         Ok(names)
     }
+}
+
+/// Add a module's public symbols to the globals, the same way
+/// `Module::import_public_symbols` injects them before evaluation.
+fn add_module_symbols(builder: &mut GlobalsBuilder, env: &FrozenModule) -> buck2_error::Result<()> {
+    for name in env.names() {
+        let Some(value) = env
+            .get_option(name.as_str())
+            .map_err(|e| from_any_with_tag(e, buck2_error::ErrorTag::Interpreter))?
+        else {
+            continue;
+        };
+        builder.set(name.as_str(), value);
+    }
+    Ok(())
 }

--- a/starlark-rust/starlark/src/typing/typecheck.rs
+++ b/starlark-rust/starlark/src/typing/typecheck.rs
@@ -244,7 +244,19 @@ impl AstModuleTypecheck for AstModule {
         let mut all_solve_errors = Vec::new();
 
         for top in cst.iter_mut() {
-            if let StmtP::Def(_) = &mut top.node {
+            // Besides functions, also solve the top-level statements that
+            // `fill_types_for_lint_typechecker` does not check: expression
+            // statements and the bodies of `if` and `for` statements.
+            // Assignments and loads are handled by the fill pass itself.
+            let solve = matches!(
+                &top.node,
+                StmtP::Def(_)
+                    | StmtP::Expression(_)
+                    | StmtP::If(..)
+                    | StmtP::IfElse(..)
+                    | StmtP::For(..)
+            );
+            if solve {
                 let bindings = match BindingsCollect::collect_one(
                     top,
                     TypecheckMode::Lint,

--- a/tests/core/starlark_command/test_typecheck_implicit_globals.py
+++ b/tests/core/starlark_command/test_typecheck_implicit_globals.py
@@ -1,0 +1,30 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# pyre-strict
+
+
+from buck2.tests.e2e_util.api.buck import Buck
+from buck2.tests.e2e_util.asserts import expect_failure
+from buck2.tests.e2e_util.buck_workspace import buck_test
+
+
+@buck_test()
+async def test_typecheck_build_file(buck: Buck) -> None:
+    # Rule names in build files come from the implicit prelude import; rule
+    # calls are typechecked against their attribute-derived signatures.
+    await buck.starlark("typecheck", "TARGETS.fixture")
+    await expect_failure(
+        buck.starlark("typecheck", "bad/TARGETS.fixture"),
+        stderr_regex="Detected 1 errors",
+    )
+
+
+@buck_test()
+async def test_typecheck_implicit_prelude_symbols_in_bzl(buck: Buck) -> None:
+    await buck.starlark("typecheck", "implicit.bzl")

--- a/tests/core/starlark_command/test_typecheck_implicit_globals_data/.buckconfig
+++ b/tests/core/starlark_command/test_typecheck_implicit_globals_data/.buckconfig
@@ -1,0 +1,12 @@
+[cells]
+  root = .
+  nano_prelude = nano_prelude
+
+[cell_aliases]
+  prelude = nano_prelude
+
+[external_cells]
+  nano_prelude = bundled
+
+[buildfile]
+  name = TARGETS.fixture

--- a/tests/core/starlark_command/test_typecheck_implicit_globals_data/TARGETS.fixture
+++ b/tests/core/starlark_command/test_typecheck_implicit_globals_data/TARGETS.fixture
@@ -1,0 +1,6 @@
+stub(
+    name = "s",
+    deps = [":t"],
+)
+
+trivial_build(name = "t")

--- a/tests/core/starlark_command/test_typecheck_implicit_globals_data/bad/TARGETS.fixture
+++ b/tests/core/starlark_command/test_typecheck_implicit_globals_data/bad/TARGETS.fixture
@@ -1,0 +1,4 @@
+stub(
+    name = "s",
+    dpes = [],
+)

--- a/tests/core/starlark_command/test_typecheck_implicit_globals_data/implicit.bzl
+++ b/tests/core/starlark_command/test_typecheck_implicit_globals_data/implicit.bzl
@@ -1,0 +1,11 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# `asserts` comes from the implicit prelude import, not a `load`.
+def check() -> None:
+    asserts.true(True)


### PR DESCRIPTION
The typecheck oracle only contained the native globals, so any name the
interpreter injects into the module scope was reported as not found:
the prelude's public symbols, the members of the prelude's `native`
struct in BUCK files, and the root implicit import. This made it
impossible to typecheck BUCK files or .bzl files that use prelude
symbols without loading them.

Extend the oracle globals with those symbols, taking the values from
the evaluated prelude module. The typechecker derives types from the
actual frozen values, so rule calls are checked against their
attribute-based signatures, including select() unions and
required/optional parameters.

That alone is not enough for BUCK files: the typechecker only ran the
binding solver on top-level `def` statements, and the lint fill pass
skips calls, so top-level rule calls were still unchecked. Run the
solver on top-level expression, `if` and `for` statements as well. The
fill pass does not check those, so nothing is reported twice;
assignments and loads stay with the fill pass.

Calls in top-level assignments are still unchecked, since the fill
pass evaluates those and returns Any for calls.