### PR TITLE
infer_target_names: fix `attrs.source()` coercion

### DIFF
--- a/app/buck2_interpreter_for_build/src/attrs/coerce/attr_type/source.rs
+++ b/app/buck2_interpreter_for_build/src/attrs/coerce/attr_type/source.rs
@@ -43,7 +43,10 @@ impl AttrTypeCoerce for SourceAttrType {
     ) -> buck2_error::Result<CoercedAttr> {
         let source_label = value.unpack_str_err()?;
 
-        let label_err = if source_label.contains(':') {
+        // A label needs a `:` (`//foo:bar`, `:bar`) unless the target name is being inferred from
+        // the package name, in which case `//foo/bar` means `//foo/bar:bar`. `//` can't appear in a
+        // valid path, so testing for it doesn't cost us any path coercions.
+        let label_err = if source_label.contains(':') || source_label.contains("//") {
             match ctx.coerce_providers_label(source_label) {
                 Ok(l) => return Ok(CoercedAttr::SourceLabel(l)),
                 Err(e) => Some(e),

--- a/tests/core/interpreter/test_infer_target_names.py
+++ b/tests/core/interpreter/test_infer_target_names.py
@@ -41,6 +41,27 @@ async def test_eponymous_dep_in_build_file_inferred_when_enabled(buck: Buck) -> 
 
 
 @buck_test()
+async def test_eponymous_source_in_build_file_rejected_by_default(buck: Buck) -> None:
+    # `attrs.source()` takes either a path or a label, so it coerces separately
+    # from `attrs.dep()`. Without the buckconfig, `//lib/greeting` is only ever
+    # tried as a path, which fails because it isn't relative.
+    await expect_failure(
+        buck.uquery("deps(root//:src_consumer)", "--console=none", "-v0"),
+        stderr_regex=r"Couldn't coerce `//lib/greeting` as a source",
+    )
+
+
+@buck_test()
+async def test_eponymous_source_in_build_file_inferred_when_enabled(
+    buck: Buck,
+) -> None:
+    # With the buckconfig, the source attr coerces to the eponymous label rather
+    # than being (mis)treated as a path.
+    res = await buck.uquery("deps(root//:src_consumer)", "-c", _ENABLE)
+    assert "root//lib/greeting:greeting" in res.stdout
+
+
+@buck_test()
 async def test_eponymous_attr_default_in_bzl_rejected_by_default(buck: Buck) -> None:
     # The `//bzl_default` rule declares `attrs.dep(default = "//lib/greeting")`.
     # The default is coerced while evaluating the .bzl module, so it errors

--- a/tests/core/interpreter/test_infer_target_names_data/TARGETS.fixture
+++ b/tests/core/interpreter/test_infer_target_names_data/TARGETS.fixture
@@ -1,6 +1,11 @@
-load(":defs.bzl", "consumer")
+load(":defs.bzl", "consumer", "src_consumer")
 
 consumer(
     name = "consumer",
     deps = ["//lib/greeting"],
+)
+
+src_consumer(
+    name = "src_consumer",
+    srcs = ["//lib/greeting"],
 )

--- a/tests/core/interpreter/test_infer_target_names_data/defs.bzl
+++ b/tests/core/interpreter/test_infer_target_names_data/defs.bzl
@@ -14,3 +14,12 @@ consumer = rule(
         "deps": attrs.list(attrs.dep(), default = []),
     },
 )
+
+# `attrs.source()` accepts either a path or a label, so it has its own coercion
+# logic and needs its own coverage for eponymous labels.
+src_consumer = rule(
+    impl = lambda _ctx: [DefaultInfo()],
+    attrs = {
+        "srcs": attrs.list(attrs.source(), default = []),
+    },
+)


### PR DESCRIPTION
Bug found while trying to update our buck2 version: apparently we screwed it up while implementing https://github.com/facebook/buck2/pull/1004.

Error in production:

```
    3: error: Error coercing attribute `srcs_deps` of `root//src/Foo:Foo`
       Traceback (most recent call last):
         * src/Foo/BUCK:28, in <module>
             mercury_haskell_library(
         * haskell/mercury_haskell.bzl:236, in mercury_haskell_library
             haskell_library(

    4: Error coercing attribute `srcs_deps` of type `attrs.dict(attrs.source(), attrs.list(attrs.source()), sorted=False, default={})`
    5: Error coercing {"FooBar.hs": ["//data/SomeMercuryThing"]}
    6: Error coercing ["//data/SomeMercuryThing"]
    7: Error coercing "//data/SomeMercuryThing"
    8: Coercing `//data/SomeMercuryThing` as a source
    9: expected a relative path but got an absolute path instead: `//data/SomeMercuryThing`
```

Assisted-By: Claude Opus 5