### PR TITLE
Set platform in REAPI Action message

### DIFF
--- a/app/buck2_execute/src/execute/command_executor.rs
+++ b/app/buck2_execute/src/execute/command_executor.rs
@@ -312,6 +312,7 @@ fn re_create_action(
 
         #[allow(unused_mut)]
         let mut action = RE::Action {
+            platform: Some(platform.clone()),
             input_root_digest: Some(input_digest.to_grpc()),
             command_digest: Some(action_and_blobs.add_command(&command).to_grpc()),
             timeout: timeout
@@ -332,7 +333,7 @@ fn re_create_action(
     let mut command = RE::Command {
         arguments: command_args,
         #[allow(deprecated)]
-        platform: Some(platform),
+        platform: Some(platform.clone()),
         working_directory: working_directory.as_str().to_owned(),
         environment_variables: environment
             .iter()
@@ -395,6 +396,7 @@ fn re_create_action(
     let mut action_and_blobs = ActionDigestAndBlobsBuilder::new(digest_config);
 
     let mut action = RE::Action {
+        platform: Some(platform),
         input_root_digest: Some(input_digest.to_grpc()),
         command_digest: Some(action_and_blobs.add_command(&command).to_grpc()),
         timeout: timeout


### PR DESCRIPTION
REAPI v2.2 introduced the platform field in the Action message as the preferred location for platform properties over the previously used Command message.

The platform field in the Command message was marked as deprecated in REAPI v2.8, but both fields should still be set.

See: remote_execution/oss/re_grpc_proto/proto/build/bazel/remote/execution/v2/remote_execution.proto:653-660