### PR TITLE
Resolve todo and read binary name from plistlib

### DIFF
--- a/prelude/apple/tools/code_signing/fast_adhoc.py
+++ b/prelude/apple/tools/code_signing/fast_adhoc.py
@@ -10,6 +10,7 @@
 
 import logging
 import os
+import plistlib
 import subprocess
 import sys
 from pathlib import Path
@@ -30,8 +31,23 @@ def _find_executable_for_signed_path(path: Path, platform: ApplePlatform) -> Pat
 
     contents_subdir = "Contents/MacOS" if platform.is_desktop() else ""
     contents_dir = path / contents_subdir
-    # TODO(): Read binary name from Info.plist
-    return contents_dir / path.stem
+
+    # Read binary name from Info.plist
+    info_plist_path = path / (
+        "Contents/Info.plist" if platform.is_desktop() else "Info.plist"
+    )
+    executable_name = path.stem
+    if info_plist_path.exists():
+        try:
+            with open(info_plist_path, "rb") as file:
+                plist = plistlib.load(file)
+            executable_name = plist.get("CFBundleExecutable", path.stem)
+        except Exception:
+            _LOGGER.info(
+                f"  Failed to parse '{info_plist_path}', falling back to '{path.stem}'"
+            )
+
+    return contents_dir / executable_name
 
 
 def _logged_subprocess_run(


### PR DESCRIPTION
There was a todo here to read the executable name from plist (https://docs.python.org/3/library/plistlib.html)

so refactored to read it from the plist config. If there's any failure reading the config or if the key isn't present, fallback to the first method (just extracting it from the path)