### PR TITLE
Return failure exit code from `log replay` when errors are present (#1389)

### DIFF
--- a/app/buck2_cmd_log_client/src/replay.rs
+++ b/app/buck2_cmd_log_client/src/replay.rs
@@ -174,8 +174,11 @@ impl BuckSubcommand for ReplayCommand {
                 buck2_client_ctx::eprintln!("{}", e.message)?;
             }
 
-            // FIXME(JakobDegen)(easy): This should probably return failures if there were errors
-            ExitResult::success()
+            if res.errors.is_empty() {
+                ExitResult::success()
+            } else {
+                ExitResult::from_command_result_errors(res.errors)
+            }
         };
 
         with_simple_sigint_handler(work)


### PR DESCRIPTION
Summary:

Fixes the `FIXME(JakobDegen)(easy)` in `buck2_cmd_log_client/src/replay.rs`.

Previously, `buck2 log replay` printed any errors from the replayed
command to stderr but then unconditionally returned
`ExitResult::success()`, so a replay of a failed command exited 0.

Now, when `res.errors` is non-empty, we return
`ExitResult::from_command_result_errors(res.errors)`, which derives the
appropriate exit code from the errors' tags (the errors were already
emitted to stderr by the loop above, so they are passed as emitted
errors and not re-printed).

Reviewed By: 8Keep

Differential Revision: D112730861


