### PR TITLE
Widen timing margin in cancellation caching tests

### DIFF
--- a/app/buck2_server/src/dice_tracker.rs
+++ b/app/buck2_server/src/dice_tracker.rs
@@ -135,6 +135,6 @@ impl BuckDiceTracker {
 
 impl DiceEventListener for BuckDiceTracker {
     fn event(&self, event: DiceEvent) {
-        let _ = self.event_forwarder.unbounded_send(event);
+        let _ignored = self.event_forwarder.unbounded_send(event);
     }
 }

--- a/dice/dice/src/epoch/worker/tests.rs
+++ b/dice/dice/src/epoch/worker/tests.rs
@@ -1316,7 +1316,13 @@ async fn _run_cancellation_caching_test(
     // Ensure that the time it took to run the test is expected
     match cancel_type {
         CancelType::Sync | CancelType::ASync => {
-            let limit = (FIRST_COMPUTE_MS as f64) * 0.05 + (CANCELLATION_WAIT_MS as f64) * 1.05;
+            // The measured window includes the full CANCELLATION_WAIT_MS sleep, so
+            // only the excess over it distinguishes a fast recompute from one that
+            // waited out the first compute (~FIRST_COMPUTE_MS). Allowing half of
+            // FIRST_COMPUTE_MS on top keeps that distinction unambiguous while
+            // tolerating sleep overshoot and slow scheduling on loaded CI runners,
+            // where the previous 5% margin (650ms total) was hit exactly.
+            let limit = (FIRST_COMPUTE_MS as f64) * 0.5 + (CANCELLATION_WAIT_MS as f64) * 1.05;
             assert!(
                 elapsed_ms < limit as u64,
                 "cancelled key recompute took too long: elapsed_ms={elapsed_ms} but expected < {limit_u64} \

--- a/dice/dice_tests/src/paging.rs
+++ b/dice/dice_tests/src/paging.rs
@@ -168,7 +168,7 @@ async fn failed_hydrate_reports_a_hydration_failed_event() -> anyhow::Result<()>
         hydration_failures: captured.clone(),
     });
     let tx = dice.updater_with_data(data).commit().await;
-    let _ = tokio::time::timeout(Duration::from_secs(10), tx.compute(&FailToHydrateKey(7)))
+    let _ignored = tokio::time::timeout(Duration::from_secs(10), tx.compute(&FailToHydrateKey(7)))
         .await
         .expect("compute must not hang when a paged-out value fails to hydrate");
 


### PR DESCRIPTION
`epoch::worker::tests::test_cancellation_sync_correct_context_does_not_cache` flaked on a macos CI runner ([example](https://github.com/facebook/buck2/actions/runs/30087161906)):

```
cancelled key recompute took too long: elapsed_ms=650 but expected < 650 (limit=650.0, cancel_type=Sync, FIRST_COMPUTE_MS=2500, CANCELLATION_WAIT_MS=500)
```

The measured window includes the full 500ms `CANCELLATION_WAIT_MS` sleep, so the previous limit of `0.05 * FIRST_COMPUTE_MS + 1.05 * CANCELLATION_WAIT_MS = 650ms` left only ~150ms of slack for sleep overshoot, scheduling, and the recompute itself — hit exactly on a loaded runner.

A genuinely broken cancellation would wait out the first compute and take ~2500ms, so the limit can be much looser without weakening the check. This bumps the `FIRST_COMPUTE_MS` slack factor from 0.05 to 0.5 (limit now 1775ms), well clear of both the healthy (~525ms) and broken (~2500ms) regimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)