### PR TITLE
Widen timing margin in cancellation caching tests

### DIFF
--- a/dice/dice/src/epoch/worker/tests.rs
+++ b/dice/dice/src/epoch/worker/tests.rs
@@ -1316,7 +1316,7 @@ async fn _run_cancellation_caching_test(
     // Ensure that the time it took to run the test is expected
     match cancel_type {
         CancelType::Sync | CancelType::ASync => {
-            let limit = (FIRST_COMPUTE_MS as f64) * 0.05 + (CANCELLATION_WAIT_MS as f64) * 1.05;
+            let limit = (FIRST_COMPUTE_MS as f64) * 0.5 + (CANCELLATION_WAIT_MS as f64) * 1.05;
             assert!(
                 elapsed_ms < limit as u64,
                 "cancelled key recompute took too long: elapsed_ms={elapsed_ms} but expected < {limit_u64} \


### PR DESCRIPTION
The upper-bound assert measures a window that includes the full CANCELLATION_WAIT_MS (500ms) sleep, leaving only ~150ms of slack for sleep overshoot, scheduling, and the recompute itself before tripping the 650ms limit. On loaded CI runners (macos especially) that boundary is hit in practice: elapsed_ms=650 with limit 650.

A genuinely broken cancellation would wait out the first compute and take ~FIRST_COMPUTE_MS (2500ms), so the limit can be far looser without weakening the check. Allow half of FIRST_COMPUTE_MS of slack (limit now 1775ms), which stays well clear of both the healthy (~525ms) and broken (~2500ms) regimes.