### PR TITLE
Implement `Serialize` for `StarlarkError` and `StarlarkResult` (#1390)

### DIFF
--- a/app/buck2_bxl/src/bxl/starlark_defs/result.rs
+++ b/app/buck2_bxl/src/bxl/starlark_defs/result.rs
@@ -13,6 +13,9 @@ use derivative::Derivative;
 use derive_more::Display;
 use display_container::fmt_container;
 use dupe::Dupe;
+use serde::Serialize;
+use serde::Serializer;
+use serde::ser::SerializeMap;
 use starlark::any::ProvidesStaticType;
 use starlark::environment::Methods;
 use starlark::environment::MethodsBuilder;
@@ -21,7 +24,6 @@ use starlark::starlark_module;
 use starlark::starlark_simple_value;
 use starlark::values::Freeze;
 use starlark::values::FrozenValue;
-use starlark::values::NoSerialize;
 use starlark::values::StarlarkValue;
 use starlark::values::Trace;
 use starlark::values::Value;
@@ -45,8 +47,6 @@ enum BxlResultError {
     ProvidesStaticType,
     Derivative,
     Display,
-    // TODO(nero): implement Serialize for StarlarkError
-    NoSerialize,
     Allocative,
     Trace,
     starlark::StarlarkPagablePanic // badbadbad!!! todo!("bxl")
@@ -54,6 +54,18 @@ enum BxlResultError {
 #[display("bxl.Error({})", StarlarkStr::repr(&format!("{err:?}")))]
 pub(crate) struct StarlarkError {
     err: buck2_error::Error,
+}
+
+impl Serialize for StarlarkError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("result", "error")?;
+        map.serialize_entry("value", &format!("{:?}", self.err))?;
+        map.end()
+    }
 }
 
 impl StarlarkError {
@@ -85,8 +97,6 @@ fn error_methods(builder: &mut MethodsBuilder) {
 
 #[derive(
     Debug,
-    // TODO(nero): implement Serialize for StarlarkResult
-    NoSerialize,
     Trace,
     Freeze,
     ProvidesStaticType,
@@ -97,6 +107,26 @@ fn error_methods(builder: &mut MethodsBuilder) {
 pub(crate) enum StarlarkResultGen<T> {
     Ok(T),
     Err(#[freeze(identity)] buck2_error::Error),
+}
+
+impl<'v, V: ValueLike<'v>> Serialize for StarlarkResultGen<V> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        match self {
+            StarlarkResultGen::Ok(val) => {
+                map.serialize_entry("result", "ok")?;
+                map.serialize_entry("value", &val.to_value())?;
+            }
+            StarlarkResultGen::Err(err) => {
+                map.serialize_entry("result", "error")?;
+                map.serialize_entry("value", &format!("{:?}", err))?;
+            }
+        }
+        map.end()
+    }
 }
 
 pub(crate) type StarlarkResult<'v> = StarlarkResultGen<Value<'v>>;


### PR DESCRIPTION
Summary:

`StarlarkError` and `StarlarkResultGen` both derived `NoSerialize`, so BXL
scripts could not serialize these values to JSON when emitting results. This
replaces the `NoSerialize` derives with manual `serde::Serialize` impls.

`StarlarkValue` requires `Serialize` as a supertrait, and `NoSerialize` is only
a convenience derive that generates an `impl Serialize` which errors at runtime.
Implementing `serde::Serialize` on the Rust type is both necessary and
sufficient to make the value serializable.

- `StarlarkError` serializes as a single-key map `{"error": "<debug string>"}`,
  matching the `message` attribute already exposed on the value.
- `StarlarkResultGen<V>` serializes as `{"ok": <value>}` for the `Ok` variant
  and `{"error": "<debug string>"}` for the `Err` variant, mirroring the
  buck2 convention of `serialize_map` + `serialize_entry` (see
  `StarlarkSelectorGen` and `TransitiveSetGen`).

Resolves the `TODO(nero)` markers on both types.

Differential Revision: D112684847


