### PR TITLE
Recover when a stale daemon pid cannot be killed

### DIFF
--- a/app/buck2_client_ctx/src/daemon/client/connect.rs
+++ b/app/buck2_client_ctx/src/daemon/client/connect.rs
@@ -854,9 +854,16 @@ async fn establish_connection_inner(
                             ))
                             .await?;
 
-                        hard_kill_until(&buckd_info.info, &deadline)
-                            .await
-                            .map_err(|error| BuckdConnectError::DaemonKillFailed { error })?;
+                        // The recorded daemon is unusable either way, so start a new one rather
+                        // than leaving buckd.info in place for the next invocation to trip over.
+                        if let Err(error) = hard_kill_until(&buckd_info.info, &deadline).await {
+                            events_ctx
+                                .eprintln(&format!(
+                                    "{}",
+                                    BuckdConnectError::DaemonKillFailed { error }
+                                ))
+                                .await?;
+                        }
 
                         reason
                     }


### PR DESCRIPTION
If buckd.info names a pid we cannot kill - it was reused by a process owned by another user, say - the kill error aborted the connect before clean_daemon_dir ran. The stale buckd.info survived, so every later invocation failed the same way and the only way out was deleting the daemon dir by hand.

Report the failed kill and start a new daemon instead of aborting.

This fixes an error seen by a user where after a PID on windows was re-used, the user was stuck until deleting their ~/.buck/buckd directory.

```
> buck2 killall; buck2 server

  Killed buck2.exe (26140).
  Could not connect to buck2 daemon (Could not connect to daemon), killing daemon..
  Command failed: Failed to connect to buck daemon.
      Daemon process info from C:\Users\...\.buck\buckd\C\git\roblox\game-engine\v2\buckd.info:
      pid: 21076
      endpoint: tcp:62852
      version: baf6de80...
      pid present on system: yes
      Try running `buck2 kill` and your command afterwards.
      Alternatively, try running `rmdir /s /q %USERPROFILE%\.buck\buckd` and your command afterwards
  Caused by:
      0: Error connecting to the daemon, daemon stderr follows:
```