### PR TITLE
prelude rust: allow NIX_DEBUG through env allowlist

### DIFF
--- a/prelude/rust/tools/rustc_action.py
+++ b/prelude/rust/tools/rustc_action.py
@@ -90,6 +90,7 @@ INHERITED_ENV = [
     "NIX_LDFLAGS",
     "NIX_LDFLAGS_FOR_TARGET",
     "NIX_NO_SELF_RPATH",
+    "NIX_DEBUG",
 ]
 
 


### PR DESCRIPTION
this allows you to dump the linker/compiler args if you're having a bad time, and diagnose what exactly went into it. it's a really useful capability, independent of nix, but is helpful to figure out what wrapper shenanigans were at fault for problems.