### PR TITLE
DICE examples: fix build on macOS

### DIFF
--- a/dice/dice_examples/bin/memory_by_key.rs
+++ b/dice/dice_examples/bin/memory_by_key.rs
@@ -163,6 +163,12 @@ fn read_heap_allocated_bytes() -> isize {
 }
 
 unsafe extern "C" {
+    // tikv_jemallocator uses a `_rjem_` prefix for its functions if prefixing is enabled:
+    // <https://docs.rs/crate/tikv-jemalloc-sys/0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8/source/src/lib.rs#143>
+    // and the prefixing is force-enabled on Apple:
+    // <https://docs.rs/crate/tikv-jemalloc-sys/0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8/source/src/env.rs#24>
+    // thus we have to prefix it. this would be avoidable if they exposed this function as API :)
+    #[cfg_attr(target_os = "macos", link_name = "_rjem_mallctl")]
     fn mallctl(
         name: *const std::ffi::c_char,
         oldp: *mut std::ffi::c_void,


### PR DESCRIPTION
this is because the jemalloc crate requires a prefix on macOS which then causes build failures when you try to link the unprefixed symbol. it of course ignores the cargo feature saying to not prefix it (lol) and doesn't expose the mallctl api in a way that's agnostic to the prefixing (lol) so you have to cfg it at the use site.