### PR TITLE
fs: allow backslashes in paths via buckconfig

### DIFF
--- a/app/buck2_client_ctx/src/immediate_config.rs
+++ b/app/buck2_client_ctx/src/immediate_config.rs
@@ -32,6 +32,7 @@ use buck2_fs::fs_util;
 use buck2_fs::paths::abs_norm_path::AbsNormPath;
 use buck2_fs::paths::abs_norm_path::AbsNormPathBuf;
 use buck2_fs::paths::abs_path::AbsPath;
+use buck2_fs::paths::init_allow_backslashes_in_paths;
 use buck2_fs::working_dir::AbsWorkingDir;
 use prost::Message;
 
@@ -59,6 +60,10 @@ impl ImmediateConfig {
             &[],
         ))?;
 
+        let daemon_startup_config = DaemonStartupConfig::new(&cells.root_config, &settings)
+            .buck_error_context("Error loading daemon startup config")?;
+        init_allow_backslashes_in_paths(daemon_startup_config.allow_backslashes_in_paths)?;
+
         let cwd_cell_alias_resolver = futures::executor::block_on(
             cells.get_cell_alias_resolver_for_cwd_fast(&roots.project_root, &roots.cwd),
         )?;
@@ -66,8 +71,7 @@ impl ImmediateConfig {
         Ok(ImmediateConfig {
             cell_resolver: cells.cell_resolver,
             cwd_cell_alias_resolver,
-            daemon_startup_config: DaemonStartupConfig::new(&cells.root_config, &settings)
-                .buck_error_context("Error loading daemon startup config")?,
+            daemon_startup_config,
             #[cfg(fbcode_build)]
             allow_daemon_start_unsandboxed_via_wrapper: cells
                 .root_config

--- a/app/buck2_common/src/init.rs
+++ b/app/buck2_common/src/init.rs
@@ -590,6 +590,9 @@ pub struct DaemonStartupConfig {
     pub retained_event_logs: usize,
     pub macos_qos_class: Option<String>,
     pub daemon_idle_timeout_s: Option<u64>,
+    /// Whether paths may contain literal backslashes on platforms where a backslash is not a path
+    /// separator. Fixed for the daemon lifetime because it changes path-type invariants.
+    pub allow_backslashes_in_paths: bool,
     /// Pagable DICE storage settings, or `None` when paging is disabled.
     pub hydration: Option<HydrationConfig>,
 }
@@ -709,6 +712,12 @@ impl DaemonStartupConfig {
                 section: "buck2",
                 property: "daemon_idle_timeout_s",
             })?,
+            allow_backslashes_in_paths: config
+                .parse(BuckconfigKeyRef {
+                    section: "buck2",
+                    property: "allow_backslashes_in_paths",
+                })?
+                .unwrap_or(false),
             hydration: HydrationConfig::from_config(config)?,
         })
     }
@@ -741,6 +750,7 @@ impl DaemonStartupConfig {
             retained_event_logs: DEFAULT_RETAINED_EVENT_LOGS,
             macos_qos_class: None,
             daemon_idle_timeout_s: None,
+            allow_backslashes_in_paths: false,
             hydration: None,
         }
     }
@@ -777,6 +787,31 @@ mod tests {
         )?;
         let startup_config = DaemonStartupConfig::new(&config, &BuckSettings::empty())?;
         assert_eq!(startup_config.daemon_idle_timeout_s, Some(10800));
+        Ok(())
+    }
+
+    #[test]
+    fn test_allow_backslashes_in_paths() -> buck2_error::Result<()> {
+        let default = parse(&[("config", indoc!(r#""#))], "config")?;
+        assert!(
+            !DaemonStartupConfig::new(&default, &BuckSettings::empty())?.allow_backslashes_in_paths
+        );
+
+        let enabled = parse(
+            &[(
+                "config",
+                indoc!(
+                    r#"
+                    [buck2]
+                    allow_backslashes_in_paths = true
+                    "#
+                ),
+            )],
+            "config",
+        )?;
+        assert!(
+            DaemonStartupConfig::new(&enabled, &BuckSettings::empty())?.allow_backslashes_in_paths
+        );
         Ok(())
     }
 }

--- a/app/buck2_fs/src/paths.rs
+++ b/app/buck2_fs/src/paths.rs
@@ -23,6 +23,8 @@
 //! of either `/` or some  windows root directory like `c:`. These behave
 //! roughly like 'Path'.
 
+use std::sync::OnceLock;
+
 pub mod abs_norm_path;
 pub mod abs_path;
 pub mod cmp_impls;
@@ -37,3 +39,59 @@ pub use into_filename_buf_iterator::IntoFileNameBufIterator;
 
 pub use self::relative_path::RelativePath;
 pub use self::relative_path::RelativePathBuf;
+
+static ALLOW_BACKSLASHES_IN_PATHS: OnceLock<bool> = OnceLock::new();
+
+/// Initializes the process-wide path policy from the daemon startup configuration.
+///
+/// Client and daemon initialization share a process under `--no-buckd`, so setting the same value
+/// more than once is allowed. A conflicting value would let one process mix path invariants and is
+/// therefore rejected.
+pub fn init_allow_backslashes_in_paths(value: bool) -> buck2_error::Result<()> {
+    init_allow_backslashes_in_paths_impl(&ALLOW_BACKSLASHES_IN_PATHS, value)
+}
+
+fn init_allow_backslashes_in_paths_impl(
+    cell: &OnceLock<bool>,
+    value: bool,
+) -> buck2_error::Result<()> {
+    let initialized = *cell.get_or_init(|| value);
+    if initialized == value {
+        Ok(())
+    } else {
+        Err(buck2_error::buck2_error!(
+            buck2_error::ErrorTag::Tier0,
+            "Backslash path policy is already initialized to `{initialized}`, cannot set it to \
+             `{value}`"
+        ))
+    }
+}
+
+/// A backslash is a path separator on Windows, so it is always rejected there. On other
+/// platforms it is a valid path character, but is rejected by default to keep paths portable.
+pub(crate) fn backslash_allowed() -> bool {
+    effective_backslash_policy(ALLOW_BACKSLASHES_IN_PATHS.get().copied().unwrap_or(false))
+}
+
+fn effective_backslash_policy(configured: bool) -> bool {
+    !cfg!(windows) && configured
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backslash_policy_initialization_is_idempotent_but_not_mutable() {
+        let policy = OnceLock::new();
+        assert!(init_allow_backslashes_in_paths_impl(&policy, false).is_ok());
+        assert!(init_allow_backslashes_in_paths_impl(&policy, false).is_ok());
+        assert!(init_allow_backslashes_in_paths_impl(&policy, true).is_err());
+    }
+
+    #[test]
+    fn backslashes_are_never_literal_path_characters_on_windows() {
+        assert!(!effective_backslash_policy(false));
+        assert_eq!(effective_backslash_policy(true), !cfg!(windows));
+    }
+}

--- a/app/buck2_fs/src/paths/file_name.rs
+++ b/app/buck2_fs/src/paths/file_name.rs
@@ -25,6 +25,7 @@ use ref_cast::RefCast;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::paths::backslash_allowed;
 use crate::paths::forward_rel_path::ForwardRelativePath;
 use crate::paths::relative_path::RelativePath;
 
@@ -44,22 +45,27 @@ enum FileNameError {
     NotUnicode(OsString),
 }
 
-fn verify_file_name(file_name: &str) -> buck2_error::Result<()> {
+fn verify_file_name_with_policy(
+    file_name: &str,
+    allow_backslashes: bool,
+) -> buck2_error::Result<()> {
     if file_name.is_empty() {
         Err(FileNameError::Empty.into())
     } else if file_name == "." {
         Err(FileNameError::Dot.into())
     } else if file_name == ".." {
         Err(FileNameError::DotDot.into())
-    } else if file_name.contains('/') || file_name.contains('\\') {
-        // Note we do not allow backslashes in file names
-        // even if it is valid file name on Linux.
+    } else if file_name.contains('/') || (file_name.contains('\\') && !allow_backslashes) {
         Err(FileNameError::Slashes(file_name.to_owned()).into())
     } else {
         // At the moment we allow characters like '\0'
         // even if they are not valid at least on Linux.
         Ok(())
     }
+}
+
+fn verify_file_name(file_name: &str) -> buck2_error::Result<()> {
+    verify_file_name_with_policy(file_name, backslash_allowed())
 }
 
 /// File name. Cannot be empty, cannot contain slashes, '.' or '..'.
@@ -128,6 +134,9 @@ impl AsRef<ForwardRelativePath> for FileName {
 impl FileName {
     /// Creates an `FileName` if the given path represents a correct
     /// platform-independent file name, otherwise error.
+    ///
+    /// A backslash is rejected by default; `[buck2] allow_backslashes_in_paths = true`
+    /// allows it on platforms where it is not a path separator.
     ///
     /// ```
     /// use buck2_fs::paths::file_name::FileName;
@@ -390,5 +399,17 @@ impl TryFrom<CompactString> for FileNameBuf {
     fn try_from(value: CompactString) -> buck2_error::Result<FileNameBuf> {
         verify_file_name(value.as_str())?;
         Ok(FileNameBuf(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backslash_policy() {
+        assert!(verify_file_name_with_policy("foo\\bar", false).is_err());
+        assert!(verify_file_name_with_policy("foo\\bar", true).is_ok());
+        assert!(verify_file_name_with_policy("foo/bar", true).is_err());
     }
 }

--- a/app/buck2_fs/src/paths/forward_rel_path.rs
+++ b/app/buck2_fs/src/paths/forward_rel_path.rs
@@ -1214,7 +1214,7 @@ impl TryFrom<PathBuf> for ForwardRelativePathBuf {
     /// ```
     fn try_from(p: PathBuf) -> buck2_error::Result<ForwardRelativePathBuf> {
         // `RelativePathBuf::from_system_path` would allocate a copy. Avoid it by going through
-        // `OsString::into_string` and letting the string verifier reject any backslashes.
+        // `OsString::into_string` and validating the resulting string directly.
         ForwardRelativePathBuf::try_from(p.into_os_string().into_string().map_err(|os| {
             ForwardRelativePathError::PathNotUtf8(os.to_string_lossy().into_owned())
         })?)

--- a/app/buck2_fs/src/paths/relative_path.rs
+++ b/app/buck2_fs/src/paths/relative_path.rs
@@ -10,10 +10,13 @@
 
 //! Platform-agnostic, UTF-8, relative paths.
 //!
-//! A `RelativePath` is a `str`-backed path that always uses `/` as a separator. Backslashes are
-//! rejected on every platform — they are not treated as path separators here, just as in
-//! [`ForwardRelativePath`](crate::paths::forward_rel_path::ForwardRelativePath). `.` and `..`
-//! components and empty components (consecutive `/`) are still permitted.
+//! A `RelativePath` is a `str`-backed path that always uses `/` as a separator. A backslash is
+//! never treated as a separator, just as in
+//! [`ForwardRelativePath`](crate::paths::forward_rel_path::ForwardRelativePath). Backslashes are
+//! rejected by default; setting `[buck2] allow_backslashes_in_paths = true` allows them on
+//! platforms other than Windows, where they are valid path characters (e.g. systemd's escaped
+//! unit names).
+//! `.` and `..` components and empty components (consecutive `/`) are still permitted.
 //!
 //! Use [`ForwardRelativePath`](crate::paths::forward_rel_path::ForwardRelativePath) when the
 //! stronger "no `.`/`..`, no leading `/`" invariant is required; `RelativePath` is the looser form
@@ -45,6 +48,7 @@ use serde::Deserializer;
 use serde::Serialize;
 use strong_hash::StrongHash;
 
+use crate::paths::backslash_allowed;
 use crate::paths::file_name::FileName;
 
 const SEP: char = '/';
@@ -98,20 +102,18 @@ impl RelativePath {
 
     /// Wraps `s` as a `RelativePath`.
     ///
-    /// This function rejects paths that do not meet our standard path requirements, eg `\\` in
-    /// components, non `/` seperators, etc.. It should *not* be used to convert paths you got from
-    /// the OS; use `from_system_path` for that, which will handle all the typical platform
-    /// weirdness.
+    /// This function rejects paths that do not meet our standard path requirements, eg non-`/`
+    /// separators (`\\` on Windows), absolute paths, etc.. It should *not* be used to convert
+    /// paths you got from the OS; use `from_system_path` for that, which will handle all the
+    /// typical platform weirdness.
     #[inline]
     pub fn new(s: &str) -> buck2_error::Result<&RelativePath> {
         verify_relative_path(s, false)?;
         Ok(RelativePath::ref_cast(s))
     }
 
-    /// Wraps `s` as a `RelativePath` without enforcing the no-`\` invariant.
-    /// Callers must guarantee the string does not contain backslashes; passing
-    /// one through `unchecked_new` produces a `RelativePath` that violates the
-    /// type's contract and breaks downstream code that relies on it.
+    /// Wraps `s` as a `RelativePath` without validating it. Callers must guarantee the string
+    /// satisfies the configured path policy.
     #[inline]
     pub fn unchecked_new(s: &str) -> &RelativePath {
         RelativePath::ref_cast(s)
@@ -301,14 +303,14 @@ impl RelativePath {
 }
 
 impl RelativePathBuf {
-    /// Wraps `s` as a `RelativePathBuf`, rejecting any backslash.
+    /// Wraps `s` as a `RelativePathBuf`, rejecting paths that violate the configured policy.
     pub fn new(s: String) -> buck2_error::Result<RelativePathBuf> {
         verify_relative_path(&s, false)?;
         Ok(RelativePathBuf(s))
     }
 
-    /// Wraps `s` as a `RelativePathBuf` without enforcing the no-`\` invariant.
-    /// See [`RelativePath::unchecked_new`] for the obligation on the caller.
+    /// Wraps `s` as a `RelativePathBuf` without validating it. See
+    /// [`RelativePath::unchecked_new`] for the obligation on the caller.
     #[inline]
     pub fn unchecked_new(s: String) -> RelativePathBuf {
         RelativePathBuf(s)
@@ -329,12 +331,10 @@ impl RelativePathBuf {
     ///
     /// Iterates the path's native components, rejecting absolute components
     /// (Windows drive prefixes and root directories) and requiring UTF-8. On
-    /// Windows, this naturally converts `\` separators to `/` because
-    /// [`Path::components`] splits on the platform separator; on Unix, a
-    /// literal backslash inside a component is rejected with
-    /// [`FromSystemPathError::Backslash`] so that the resulting
-    /// `RelativePathBuf` upholds the no-`\` invariant. `.` components are
-    /// stripped; `..` components are preserved literally.
+    /// Windows, this converts `\` separators to `/` because [`Path::components`]
+    /// splits on the platform separator. On Unix, a backslash in a component is
+    /// rejected unless `[buck2] allow_backslashes_in_paths = true` is set. `.`
+    /// components are stripped and `..` components are preserved.
     ///
     /// ```
     /// use std::path::Path;
@@ -352,13 +352,19 @@ impl RelativePathBuf {
     pub fn from_system_path<P: AsRef<Path>>(
         path: P,
     ) -> Result<RelativePathBuf, FromSystemPathError> {
+        Self::from_system_path_with_policy(path.as_ref(), backslash_allowed())
+    }
+
+    fn from_system_path_with_policy(
+        path: &Path,
+        allow_backslashes: bool,
+    ) -> Result<RelativePathBuf, FromSystemPathError> {
         use std::path::Component::CurDir;
         use std::path::Component::Normal;
         use std::path::Component::ParentDir;
         use std::path::Component::Prefix;
         use std::path::Component::RootDir;
 
-        let path = path.as_ref();
         let mut buf = RelativePathBuf::empty();
         for c in path.components() {
             match c {
@@ -371,7 +377,7 @@ impl RelativePathBuf {
                     let s = s
                         .to_str()
                         .ok_or_else(|| FromSystemPathError::NonUtf8(path.display().to_string()))?;
-                    if memchr::memchr(b'\\', s.as_bytes()).is_some() {
+                    if memchr::memchr(b'\\', s.as_bytes()).is_some() && !allow_backslashes {
                         return Err(FromSystemPathError::Backslash(path.display().to_string()));
                     }
                     buf.push(RelativePath::unchecked_new(s));
@@ -610,6 +616,14 @@ pub(super) fn verify_relative_path(
     rel_path: &str,
     expect_forward: bool,
 ) -> buck2_error::Result<()> {
+    verify_relative_path_with_policy(rel_path, expect_forward, backslash_allowed())
+}
+
+fn verify_relative_path_with_policy(
+    rel_path: &str,
+    expect_forward: bool,
+    allow_backslashes: bool,
+) -> buck2_error::Result<()> {
     let bytes = rel_path.as_bytes();
     if bytes.is_empty() {
         return Ok(());
@@ -617,7 +631,7 @@ pub(super) fn verify_relative_path(
     if bytes[0] == b'/' {
         return Err(RelativePathError::PathNotRelative(rel_path.to_owned()).into());
     }
-    if memchr::memchr(b'\\', bytes).is_some() {
+    if memchr::memchr(b'\\', bytes).is_some() && !allow_backslashes {
         return Err(RelativePathError::Backslash(rel_path.to_owned()).into());
     }
 
@@ -819,9 +833,15 @@ mod tests {
     #[test]
     fn from_system_path_unix_rejects_backslash() {
         // On Unix, `\` is just a normal character in a path component. We
-        // reject it because `RelativePath` itself bans backslashes.
+        // reject it because `RelativePath` bans backslashes by default.
         let err = RelativePathBuf::from_system_path(Path::new("foo\\bar")).unwrap_err();
         assert!(matches!(err, FromSystemPathError::Backslash(_)), "{err:?}");
+        assert_eq!(
+            "foo\\bar",
+            RelativePathBuf::from_system_path_with_policy(Path::new("foo\\bar"), true)
+                .unwrap()
+                .as_str()
+        );
     }
 
     #[test]
@@ -833,6 +853,8 @@ mod tests {
         assert!(RelativePath::new("foo/./bar").is_ok());
         assert!(ForwardRelativePath::new("foo/./bar").is_err());
         assert!(RelativePath::new("a\\b").is_err());
+        assert!(verify_relative_path_with_policy("a\\b", false, true).is_ok());
+        assert!(verify_relative_path_with_policy("a\\b", true, true).is_ok());
         assert!(RelativePath::new("/a/b").is_err());
         assert!(RelativePath::new("a/b/").is_err());
         assert!(RelativePath::new("a//b").is_err());

--- a/app/buck2_server/src/daemon/state.rs
+++ b/app/buck2_server/src/daemon/state.rs
@@ -68,6 +68,7 @@ use buck2_execute_impl::sqlite::materializer_db::MaterializerState;
 use buck2_execute_impl::sqlite::materializer_db::MaterializerStateSqliteDb;
 use buck2_file_watcher::file_watcher::FileWatcher;
 use buck2_fs::cwd::WorkingDirectory;
+use buck2_fs::paths::init_allow_backslashes_in_paths;
 use buck2_hash::StdBuckHashMap;
 use buck2_http::HttpClient;
 use buck2_http::HttpClientBuilder;
@@ -310,6 +311,9 @@ impl DaemonState {
 
         let daemon_state_data_rt = rt.clone();
         let init_fut = async move {
+            init_allow_backslashes_in_paths(
+                init_ctx.daemon_startup_config.allow_backslashes_in_paths,
+            )?;
             let fs = paths.project_root().clone();
 
             tracing::info!("Reading config...");

--- a/docs/concepts/buckconfig.md
+++ b/docs/concepts/buckconfig.md
@@ -232,6 +232,22 @@ exists.
 
 Below is an incomplete list of supported buckconfigs.
 
+## [buck2]
+
+By default, Buck2 rejects backslashes in file names and relative paths on every
+platform so that paths remain portable. Projects that require literal
+backslashes on platforms where they are valid path characters can opt in from
+the root `.buckconfig`:
+
+```ini
+[buck2]
+  allow_backslashes_in_paths = true
+```
+
+Changing this setting restarts the Buck2 daemon because it changes path-type
+invariants for the process. On Windows, where a backslash is a path separator,
+literal backslashes remain disallowed.
+
 ## [alias]
 
 This section contains definitions of [build target](build_target.md) aliases.


### PR DESCRIPTION
File names and relative paths reject backslashes on every platform. On
Windows a backslash is a path separator, but on other platforms it is a
valid path character that occurs in practice. Building OS images, for
example, can produce systemd-escaped names such as
`system-systemd\x2dfoo.slice`, which Buck2 currently rejects.

Keep rejecting backslashes by default, but add
`[buck2] allow_backslashes_in_paths = true` to permit them on platforms
where they are not path separators. Treat the setting as daemon startup
configuration so changing it restarts buckd and one daemon cannot mix
path invariants. Windows continues to reject literal backslashes.

Initialize the low-level path policy from the startup configuration in
both the client and daemon. Same-value initialization is idempotent for
`--no-buckd`, while conflicting values are rejected. This also preserves
the original concrete error type of `from_system_path`, since validation
no longer performs a fallible environment lookup.

Cover policy initialization, platform behavior, and all affected path
validators in buck2_fs tests. Cover buckconfig parsing in buck2_common,
and document the opt-in in the buckconfig reference.

Signed-off-by: Daan De Meyer <daan@amutable.com>