### PR TITLE
pagable: Fix stale DataKey documentation

### DIFF
--- a/pagable/src/storage/data.rs
+++ b/pagable/src/storage/data.rs
@@ -23,11 +23,12 @@ use dupe::Dupe;
 /// The 128-bit size provides an extremely low collision probability
 /// (< 1e-15 after 820 billion samples).
 ///
-/// Stored as `[u64; 2]` rather than `u128` to keep 8-byte alignment instead of 16-byte,
-/// while remaining bytemuck-compatible. The first half is morally a `NonZeroU64` —
-/// `compute()` ensures `self.0[0] != 0` so that [`OptionalDataKey`] can pack itself
-/// as `(NonZeroU64, u64)` and inherit the same 8-byte alignment.
+/// Stored as a [`NonZeroU64`] followed by a `u64`, rather than a `u128`, to keep 8-byte
+/// alignment instead of 16-byte while remaining bytemuck-compatible. The non-zero first half
+/// provides a niche so [`Option<DataKey>`] has the same size and alignment as `DataKey`.
 ///
+/// [`NonZeroU64`]: std::num::NonZeroU64
+/// [`Option<DataKey>`]: std::option::Option
 /// [`PagableArc`]: crate::PagableArc
 #[derive(
     Allocative,
@@ -60,7 +61,7 @@ impl DataKey {
         let lo = u64::from_le_bytes(hash_bytes[..8].try_into().unwrap());
         let hi = u64::from_le_bytes(hash_bytes[8..16].try_into().unwrap());
 
-        // OptionalDataKey's niche representation requires `lo` to be non-zero. In the
+        // Option<DataKey> uses the first half's non-zero invariant as its niche. In the
         // astronomically unlikely case of a zero first half, use 1 instead. Collision resistance
         // remains effectively 128 bits.
         let lo = NonZeroU64::new(lo).unwrap_or(NonZeroU64::new(1).unwrap());


### PR DESCRIPTION
Stale rustdoc that wasn't caught by Phabricator, I think. Should allow https://github.com/facebook/buck2/pull/1357 to pass.