### PR TITLE
prelude/git: Expose the fetched repository as a `.git` sub-target

### DIFF
--- a/prelude/git/git_fetch.bzl
+++ b/prelude/git/git_fetch.bzl
@@ -63,9 +63,16 @@ def git_fetch_impl(ctx: AnalysisContext) -> list[Provider]:
         allow_cache_upload = ctx.attrs.allow_cache_upload,
     )
 
+    sub_targets = {path: [DefaultInfo(default_output = work_tree.project(path))] for path in ctx.attrs.sub_targets}
+
+    # The repository itself, for consumers that need to serve the fetch as a local git remote
+    # rather than read the checked-out files. git refuses to track a path named ".git", so no
+    # requested work-tree projection can ever claim this key.
+    sub_targets[".git"] = [DefaultInfo(default_output = git_dir)]
+
     return [
         DefaultInfo(
             default_output = work_tree,
-            sub_targets = {path: [DefaultInfo(default_output = work_tree.project(path))] for path in ctx.attrs.sub_targets},
+            sub_targets = sub_targets,
         )
     ]

--- a/tests/core/prelude/BUCK
+++ b/tests/core/prelude/BUCK
@@ -1,0 +1,5 @@
+load("@fbcode//buck2/tests:buck_e2e.bzl", "buck2_core_tests")
+
+oncall("build_infra")
+
+buck2_core_tests()

--- a/tests/core/prelude/test_git_fetch.py
+++ b/tests/core/prelude/test_git_fetch.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# pyre-strict
+
+import subprocess
+from pathlib import Path
+
+from buck2.tests.e2e_util.api.buck import Buck
+from buck2.tests.e2e_util.asserts import expect_failure
+from buck2.tests.e2e_util.buck_workspace import buck_test
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    return subprocess.check_output(["git", *args], cwd=cwd, encoding="utf-8").strip()
+
+
+def _init_repo(cwd: Path) -> str:
+    """Create the repository to fetch from, and return the commit to pin.
+
+    It sits next to the project rather than inside it, so that buck neither sees it as
+    source nor watches it.
+    """
+    repo = (cwd.parent / "remote").absolute()
+    repo.mkdir()
+    _git(["init"], cwd=repo)
+    _git(["config", "user.name", "notarealuser"], cwd=repo)
+    _git(["config", "user.email", "notarealuser@fb.com"], cwd=repo)
+    # git_fetch asks for a commit by hash, which a repository only serves when told to.
+    # The hosts it is aimed at allow that; a freshly created repository does not.
+    _git(["config", "uploadpack.allowAnySHA1InWant", "true"], cwd=repo)
+
+    (repo / "hello.txt").write_text("hello\n")
+    (repo / "subdir").mkdir()
+    (repo / "subdir" / "nested.txt").write_text("nested\n")
+    _git(["add", "."], cwd=repo)
+    _git(["commit", "-m", "Commit name"], cwd=repo)
+    rev = _git(["log", "--format=format:%H", "-1"], cwd=repo)
+
+    with open(cwd / ".buckconfig", "a") as f:
+        f.write(f"\n[test_git_fetch]\n  repo = {repo.as_uri()}\n  rev = {rev}\n")
+    return rev
+
+
+@buck_test()
+async def test_fetches_the_work_tree(buck: Buck) -> None:
+    _init_repo(cwd=buck.cwd)
+
+    res = await buck.build_without_report(
+        "root//:fetch.git", "--show-full-simple-output"
+    )
+    assert (Path(res.stdout.strip()) / "hello.txt").read_text() == "hello\n"
+
+
+@buck_test()
+async def test_requested_paths_are_sub_targets(buck: Buck) -> None:
+    _init_repo(cwd=buck.cwd)
+
+    res = await buck.build_without_report(
+        "root//:fetch.git[subdir]", "--show-full-simple-output"
+    )
+    assert (Path(res.stdout.strip()) / "nested.txt").read_text() == "nested\n"
+
+
+@buck_test()
+async def test_the_repository_itself_is_not_reachable(buck: Buck) -> None:
+    _init_repo(cwd=buck.cwd)
+
+    await expect_failure(
+        buck.build("root//:fetch.git[.git]"),
+        stderr_regex="sub target named `.git`.*is not available",
+    )

--- a/tests/core/prelude/test_git_fetch.py
+++ b/tests/core/prelude/test_git_fetch.py
@@ -12,7 +12,6 @@ import subprocess
 from pathlib import Path
 
 from buck2.tests.e2e_util.api.buck import Buck
-from buck2.tests.e2e_util.asserts import expect_failure
 from buck2.tests.e2e_util.buck_workspace import buck_test
 
 
@@ -68,10 +67,15 @@ async def test_requested_paths_are_sub_targets(buck: Buck) -> None:
 
 
 @buck_test()
-async def test_the_repository_itself_is_not_reachable(buck: Buck) -> None:
-    _init_repo(cwd=buck.cwd)
+async def test_git_dir_sub_target_is_a_repository(buck: Buck) -> None:
+    rev = _init_repo(cwd=buck.cwd)
 
-    await expect_failure(
-        buck.build("root//:fetch.git[.git]"),
-        stderr_regex="sub target named `.git`.*is not available",
+    res = await buck.build_without_report(
+        "root//:fetch.git[.git]", "--show-full-simple-output"
+    )
+    git_dir = Path(res.stdout.strip())
+
+    # Validate this is a proper .git tree
+    assert _git(["--git-dir", str(git_dir), "cat-file", "-t", rev], cwd=buck.cwd) == (
+        "commit"
     )

--- a/tests/core/prelude/test_git_fetch_data/.buckconfig
+++ b/tests/core/prelude/test_git_fetch_data/.buckconfig
@@ -1,0 +1,25 @@
+[cells]
+  root = .
+  prelude = prelude
+
+[cell_aliases]
+  config = prelude
+  toolchains = root
+  # Just have to exist, not actually used for this test
+  fbsource = root
+  fbcode = root
+  buck = root
+
+# This test runs in a workspace of its own, with no path back to the repository's
+# prelude/ directory. `bundled` uses the copy that gets compiled into the buck2
+# binary from it, so the test exercises this repository's prelude/, not a stub.
+[external_cells]
+  prelude = bundled
+
+[buildfile]
+  name = TARGETS.fixture
+
+[parser]
+  target_platform_detector_spec = target:root//...->prelude//platforms:default
+
+# The test appends a [test_git_fetch] section naming the repository it created.

--- a/tests/core/prelude/test_git_fetch_data/TARGETS.fixture
+++ b/tests/core/prelude/test_git_fetch_data/TARGETS.fixture
@@ -1,0 +1,13 @@
+load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
+
+system_python_bootstrap_toolchain(
+    name = "python_bootstrap",
+    visibility = ["PUBLIC"],
+)
+
+git_fetch(
+    name = "fetch.git",
+    repo = read_config("test_git_fetch", "repo"),
+    rev = read_config("test_git_fetch", "rev"),
+    sub_targets = ["subdir"],
+)


### PR DESCRIPTION
`git_fetch()` declares the `.git` directory as an output, but previously
only handed out the checked-out work tree.

Expose the existing output as a `.git` sub-target next to the
path-projection sub-targets. The name cannot collide: git refuses to
track a path named `.git`, so no requested work-tree projection can
ever claim it.

This is useful for e.g. fetching cargo git repos: cargo's source
replacement (`[source.x] git = "file://..."`) fetches from the object
database, which is how a Rust crate's git dependencies can be served
locally. A work tree cannot be re-initialized as a git repo, as that
would not carry the actual pinned hash.

Flip the previous commit's test accordingly: the sub-target holds the
pinned commit in an object database.

---

Plus a preparatory commit that introduces `git_fetch()` coverage in the first place -- it didn't have any tests before.