### PR TITLE
shim/rust: fix a few crate fixups for OSS buck2-on-buck2

### DIFF
--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -126,8 +126,6 @@ ipnetwork = "0.20.0"
 is_proc_translated = "0.1.1"
 itertools = "0.14.0"
 jemallocator = { version = "0.6.1", package = "tikv-jemallocator" }
-lalrpop = { version = "0.23.1", features = ["pico-args"], artifact = "bin:lalrpop", lib = true }
-lalrpop-util = "0.23.1"
 libc = "0.2.183"
 libfuzzer-sys = "0.4.12"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }

--- a/shim/third-party/rust/fixups/crossbeam-deque/fixups.toml
+++ b/shim/third-party/rust/fixups/crossbeam-deque/fixups.toml
@@ -6,6 +6,4 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
-cargo_env = true
-
 buildscript.run = false

--- a/shim/third-party/rust/fixups/ctor/fixups.toml
+++ b/shim/third-party/rust/fixups/ctor/fixups.toml
@@ -1,0 +1,1 @@
+cargo_env = true

--- a/shim/third-party/rust/fixups/inotify-sys/fixups.toml
+++ b/shim/third-party/rust/fixups/inotify-sys/fixups.toml
@@ -6,6 +6,4 @@
 # of this source tree. You may select, at your option, one of the
 # above-listed licenses.
 
-cargo_env = true
-
 buildscript.run = false

--- a/shim/third-party/rust/fixups/ring/fixups.toml
+++ b/shim/third-party/rust/fixups/ring/fixups.toml
@@ -101,13 +101,13 @@ fixup_include_paths = ["include"]
 compiler_flags = ["-Wno-error"]
 preferred_linkage = "static"
 
-[['cfg(all(version = "=0.17.14", target_arch = "x86_64", target_os = "windows"))'.cxx_library]]
+[['cfg(all(version = "=0.17.14", target_arch = "x86_64", target_os = "windows", target_env = "msvc"))'.cxx_library]]
 name = "ring-c-win-x86_84"
 srcs = ["crypto/**/*.c"]
 headers = ["include/**/*.h", "crypto/**/*.h", "third_party/**/*.h", "crypto/**/*.inl"]
 include_paths = ["include", "."]
 fixup_include_paths = ["include"]
-compiler_flags = ["-Wno-error"]
+compiler_flags = ["/WX-"]
 preferred_linkage = "static"
 [['cfg(all(version = "=0.17.14", target_arch = "x86_64", target_os = "windows"))'.prebuilt_cxx_library]]
 name = "ring-asm-windows-x86_84"

--- a/shim/third-party/rust/fixups/zstd-sys/fixups.toml
+++ b/shim/third-party/rust/fixups/zstd-sys/fixups.toml
@@ -63,7 +63,12 @@ compiler_flags = [
     "-DZSTDLIB_VISIBILITY=",
     "-DZDICTLIB_VISIBILITY=",
     "-DZSTDERRORLIB_VISIBILITY=",
-    "-DZSTD_LEGACY_SUPPORT=1"
+    "-DZSTD_LEGACY_SUPPORT=1",
+    # The zstd crate is built with the "zstdmt" feature, whose Rust side
+    # references ZSTD_createThreadPool/ZSTD_freeThreadPool — only defined
+    # when ZSTD_MULTITHREAD is set (zstd-sys build.rs does the same).
+    # ELF links hid the mismatch via --gc-sections; link.exe does not.
+    "-DZSTD_MULTITHREAD"
 ]
 
 [['cfg(all(target_os = "windows", target_env = "msvc"))'.cxx_library]]
@@ -120,5 +125,7 @@ compiler_flags = [
     "-DZSTDLIB_VISIBILITY=",
     "-DZDICTLIB_VISIBILITY=",
     "-DZSTDERRORLIB_VISIBILITY=",
-    "-DZSTD_LEGACY_SUPPORT=1"
+    "-DZSTD_LEGACY_SUPPORT=1",
+    # See the unix section: required by the zstd crate's "zstdmt" feature.
+    "-DZSTD_MULTITHREAD"
 ]


### PR DESCRIPTION
When trying to bootstrap buck2-on-buck2, we need a few changes to the default fixups. These don't fix everything perfectly yet but they're more correct anyway.

- `lalrpop` is no longer used
- `ctor` (on macOS IIRC) needs to have `cargo_env` set
- `ring` on msvc windows was passing an invalid build flag
- `zstd` crate enabled multithreading, but the fixup didn't apply `-DZSTDMT` as required
- `crossbeam` has seen various updates and these were just rewritten.

Note that while there are 4 commits I think it's probably fine to just land this stack as one commit through Phabricator, which is probably the default behavior still.