### PR TITLE
test: don't print passing test details by default

### DIFF
--- a/app/buck2_client/BUCK
+++ b/app/buck2_client/BUCK
@@ -40,6 +40,7 @@ rust_library(
         "//buck2/app/buck2_data:buck2_data",
         "//buck2/app/buck2_error:buck2_error",
         "//buck2/app/buck2_event_log:buck2_event_log",
+        "//buck2/app/buck2_event_observer:buck2_event_observer",
         "//buck2/app/buck2_fs:buck2_fs",
         "//buck2/app/buck2_hash:buck2_hash",
         "//buck2/app/buck2_query_parser:buck2_query_parser",

--- a/app/buck2_client/Cargo.toml
+++ b/app/buck2_client/Cargo.toml
@@ -17,6 +17,7 @@ buck2_core.workspace = true
 buck2_data.workspace = true
 buck2_error.workspace = true
 buck2_event_log.workspace = true
+buck2_event_observer.workspace = true
 buck2_fs.workspace = true
 buck2_hash.workspace = true
 buck2_query_parser.workspace = true

--- a/app/buck2_client/src/commands/test.rs
+++ b/app/buck2_client/src/commands/test.rs
@@ -38,6 +38,8 @@ use buck2_client_ctx::subscribers::superconsole::test::span_from_build_failure_c
 use buck2_error::BuckErrorContext;
 use buck2_error::ExitCode;
 use buck2_error::internal_error;
+use buck2_event_observer::verbosity::Verbosity;
+use buck2_event_observer::verbosity::VerbosityItem;
 use buck2_fs::error::IoResultExt;
 use buck2_fs::fs_util;
 use buck2_fs::working_dir::AbsWorkingDir;
@@ -199,6 +201,13 @@ If include patterns are present, regardless of whether exclude patterns are pres
     #[allow(unused)]
     #[clap(long, group = "run-info")]
     skip_run_info: bool,
+
+    /// Show stdout/stderr output for passing tests.
+    ///
+    /// By default, passing tests only show a summary line. This flag
+    /// causes their full stdout/stderr to be displayed.
+    #[clap(long)]
+    print_passing_details: bool,
 
     /// This option does nothing. It is here to keep compatibility with Buck1 and ci
     #[clap(long = "deep", hide = true)]
@@ -559,6 +568,13 @@ impl StreamingCommand for TestCommand {
             }
             _ => exit_result,
         }
+    }
+
+    fn adjust_verbosity(&self, mut verbosity: Verbosity) -> Verbosity {
+        if self.print_passing_details {
+            verbosity.add_item(VerbosityItem::TestPassingDetails);
+        }
+        verbosity
     }
 
     fn console_opts(&self) -> &CommonConsoleOptions {

--- a/app/buck2_client_ctx/src/streaming.rs
+++ b/app/buck2_client_ctx/src/streaming.rs
@@ -18,6 +18,7 @@ use buck2_common::init::DEFAULT_RETAINED_EVENT_LOGS;
 use buck2_common::invocation_paths::InvocationPaths;
 use buck2_error::ExitCode;
 use buck2_event_observer::span_tracker::EventTimestamp;
+use buck2_event_observer::verbosity::Verbosity;
 use dupe::Dupe;
 
 use crate::client_ctx::BuckSubcommand;
@@ -92,10 +93,11 @@ fn update_events_ctx<T: StreamingCommand>(
         (None, None, None)
     };
 
+    let verbosity = cmd.adjust_verbosity(ctx.verbosity);
     let (console_subscriber, used_superconsole) = get_console_with_root(
         ctx.trace_id.dupe(),
         console_opts.console_type,
-        ctx.verbosity,
+        verbosity,
         expect_spans,
         Timekeeper::new(
             Box::new(RealtimeClock),
@@ -189,6 +191,10 @@ pub trait StreamingCommand: Sized + Send + Sync {
     fn build_config_opts(&self) -> &CommonBuildConfigurationOptions;
 
     fn starlark_opts(&self) -> &CommonStarlarkOptions;
+
+    fn adjust_verbosity(&self, verbosity: Verbosity) -> Verbosity {
+        verbosity
+    }
 
     fn extra_subscribers(&self) -> Vec<Box<dyn EventSubscriber>> {
         vec![]

--- a/app/buck2_event_observer/src/display.rs
+++ b/app/buck2_event_observer/src/display.rs
@@ -836,12 +836,12 @@ pub fn format_test_result(
             ))?);
         }
     }
-    // If a test has details, we always show them. It's the test runner's
-    // responsibility to withhold details when these are not relevant.
-    // For instance, tpx will always withhold details of passing tests
-    // unless the --print-passing-details is set.
+    // Show details for non-passing tests always. For passing tests, only
+    // show details if the test_passing_details verbosity item is set
+    // (e.g. via --print-passing-details or -v=test_passing_details).
     let mut lines = vec![base];
-    if !details.is_empty() {
+    let is_passing = matches!(&status, TestStatus::PASS | TestStatus::LISTING_SUCCESS);
+    if !details.is_empty() && (!is_passing || verbosity.print_test_passing_details()) {
         lines.append(&mut Lines::from_multiline_string(details, Default::default()).0);
     }
     Ok(Some(Lines(lines)))

--- a/app/buck2_event_observer/src/verbosity.rs
+++ b/app/buck2_event_observer/src/verbosity.rs
@@ -20,7 +20,7 @@ enum VerbosityError {
     UnknownItem(String),
 }
 
-const VERBOSITY_ITEM_VARIANTS: usize = 7;
+const VERBOSITY_ITEM_VARIANTS: usize = 8;
 
 /// The logging verbosity to use in our various consoles.
 ///
@@ -65,6 +65,8 @@ pub enum VerbosityItem {
     Stats,
     /// Some commands print a success message to stderr when they succeed
     Success,
+    /// Show stdout/stderr details for passing tests
+    TestPassingDetails,
     // ** update VERBOSITY_ITEM_VARIANTS const if more items are added **
 }
 
@@ -123,6 +125,7 @@ impl VerbosityItem {
             "status" => Self::Status,
             "stats" => Self::Stats,
             "success" => Self::Success,
+            "test_passing_details" => Self::TestPassingDetails,
             _ => return Err(VerbosityError::UnknownItem(value.to_owned()).into()),
         };
         Ok(item)
@@ -204,6 +207,20 @@ impl Verbosity {
     /// For commands that might do this, whether a message should be printed when the command succeeds.
     pub fn print_success_message(self) -> bool {
         self.has(VerbosityItem::Success)
+    }
+
+    /// Whether to show stdout/stderr details for passing tests.
+    pub fn print_test_passing_details(self) -> bool {
+        self.has(VerbosityItem::TestPassingDetails)
+    }
+
+    /// Add a verbosity item.
+    pub fn add_item(&mut self, item: VerbosityItem) {
+        if !self.has(item) {
+            if let Some(slot) = self.items.iter_mut().find(|s| s.is_none()) {
+                *slot = Some(item);
+            }
+        }
     }
 }
 

--- a/tests/core/help/test_help_data/buck2-help-test.golden.txt
+++ b/tests/core/help/test_help_data/buck2-help-test.golden.txt
@@ -80,6 +80,12 @@ Options:
       --skip-run-info
           Do not build RunInfo provider (this is the default)
 
+      --print-passing-details
+          Show stdout/stderr output for passing tests.
+
+          By default, passing tests only show a summary line. This flag causes their full
+          stdout/stderr to be displayed.
+
       --build-report <PATH>
           Print a build report
 


### PR DESCRIPTION
This makes the default test output much, much easier to parse, navigate, and read; `stdout` and `stderr` for working tests can completely drown things out, and when you have thousands of tests there's no need to see it

The current behavior can be restored with two different flags:

     --print-passing-details

or

     -v=test_passing_details

This is often useful for dialing in a specific test so that you can analyze it. Note: this does not change the _failing_ behavior, which is to still print the output streams, as expected.

Example of before vs after:

---

**Before**

```
a@spark-92da ~/a/t/a/libedsign> buck test --print-passing-details ...
✓ Pass: depot-tilde//aseipp/libedsign:test-fingerprint (0.0s)
---- STDOUT ----
result: OK

---- STDERR ----

✓ Pass: depot-tilde//aseipp/libedsign:test-roundtrip (0.0s)
---- STDOUT ----
result: OK

---- STDERR ----

✓ Pass: depot-tilde//aseipp/libedsign:test-rekey (0.0s)
---- STDOUT ----
result: OK

---- STDERR ----

Build ID: 09771699-0b17-4860-8be9-7657a8d479db
...
```

---

**After**

```
a@spark-92da ~/a/t/a/libedsign> buck test ...
✓ Pass: depot-tilde//aseipp/libedsign:test-roundtrip (0.0s)
✓ Pass: depot-tilde//aseipp/libedsign:test-fingerprint (0.0s)
✓ Pass: depot-tilde//aseipp/libedsign:test-rekey (0.0s)
Build ID: ae93786d-2993-42a9-8711-1140add76160
...
```