### PR TITLE
blake3 fixups: fix unsafe overbroad enabling of fancy instructions

### DIFF
--- a/shim/third-party/macros/rust_third_party.bzl
+++ b/shim/third-party/macros/rust_third_party.bzl
@@ -5,7 +5,10 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-def third_party_rust_prebuilt_cxx_library(name, **kwargs):
+load("@prelude//rust:cargo_package.bzl", "apply_platform_attrs", "cargo", "get_reindeer_platforms")
+load("@prelude//utils:selects.bzl", "selects")
+
+def _third_party_rust_prebuilt_cxx_library(name, **kwargs):
     # FIXME: This should probably be a fixup.toml, but it currently can't be expressed.
     # The windows-sys crate does -lwindows to find windows. We pass libwindows.a on the command line,
     # which resolves the symbols, but the linker still needs to "find" windows, so we also put its
@@ -14,4 +17,48 @@ def third_party_rust_prebuilt_cxx_library(name, **kwargs):
         kwargs["exported_linker_flags"] = ["-Lshim/third-party/rust/" + kwargs["static_lib"].rpartition("/")[0]]
 
     # @lint-ignore BUCKLINT
-    native.prebuilt_cxx_library(name = name, **kwargs)
+    native.prebuilt_cxx_library(
+        name = name,
+        **kwargs
+    )
+
+def third_party_rust_alias(name, **kwargs):
+    # slightly silly thing reindeer makes us do by giving us a list
+    platforms = kwargs.pop("platforms", {})
+    platform = {k: {} for k in platforms}
+
+    # @lint-ignore BUCKLINT: avoid "Direct usage of native rules is not allowed."
+    _target_restricted(native.alias, name = name, platform = platform, **kwargs)
+
+def _target_restricted(f, name, target_compatible_with = None, **kwargs):
+    platform = kwargs.pop("platform", {})
+    kwargs = apply_platform_attrs(platform, kwargs)
+
+    target_compatible_with = target_compatible_with or _target_constraints(platform, kwargs)
+    return f(
+        name = name,
+        target_compatible_with = target_compatible_with,
+        **kwargs
+    )
+
+def _target_constraints(platforms, kwargs):
+    target_compatible_with = kwargs.pop("target_compatible_with", [])
+
+    if kwargs.get("proc_macro", False) or platforms == {}:
+        return target_compatible_with
+    else:
+        return selects.apply(
+            get_reindeer_platforms(),
+            lambda p: target_compatible_with if p in platforms else ["prelude//:none"],
+        )
+
+third_party_rust_prebuilt_cxx_library = partial(_target_restricted, _third_party_rust_prebuilt_cxx_library)
+
+# @lint-ignore BUCKLINT: avoid "Direct usage of native rules is not allowed."
+third_party_rust_cxx_library = partial(_target_restricted, native.cxx_library)
+
+# @lint-ignore BUCKLINT: avoid "Direct usage of native rules is not allowed."
+third_party_rust_rust_library = partial(_target_restricted, cargo.rust_library)
+
+# @lint-ignore BUCKLINT: avoid "Direct usage of native rules is not allowed."
+third_party_rust_rust_binary = partial(_target_restricted, cargo.rust_binary)

--- a/shim/third-party/rust/Cargo.toml
+++ b/shim/third-party/rust/Cargo.toml
@@ -93,7 +93,6 @@ fs4 = { version = "0.9.1", features = ["sync"] }
 futures = "0.3.31"
 futures-intrusive = "0.4.2"
 fxhash = "0.2.1"
-gazebo = { version = "0.8.1", features = ["str_pattern_extensions"] }
 glob = "0.3.2"
 globset = { version = "0.4.13", features = ["serde1"] }
 hashbrown = "0.17"

--- a/shim/third-party/rust/fixups/blake3/fixups.toml
+++ b/shim/third-party/rust/fixups/blake3/fixups.toml
@@ -13,7 +13,10 @@ buildscript.run = false
 ['cfg(target_arch = "x86_64")']
 cfgs = ["blake3_sse2_ffi", "blake3_sse41_ffi", "blake3_avx2_ffi", "blake3_avx512_ffi"]
 
-# , any(target_env = "fbcode", target_env = "gnu")
+# NOTE: extra vector instructions must NOT be enabled on this library. blake3_dispatch.c does the
+# runtime CPUID check and blake3_portable.c is the baseline fallback, so both of them execute on
+# machines with no fancy instructions at all. Telling the compiler the target supports AVX-512 lets
+# it auto-vectorize those two TUs with AVX-512 so they crash at runtime on incompatible systems.
 [['cfg(all(target_arch = "x86_64", any(target_os = "linux", target_os = "macos")))'.cxx_library]]
 name = "simd_x86_unix"
 srcs = [
@@ -22,18 +25,23 @@ srcs = [
     "c/blake3_portable.c",
     "c/blake3_sse2_x86-64_unix.S",
     "c/blake3_sse41_x86-64_unix.S",
-    "c/blake3_avx2_x86-64_unix.S",
-    "c/blake3_avx512_x86-64_unix.S"
+    "c/blake3_avx2_x86-64_unix.S"
 ]
+headers = ["c/*.h"]
+
+# Only the AVX-512 assembly gets the AVX-512 flags. This is a .S file, so
+# there is no compiler codegen to poison -- the flags only affect what the
+# assembler is willing to accept.
+[['cfg(all(target_arch = "x86_64", any(target_os = "linux", target_os = "macos")))'.cxx_library]]
+name = "simd_x86_unix_avx512"
+srcs = ["c/blake3_avx512_x86-64_unix.S"]
 # Older versions of Clang require these flags, even for assembly. See
 # https://github.com/BLAKE3-team/BLAKE3/issues/79.
 compiler_flags = ["-mavx512f", "-mavx512vl"]
 headers = ["c/*.h"]
-compatible_with = [
-    "prelude//os/constraints:linux",
-    "prelude//os/constraints:macos",
-]
 
+# Same split as the unix libraries above -- see the note there for why the
+# AVX-512 flags cannot be applied to the dispatch/portable TUs.
 [['cfg(all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"))'.cxx_library]]
 name = "simd_x86_windows_gnu"
 srcs = [
@@ -42,14 +50,17 @@ srcs = [
     "c/blake3_portable.c",
     "c/blake3_sse2_x86-64_windows_gnu.S",
     "c/blake3_sse41_x86-64_windows_gnu.S",
-    "c/blake3_avx2_x86-64_windows_gnu.S",
-    "c/blake3_avx512_x86-64_windows_gnu.S"
+    "c/blake3_avx2_x86-64_windows_gnu.S"
 ]
+headers = ["c/*.h"]
+
+[['cfg(all(target_arch = "x86_64", target_os = "windows", target_env = "gnu"))'.cxx_library]]
+name = "simd_x86_windows_gnu_avx512"
+srcs = ["c/blake3_avx512_x86-64_windows_gnu.S"]
 # Older versions of Clang require these flags, even for assembly. See
 # https://github.com/BLAKE3-team/BLAKE3/issues/79.
 compiler_flags = ["-mavx512f", "-mavx512vl"]
 headers = ["c/*.h"]
-compatible_with = ["prelude//os/constraints:windows"]
 
 [['cfg(all(target_arch = "x86_64", target_os = "windows", target_env = "msvc"))'.cxx_library]]
 name = "simd_x86_windows_msvc"
@@ -63,7 +74,6 @@ srcs = [
     "c/blake3_avx512_x86-64_windows_msvc.asm"
 ]
 headers = ["c/*.h"]
-compatible_with = ["prelude//os/constraints:windows"]
 
 ## ARM and AArch64 fixups
 

--- a/shim/third-party/rust/reindeer.toml
+++ b/shim/third-party/rust/reindeer.toml
@@ -26,13 +26,25 @@ bindeps = true
 # Name of the generated file.
 file_name = "BUCK.reindeer"
 
+platform_compatibility_on_all_targets = true
+
 # Rules used for various kinds of targets.
-rust_library = "cargo.rust_library"
-rust_binary = "cargo.rust_binary"
+rust_library = "third_party_rust_rust_library"
+rust_binary = "third_party_rust_rust_binary"
 prebuilt_cxx_library = "third_party_rust_prebuilt_cxx_library"
+cxx_library = "third_party_rust_cxx_library"
+alias = "third_party_rust_alias"
+alias_with_platforms = "third_party_rust_alias"
 
 buckfile_imports = """
 load("@prelude//rust:cargo_buildscript.bzl", "buildscript_run")
 load("@prelude//rust:cargo_package.bzl", "cargo")
-load("@shim//third-party/macros:rust_third_party.bzl", "third_party_rust_prebuilt_cxx_library")
+load(
+    "@shim//third-party/macros:rust_third_party.bzl",
+    "third_party_rust_alias",
+    "third_party_rust_cxx_library",
+    "third_party_rust_prebuilt_cxx_library",
+    "third_party_rust_rust_binary",
+    "third_party_rust_rust_library",
+)
 """


### PR DESCRIPTION
Previously to this commit, these instructions were inadvertently enabled in the portable (must run on all systems) sections of the library.

This PR also adds support for target_compatible_with in shim/third-party/rust, eliminating `compatible_with` bugs with the previous definitions.