### PR TITLE
prelude/go: add cache upload control to the Go toolchain

### DIFF
--- a/prelude/go/cgo_builder.bzl
+++ b/prelude/go/cgo_builder.bzl
@@ -127,7 +127,7 @@ def _cgo(
     env = get_toolchain_env_vars(go_toolchain)
     env["CC"] = _cxx_wrapper(actions, go_toolchain, cgo_build_context, own_pre)
 
-    actions.run(cmd, env = env, category = "go_cgo", identifier = pkg_import_path)
+    actions.run(cmd, env = env, category = "go_cgo", identifier = pkg_import_path, allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return project_go_and_c_files(srcs, gen_dir), gen_dir
 

--- a/prelude/go/coverage.bzl
+++ b/prelude/go/coverage.bzl
@@ -67,6 +67,6 @@ def cover_srcs(
         cgo_files,
     ]
 
-    actions.run(cover_cmd, env = env, category = "go_cover", identifier = pkg_import_path)
+    actions.run(cover_cmd, env = env, category = "go_cover", identifier = pkg_import_path, allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return [instrum_vars_file] + instrum_go_files, instrum_cgo_files, out_config_file

--- a/prelude/go/go_library.bzl
+++ b/prelude/go/go_library.bzl
@@ -145,6 +145,6 @@ def _combine_package(ctx: AnalysisContext, pkg_import_path: str, a_file: Artifac
     ]
 
     identifier = paths.basename(pkg_import_path) + "-combined"
-    ctx.actions.run(pack_cmd, env = env, category = "go_pack", identifier = identifier)
+    ctx.actions.run(pack_cmd, env = env, category = "go_pack", identifier = identifier, allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return pkg_file

--- a/prelude/go/go_list.bzl
+++ b/prelude/go/go_list.bzl
@@ -71,7 +71,7 @@ def go_list(
     ]
 
     identifier = paths.basename(pkg_import_path)
-    actions.run(go_list_args, env = env, category = "go_list", identifier = identifier)
+    actions.run(go_list_args, env = env, category = "go_list", identifier = identifier, allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return go_list_out
 

--- a/prelude/go/go_list_stdlib.bzl
+++ b/prelude/go/go_list_stdlib.bzl
@@ -33,7 +33,7 @@ def go_list_stdlib(actions: AnalysisActions, go_toolchain: GoToolchainInfo, cgo_
         ["-asan"] if go_toolchain.asan and cgo_enabled else [],
         "std",
     ]
-    actions.run(go_list_args, env = env, category = "go_list_stdlib")
+    actions.run(go_list_args, env = env, category = "go_list_stdlib", allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return go_list_stdlib_out
 

--- a/prelude/go/go_test.bzl
+++ b/prelude/go/go_test.bzl
@@ -27,7 +27,7 @@ load(":coverage.bzl", "GoCoverageMode")
 load(":link.bzl", "GoBuildMode", "get_inherited_link_pkgs", "link")
 load(":package_builder.bzl", "GoBuildConfig", "GoSourceInputs", "declare_package_build")
 load(":packages.bzl", "go_attr_pkg_name")
-load(":toolchain.bzl", "evaluate_cgo_enabled")
+load(":toolchain.bzl", "GoToolchainInfo", "evaluate_cgo_enabled")
 
 def _gen_test_main(
     ctx: AnalysisContext,
@@ -53,7 +53,7 @@ def _gen_test_main(
         cmd.extend(["--cover-mode", coverage_mode.value])
     cmd.append(cmd_args(cover_pkgs_argsfile, format = "@{}"))
     cmd.append(cmd_args(test_go_files_argsfile, format = "@{}"))
-    ctx.actions.run(cmd_args(cmd), category = "go_test_main_gen")
+    ctx.actions.run(cmd_args(cmd), category = "go_test_main_gen", allow_cache_upload = ctx.attrs._go_toolchain[GoToolchainInfo].allow_cache_upload)
     return output
 
 def is_subpackage_of(other_pkg_import_path: str, pkg_import_path: str) -> bool:

--- a/prelude/go/link.bzl
+++ b/prelude/go/link.bzl
@@ -277,6 +277,7 @@ def link(
             shared = use_shared_code,
             identifier = identifier_prefix,
             out = output.as_output(),
+            allow_cache_upload = go_toolchain.allow_cache_upload,
         )
     )
 
@@ -298,6 +299,7 @@ def _link_impl(
     shared: bool,
     identifier: str,
     out: OutputArtifact,
+    allow_cache_upload: bool | None,
 ) -> list[Provider]:
     go_stdlib_value = go_stdlib_value.providers[GoStdlibDynamicValue]
 
@@ -311,7 +313,7 @@ def _link_impl(
         ["-o", out],
         main_pkg_o,
     ]
-    actions.run(cmd, env = env_vars, category = "go_link", identifier = identifier)
+    actions.run(cmd, env = env_vars, category = "go_link", identifier = identifier, allow_cache_upload = allow_cache_upload)
     return []
 
 _link = dynamic_actions(
@@ -326,5 +328,6 @@ _link = dynamic_actions(
         "shared": dynattrs.value(bool),
         "identifier": dynattrs.value(str),
         "out": dynattrs.output(),
+        "allow_cache_upload": dynattrs.value(bool | None),
     },
 )

--- a/prelude/go/package_builder.bzl
+++ b/prelude/go/package_builder.bzl
@@ -493,7 +493,7 @@ def _compile(
     )
 
     actions.run(
-        compile_cmd, env = env, category = "go_compile", identifier = "{} [{}]".format(pkg_import_path, build_variant_id), error_handler = go_build_error_handler
+        compile_cmd, env = env, category = "go_compile", identifier = "{} [{}]".format(pkg_import_path, build_variant_id), error_handler = go_build_error_handler, allow_cache_upload = go_toolchain.allow_cache_upload
     )
 
     return (out_x, out_a, asmhdr)
@@ -533,7 +533,7 @@ def _symabis(
         s_files,
     ]
 
-    actions.run(asm_cmd, env = env, category = "go_symabis", identifier = pkg_import_path)
+    actions.run(asm_cmd, env = env, category = "go_symabis", identifier = pkg_import_path, allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return symabis
 
@@ -574,7 +574,7 @@ def _asssembly(
             s_file,
         ]
 
-        actions.run(asm_cmd, env = env, category = "go_assembly", identifier = "{}/{} [{}]".format(pkg_import_path, s_file.short_path, build_variant_id))
+        actions.run(asm_cmd, env = env, category = "go_assembly", identifier = "{}/{} [{}]".format(pkg_import_path, s_file.short_path, build_variant_id), allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return o_files
 
@@ -597,7 +597,7 @@ def _pack(
         o_files,
     ]
 
-    actions.run(pack_cmd, env = env, category = "go_pack", identifier = "{} [{}]".format(pkg_import_path, build_variant_id))
+    actions.run(pack_cmd, env = env, category = "go_pack", identifier = "{} [{}]".format(pkg_import_path, build_variant_id), allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return pkg_file
 
@@ -622,7 +622,7 @@ def _embedcfg(
         embed_patterns,
     ]
 
-    actions.run(embed_cmd, category = "go_embedcfg", identifier = pkg_import_path)
+    actions.run(embed_cmd, category = "go_embedcfg", identifier = pkg_import_path, allow_cache_upload = go_toolchain.allow_cache_upload)
 
     return embedcfg.with_associated_artifacts([srcs_dir])
 

--- a/prelude/go/toolchain.bzl
+++ b/prelude/go/toolchain.bzl
@@ -25,6 +25,7 @@ GoDistrInfo = provider(
 GoToolchainInfo = provider(
     # @unsorted-dict-items
     fields = {
+        "allow_cache_upload": provider_field(bool | None, default = None),
         "assembler": provider_field(RunInfo),
         "assembler_flags": provider_field(typing.Any, default = []),
         "cxx_compiler_flags": provider_field(typing.Any, default = []),

--- a/prelude/toolchains/go/go_toolchain.bzl
+++ b/prelude/toolchains/go/go_toolchain.bzl
@@ -30,6 +30,7 @@ def _go_toolchain_impl(ctx):
             },
         ),
         GoToolchainInfo(
+            allow_cache_upload = ctx.attrs.allow_cache_upload,
             assembler = go_distr.tool_asm,
             assembler_flags = ctx.attrs.assembler_flags,
             cxx_compiler_flags = ctx.attrs.cxx_compiler_flags,
@@ -63,6 +64,7 @@ go_toolchain = rule(
     impl = _go_toolchain_impl,
     is_toolchain_rule = True,
     attrs = {
+        "allow_cache_upload": attrs.option(attrs.bool(), default = None),
         "asan": attrs.bool(default = False),
         "assembler_flags": attrs.list(attrs.arg(), default = []),
         "build_tags": attrs.list(attrs.string(), default = []),

--- a/prelude/toolchains/go/system_go_toolchain.bzl
+++ b/prelude/toolchains/go/system_go_toolchain.bzl
@@ -57,6 +57,7 @@ def _system_go_toolchain_impl(ctx):
             }
         ),
         GoToolchainInfo(
+            allow_cache_upload = ctx.attrs.allow_cache_upload,
             assembler = RunInfo(cmd_script(ctx.actions, "asm", cmd_args(go, "tool", "asm"), script_language)),
             cgo = RunInfo(go_root.project(tool_prefix + "/cgo" + suffix)),
             pkg_analyzer = ctx.attrs.pkg_analyzer[RunInfo],
@@ -87,6 +88,7 @@ system_go_toolchain = rule(
       visibility = ["PUBLIC"],
   )""",
     attrs = {
+        "allow_cache_upload": attrs.option(attrs.bool(), default = None),
         "copy_goroot": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//go/tools:copy_goroot")),
         "gen_embedcfg": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//go/tools:gen_embedcfg")),
         "go_wrapper": attrs.default_only(attrs.dep(providers = [RunInfo], default = "prelude//go/tools:go_wrapper")),


### PR DESCRIPTION
Go actions do not set `allow_cache_upload`. If you use a remote cache but no remote execution, the results never reach the cache.

This change adds an `allow_cache_upload` field to `GoToolchainInfo`. The Go actions in `prelude/go` use this field. The `system_go_toolchain` rule and the `go_toolchain` rule get a related attribute.

The field is `bool | None`. The default value is `None`, similar to [PR #1367](https://github.com/facebook/buck2/pull/1367). `None` gives the control to the `buck2.default_allow_cache_upload` configuration. A default of `False` stops the cache upload for users of that configuration.

The behavior does not change if you do not set the attribute.

## Test

I built the Go example in `examples/with_prelude/go` and tested it with a local `bazel-remote` instance. All actions ran locally with no remote execution. Buck2 could read and write to the cache. I stopped the daemon and removed `buck-out` between the two tests.

With `allow_cache_upload = True` on the toolchain:
- Build 1: `Commands: 526 (cached: 0, remote: 0, local: 526)`
- Build 2: `Commands: 526 (cached: 501, remote: 0, local: 25)`

With no attribute and an empty cache:
- Build 1: `Commands: 526 (cached: 0, remote: 0, local: 526)`
- Build 2: `Commands: 526 (cached: 0, remote: 0, local: 526)`

The cache stayed empty. Thus the default behavior did not change.