### PR TITLE
Hide console status in quiet mode

### DIFF
--- a/app/buck2_client/src/commands/build.rs
+++ b/app/buck2_client/src/commands/build.rs
@@ -395,7 +395,8 @@ pub(crate) fn print_build_succeeded(
 /// Prints two things at command end:
 ///
 /// 1. **Buck UI URL re-print** — emitted only when a superconsole was
-///    actually constructed for the command (`used_superconsole`).
+///    actually constructed for the command (`used_superconsole`) and status
+///    verbosity is enabled.
 ///    Superconsole's live area showed the URL during the command but
 ///    clears on exit, so without the re-print the URL would be gone from
 ///    scrollback. Simple-console runs already printed it at command start
@@ -425,6 +426,10 @@ pub(crate) fn print_buck_ui_and_rating(
     ctx: &ClientCommandContext<'_>,
     used_superconsole: bool,
 ) -> buck2_error::Result<()> {
+    if !ctx.verbosity.print_status() {
+        return Ok(());
+    }
+
     let show_rating = should_show_rating(&ctx.trace_id);
 
     if used_superconsole {

--- a/app/buck2_client_ctx/src/subscribers/simpleconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/simpleconsole.rs
@@ -450,6 +450,9 @@ where
         _command: &buck2_data::CommandStart,
         event: &BuckEvent,
     ) -> buck2_error::Result<()> {
+        if !self.verbosity.print_status() {
+            return Ok(());
+        }
         if cfg!(fbcode_build) {
             echo!(
                 "Buck UI: https://www.internalfb.com/buck2/{}",
@@ -490,12 +493,14 @@ where
             }
         }
 
-        if let Some(re) = &self
-            .observer()
-            .re_state()
-            .render_header(snapshots, DrawMode::Final)
-        {
-            echo!("{}", re)?;
+        if self.verbosity.print_status() {
+            if let Some(re) = &self
+                .observer()
+                .re_state()
+                .render_header(snapshots, DrawMode::Final)
+            {
+                echo!("{}", re)?;
+            }
         }
 
         if let Some(test_session) = &self.observer().session_info().test_session {

--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -430,6 +430,7 @@ struct BuckRootComponent<'s> {
     header: &'s str,
     state: &'s SuperConsoleState,
     games_overlay: &'s GamesOverlay,
+    verbosity: Verbosity,
 }
 
 /// Adapter that wraps a `Component<Error = anyhow::Error>` to produce
@@ -498,6 +499,7 @@ impl Component for BuckRootComponent<'_> {
         });
 
         let mut draw = DrawVertical::new(dimensions);
+        let show_status = !matches!(mode, DrawMode::Final) || self.verbosity.print_status();
 
         // Render games overlay above normal build output when active.
         if self.games_overlay.active {
@@ -542,34 +544,36 @@ impl Component for BuckRootComponent<'_> {
             )?;
         }
 
-        draw.draw(
-            &SessionInfoComponent {
-                session_info: self.state.session_info(),
-            },
-            mode,
-        )?;
-        draw.draw(
-            &ReHeader {
-                super_console_config: &self.state.config,
-                re_state: self.state.simple_console.observer.re_state(),
-                two_snapshots: self.state.simple_console.observer.two_snapshots(),
-            },
-            mode,
-        )?;
-        draw.draw(
-            &IoHeader {
-                super_console_config: &self.state.config,
-                two_snapshots: self.state.simple_console.observer.two_snapshots(),
-            },
-            mode,
-        )?;
-        draw.draw(
-            &TestHeader {
-                session_info: self.state.session_info(),
-                test_state: self.state.simple_console.observer.test_state(),
-            },
-            mode,
-        )?;
+        if show_status {
+            draw.draw(
+                &SessionInfoComponent {
+                    session_info: self.state.session_info(),
+                },
+                mode,
+            )?;
+            draw.draw(
+                &ReHeader {
+                    super_console_config: &self.state.config,
+                    re_state: self.state.simple_console.observer.re_state(),
+                    two_snapshots: self.state.simple_console.observer.two_snapshots(),
+                },
+                mode,
+            )?;
+            draw.draw(
+                &IoHeader {
+                    super_console_config: &self.state.config,
+                    two_snapshots: self.state.simple_console.observer.two_snapshots(),
+                },
+                mode,
+            )?;
+            draw.draw(
+                &TestHeader {
+                    session_info: self.state.session_info(),
+                    test_state: self.state.simple_console.observer.test_state(),
+                },
+                mode,
+            )?;
+        }
         draw.draw(
             &DebugEventsComponent {
                 super_console_config: &self.state.config,
@@ -601,8 +605,10 @@ impl Component for BuckRootComponent<'_> {
             },
             mode,
         )?;
-        draw.draw(&TasksHeader::new(self.header, self.state), mode)?;
-        draw.draw(&TimedList::new(&CUTOFFS, self.state), mode)?;
+        if show_status {
+            draw.draw(&TasksHeader::new(self.header, self.state), mode)?;
+            draw.draw(&TimedList::new(&CUTOFFS, self.state), mode)?;
+        }
 
         Ok(draw.finish())
     }
@@ -1391,6 +1397,7 @@ impl StatefulSuperConsoleImpl {
             header: &self.header,
             state: &self.state,
             games_overlay: &self.games_overlay,
+            verbosity: self.verbosity,
         })?;
         Ok(())
     }
@@ -1416,6 +1423,7 @@ impl StatefulSuperConsoleImpl {
                 header: &self.header,
                 state: &self.state,
                 games_overlay: &self.games_overlay,
+                verbosity: self.verbosity,
             })
             .err();
         (self.state, err)
@@ -1823,6 +1831,41 @@ mod tests {
         console
             .handle_command_result(&buck2_cli_proto::CommandResult { result: None })
             .await?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_quiet_status_is_not_persisted() -> buck2_error::Result<()> {
+        let verbosity = Verbosity::try_from_cli("0,actions")?;
+        let state = SuperConsoleState::new(
+            Timekeeper::new(
+                Box::new(RealtimeClock),
+                EventTimestamp(SystemTime::now().into()),
+            ),
+            TraceId::new(),
+            verbosity,
+            true,
+            Default::default(),
+            None,
+        )?;
+        let games_overlay = GamesOverlay::new();
+        let root = BuckRootComponent {
+            header: "Command: run.",
+            state: &state,
+            games_overlay: &games_overlay,
+            verbosity,
+        };
+
+        assert!(
+            !root
+                .draw_unchecked(StatefulSuperConsole::FALLBACK_SIZE, DrawMode::Normal)?
+                .is_empty()
+        );
+        assert!(
+            root.draw_unchecked(StatefulSuperConsole::FALLBACK_SIZE, DrawMode::Final)?
+                .is_empty()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Make simple-console command start and final remote execution summaries respect
status verbosity. Extend the same behavior to the superconsole final status
frame and the post-superconsole Build ID reprint.

This allows -v 0,actions to report completed actions in the simple console
while remaining silent when a command performs no work. The live superconsole
still renders while a command is running, preserving interactive progress
without leaving status-only output in scrollback.

Add regression coverage that verifies quiet superconsole status remains visible
during normal rendering but is omitted from the final frame.

Validated with the buck2_client_ctx superconsole unit tests, a buck2_client
Cargo check, and rustfmt.

Signed-off-by: Daan De Meyer <daan@amutable.com>
