### PR TITLE
Fix clang-specific cc/cxx invocations in cargo_buildscript

### DIFF
--- a/prelude/rust/cargo_buildscript.bzl
+++ b/prelude/rust/cargo_buildscript.bzl
@@ -304,6 +304,8 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
     )
     deps_link = deps_tset.project_as_args("default")
     sanitizer_flags = ["-fno-sanitize=all"]
+    cc_is_clang = cxx_toolchain_info.c_compiler_info.compiler_type.startswith("clang")
+    cxx_is_clang = cxx_toolchain_info.cxx_compiler_info.compiler_type.startswith("clang")
     env["LD"] = _make_cc_shim(
         ctx = ctx,
         name = "__ld_shim",
@@ -319,7 +321,7 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
         name = "__cc_shim",
         cmd = cmd_args(
             cxx_toolchain_info.c_compiler_info.compiler,
-            cmd_args(env["LD"], format = "--ld-path={}"),
+            cmd_args(env["LD"], format = "--ld-path={}") if cc_is_clang else cmd_args(),
             cxx_toolchain_info.c_compiler_info.preprocessor_flags,
             cxx_toolchain_info.c_compiler_info.compiler_flags,
             deps_preprocessor_flags,
@@ -334,7 +336,7 @@ def _cargo_buildscript_impl(ctx: AnalysisContext) -> list[Provider]:
         name = "__cxx_shim",
         cmd = cmd_args(
             cxx_toolchain_info.cxx_compiler_info.compiler,
-            cmd_args(env["LD"], format = "--ld-path={}"),
+            cmd_args(env["LD"], format = "--ld-path={}") if cxx_is_clang else cmd_args(),
             cxx_toolchain_info.cxx_compiler_info.preprocessor_flags,
             cxx_toolchain_info.cxx_compiler_info.compiler_flags,
             deps_preprocessor_flags,


### PR DESCRIPTION
After updating to a version of buck2 that included these changes (using bundled prelude), we started seeing the following when building the `openssl-sys` crate via a Reindeer-generated BUCK file:

```
Header expansion error:
Error { kind: ToolExecError, message: "command did not execute successfully (status code exit status: 1): LC_ALL="C" "…/__openssl-sys-0.9-build-script-main-run__/74052bece190009d/__cc_shim.sh" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "../../../../../../toolchains/b42aeba648b8c415/__openssl_includes__/out.link-dev/include" "-Wall" "-Wextra" "-E" "build/expando.c"" }
Failed to find OpenSSL development headers.
```

The real error (which, unfortunately, is not shown) is that `--ld-path` is a clang-specific flag - or at least, that it is not recognized by gcc. It seems a little unlikely to me that buildscripts need to access the linker in general so I'm not sure we necessarily need to be passing `--ld-path` at all? But this change should at least expand the set of cargo build scripts that can successfully run with gcc toolchains, without affecting clang.

I've tested this in the context of Mercury's monorepo and I'm confident it works there, but I'm struggling a bit to set up a reproducer/test outside of the context of that monorepo. Can you help me figure out whether this should be accompanied by a test, and if so what kind of test?