### PR TITLE
Fix let_underscore_drop lint error in dice_tracker

### DIFF
--- a/app/buck2_server/src/dice_tracker.rs
+++ b/app/buck2_server/src/dice_tracker.rs
@@ -135,6 +135,6 @@ impl BuckDiceTracker {
 
 impl DiceEventListener for BuckDiceTracker {
     fn event(&self, event: DiceEvent) {
-        let _ = self.event_forwarder.unbounded_send(event);
+        let _ignored = self.event_forwarder.unbounded_send(event);
     }
 }

--- a/dice/dice_tests/src/paging.rs
+++ b/dice/dice_tests/src/paging.rs
@@ -168,7 +168,7 @@ async fn failed_hydrate_reports_a_hydration_failed_event() -> anyhow::Result<()>
         hydration_failures: captured.clone(),
     });
     let tx = dice.updater_with_data(data).commit().await;
-    let _ = tokio::time::timeout(Duration::from_secs(10), tx.compute(&FailToHydrateKey(7)))
+    let _ignored = tokio::time::timeout(Duration::from_secs(10), tx.compute(&FailToHydrateKey(7)))
         .await
         .expect("compute must not hang when a paged-out value fails to hydrate");
 


### PR DESCRIPTION
OSS CI (`test.py` / `cargo clippy`) is currently failing on every PR and on main itself with:

```
error: non-binding let on a type that has a destructor
   --> app/buck2_server/src/dice_tracker.rs:138:9
```

0578509c0a added the `HydrationFailed` variant with a `String` field to `DiceEvent`, giving it a destructor. That armed the deny-listed `let_underscore_drop` lint (`lint_levels.bzl`) on the pre-existing `let _ =` in `BuckDiceTracker::event`. Bind to `_ignored` instead, matching other call sites that discard `unbounded_send` results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)