### PR TITLE
fix: python bootstrap uses relative paths

### DIFF
--- a/prelude/python/make_py_package.bzl
+++ b/prelude/python/make_py_package.bzl
@@ -591,7 +591,12 @@ def _make_py_package_impl(
         modules.add(modules_args)
         if package_style == PackageStyle("outplace"):
             modules.add(cmd_args("--copy-files", hidden = runtime_artifacts))
-        ctx.actions.run(modules, category = "par", identifier = "modules{}".format(output_suffix))
+        ctx.actions.run(
+            modules,
+            category = "par",
+            identifier = "modules{}".format(output_suffix),
+            allow_cache_upload = allow_cache_upload,
+        )
 
         bootstrap = cmd_args(python_internal_tools.make_py_package_inplace)
         bootstrap.add(bootstrap_args)
@@ -604,7 +609,12 @@ def _make_py_package_impl(
         for flag in ctx.attrs.interpreter_args:
             bootstrap.add(cmd_args(["--python-interpreter-flags={}".format(flag)]))
 
-        ctx.actions.run(bootstrap, category = "par", identifier = "bootstrap{}".format(output_suffix))
+        ctx.actions.run(
+            bootstrap,
+            category = "par",
+            identifier = "bootstrap{}".format(output_suffix),
+            allow_cache_upload = allow_cache_upload,
+        )
 
     run_args = []
 

--- a/prelude/python/tools/BUCK
+++ b/prelude/python/tools/BUCK
@@ -120,11 +120,13 @@ prelude.python_bootstrap_binary(
 )
 
 # Run the test suite with this command:
-# buck2 run prelude//python/tools:wheel_tests --target-platforms prelude//platforms:default
+# buck2 run prelude//python/tools:tool_tests --target-platforms prelude//platforms:default
 prelude.sh_binary(
-    name = "wheel_tests",
+    name = "tool_tests",
     main = "tests/main.sh",
     resources = [
+        "make_py_package_inplace.py",
+        "run_inplace.py.in",
         "wheel.py",
     ]
     + glob(["tests/**/*.py"]),

--- a/prelude/python/tools/make_py_package_inplace.py
+++ b/prelude/python/tools/make_py_package_inplace.py
@@ -43,6 +43,32 @@ import platform
 import stat
 from pathlib import Path
 
+# Shell/Python polyglot, substituted for `<PYTHON>` in the template (i.e. it is
+# what follows the `#!`). `/bin/sh` runs the block between the `"true"` line and
+# the closing quotes; Python parses that same text as a pair of implicitly
+# concatenated string literals and ignores it. Windows has no `#!` support and
+# runs the bootstrapper as `python <pex>`, where this is likewise inert.
+_SH_TRAMPOLINE = r"""/bin/sh
+"true" '''\'
+# The interpreter is at a path relative to this script rather than at a fixed
+# absolute one, so resolve it here (following symlinks) and hand off.
+_self=$0
+case $_self in */*) ;; *) _self=./$_self ;; esac
+_depth=0
+while [ -L "$_self" ] && [ "$_depth" -lt 32 ]; do
+    # `readlink` is not in POSIX sh builtins and `$PATH` may be scrubbed; if it is missing, settle
+    # for the directory holding the symlink.
+    _link=$(readlink "$_self" 2>/dev/null) || break
+    [ -n "$_link" ] || break
+    case $_link in
+        /*) _self=$_link ;;
+        *) _self=${_self%/*}/$_link ;;
+    esac
+    _depth=$((_depth + 1))
+done
+exec "${_self%/*}/<REL_PYTHON>" "$0" "$@"
+'''"""
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -69,7 +95,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--python",
         required=True,
-        help="The python binary to put in the bootstrapper hashbang",
+        help=(
+            "The python binary to launch the bootstrapper with. An absolute path"
+            " or a bare name goes straight into the hashbang; a path relative to"
+            " the project root is resolved at runtime relative to the"
+            " bootstrapper instead, see write_bootstrapper()"
+        ),
     )
     parser.add_argument(
         "--host-python",
@@ -155,24 +186,38 @@ def write_bootstrapper(args: argparse.Namespace) -> None:
     relative_modules_dir = os.path.relpath(args.modules_dir, args.output.parent)
     native_lib_dirs = [relative_modules_dir] + args.native_library_runtime_paths
 
-    # TODO(nmj): Remove this hack. So, if arg0 in your shebang is a bash script
-    #                 (like /usr/local/fbcode/platform007/bin/python3.7 on macs is)
-    #                 OSX just sort of ignores it and tries to run your thing with
-    #                 the current shell. So, we hack in /usr/bin/env in the front
-    #                 for now, and let it do the lifting. OSX: Bringing you the best
-    #                 of 1980s BSD in 2021...
-
     ld_preload = None
     if args.preload_libraries:
         ld_preload = [p.name for p in args.preload_libraries]
 
     python = str(args.python)
-    if not os.path.isabs(python) and os.path.sep in python:
-        python = os.path.abspath(python)
+    separators = [os.path.sep] + ([os.path.altsep] if os.path.altsep else [])
+    if os.path.isabs(python) or not any(sep in python for sep in separators):
+        # An absolute path is machine-independent already, and a bare word is for `/usr/bin/env` to
+        # look up on `$PATH`. Both are fine in a `#!` line.
+        #
+        # TODO(nmj): Remove this hack. So, if arg0 in your shebang is a bash script
+        #                 (like /usr/local/fbcode/platform007/bin/python3.7 on macs is)
+        #                 OSX just sort of ignores it and tries to run your thing with
+        #                 the current shell. So, we hack in /usr/bin/env in the front
+        #                 for now, and let it do the lifting. OSX: Bringing you the best
+        #                 of 1980s BSD in 2021...
+        launcher = f"/usr/bin/env {python}"
+    else:
+        # The interpreter is a build artifact, so we have a cwd (project/cell root) relative path.
+        #
+        # However, the shebang must be absolute (relative paths are resolved relative to cwd at
+        # runtime and we want to be cwd-independent).
+        # Thus we use a #!/bin/sh trampoline.
+        relative_python = os.path.relpath(python, args.output.parent)
+        launcher = _SH_TRAMPOLINE.replace(
+            "<REL_PYTHON>", relative_python.replace(os.path.sep, "/")
+        )
 
-    new_data = data.replace("<PYTHON>", f"/usr/bin/env {python}")
-    # Instead, pass interpreter flags via the Python variable that the re-exec
-    # path uses (e.g. -Xgil=0 for free-threaded builds).
+    new_data = data.replace("<PYTHON>", launcher, 1)
+    # Interpreter flags go into the Python variable that the re-exec path uses
+    # (e.g. -Xgil=0 for free-threaded builds) rather than onto the launcher line,
+    # which on Linux can carry at most one argument.
     new_data = new_data.replace(
         "<PYTHON_INTERPRETER_FLAGS>", " ".join(args.python_interpreter_flags or [])
     )

--- a/prelude/python/tools/run_inplace.py.in
+++ b/prelude/python/tools/run_inplace.py.in
@@ -6,6 +6,9 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+# N.B. The `#!` line above expands to multiple lines of shell/python polyglot that resolves the
+# interpreter relative to the generated file if the Python interpreter is an artifact path.
+
 # LINKTREEDIR=<MODULES_DIR>
 
 main_module = "<MAIN_MODULE>"

--- a/prelude/python/tools/tests/make_py_package_inplace_test.py
+++ b/prelude/python/tools/tests/make_py_package_inplace_test.py
@@ -1,0 +1,217 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+# pyre-strict
+
+import contextlib
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+import make_py_package_inplace
+
+TEMPLATE: Path = Path(__file__).resolve().parent.parent / "run_inplace.py.in"
+
+STUB_RUNNER = """\
+def run_as_main(main_module, main_function):
+    import runpy
+
+    runpy.run_module(main_module, run_name="__main__", alter_sys=True)
+"""
+
+APP = """\
+import os
+
+print("ran with PYTHONPATH", os.environ["PYTHONPATH"])
+"""
+
+
+@contextlib.contextmanager
+def _cwd(path: Path) -> Iterator[None]:
+    old = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+def _make_bootstrapper(
+    project_root: Path,
+    python: str,
+    output: str = "out/bin.pex",
+    modules_dir: str = "out/bin#link-tree",
+    extra_args: Optional[List[str]] = None,
+) -> Path:
+    """Run the tool as buck2 would: from the project root, with relative paths."""
+
+    argv = [
+        "make_py_package_inplace.py",
+        "--template",
+        str(TEMPLATE),
+        "--python",
+        python,
+        "--host-python",
+        sys.executable,
+        "--entry-point",
+        "app",
+        "--main-runner",
+        "stub_runner.run_as_main",
+        "--modules-dir",
+        modules_dir,
+        output,
+    ]
+    argv.extend(extra_args or [])
+
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        with _cwd(project_root):
+            make_py_package_inplace.main()
+    finally:
+        sys.argv = old_argv
+    return project_root / output
+
+
+class ShebangTest(unittest.TestCase):
+    """The interpreter must never reach the output as an absolute path that was
+    derived from the project root: the action's command line, and so its cache
+    key, is project-root-independent, so its output has to be too."""
+
+    def test_bare_interpreter_is_left_to_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(Path(tmpdir), "python3")
+            self.assertEqual(
+                pex.read_text(encoding="utf8").splitlines()[0],
+                "#!/usr/bin/env python3",
+            )
+
+    def test_absolute_interpreter_is_used_verbatim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(Path(tmpdir), "/usr/bin/python3")
+            self.assertEqual(
+                pex.read_text(encoding="utf8").splitlines()[0],
+                "#!/usr/bin/env /usr/bin/python3",
+            )
+
+    def test_relative_interpreter_uses_sh_trampoline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(
+                Path(tmpdir), "buck-out/v2/gen/toolchains/cpython/bin/python3"
+            )
+            data = pex.read_text(encoding="utf8")
+            lines = data.splitlines()
+
+            self.assertEqual(lines[0], "#!/bin/sh")
+            self.assertIn(
+                'exec "${_self%/*}/../buck-out/v2/gen/toolchains/cpython/bin/python3"'
+                ' "$0" "$@"',
+                lines,
+            )
+            # The whole point: nothing machine-specific in the output.
+            self.assertNotIn(tmpdir, data)
+
+    def test_output_does_not_depend_on_project_root(self) -> None:
+        interpreter = "buck-out/v2/gen/toolchains/cpython/bin/python3"
+        outputs = []
+        for name in ("short", "a/much/deeper/checkout/path"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir) / name
+                root.mkdir(parents=True)
+                outputs.append(
+                    _make_bootstrapper(root, interpreter).read_bytes(),
+                )
+        self.assertEqual(outputs[0], outputs[1])
+
+    def test_bootstrapper_is_valid_python(self) -> None:
+        # Windows ignores `#!` and runs the bootstrapper as `python <pex>`, so
+        # the shell trampoline has to parse as Python too.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = _make_bootstrapper(
+                Path(tmpdir), "buck-out/v2/gen/toolchains/cpython/bin/python3"
+            )
+            compile(pex.read_text(encoding="utf8"), str(pex), "exec")
+
+
+@unittest.skipIf(sys.platform == "win32", "no #! support on Windows")
+class TrampolineRuntimeTest(unittest.TestCase):
+    def _make_project(self, tmpdir: str) -> Path:
+        root = Path(tmpdir) / "project"
+        (root / "out/bin#link-tree").mkdir(parents=True)
+        (root / "out/bin#link-tree/stub_runner.py").write_text(
+            STUB_RUNNER, encoding="utf8"
+        )
+        (root / "out/bin#link-tree/app.py").write_text(APP, encoding="utf8")
+
+        # Stand in for a hermetic interpreter built by some other rule.
+        (root / "buck-out/interpreter").mkdir(parents=True)
+        os.symlink(
+            os.path.realpath(sys.executable), root / "buck-out/interpreter/python3"
+        )
+
+        _make_bootstrapper(root, "buck-out/interpreter/python3")
+        return root
+
+    def _run(self, argv: List[str], cwd: str) -> str:
+        proc = subprocess.run(
+            argv,
+            cwd=cwd,
+            capture_output=True,
+            encoding="utf8",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        return proc.stdout
+
+    def test_runs_from_an_unrelated_cwd(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_project(tmpdir)
+            out = self._run([str(root / "out/bin.pex")], cwd=tempfile.gettempdir())
+            self.assertIn(
+                "ran with PYTHONPATH {}".format(root / "out/bin#link-tree"), out
+            )
+
+    def test_runs_with_a_relative_argv0(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_project(tmpdir)
+            out = self._run(["./out/bin.pex"], cwd=str(root))
+            self.assertIn(
+                "ran with PYTHONPATH {}".format(root / "out/bin#link-tree"), out
+            )
+
+    def test_runs_through_a_chain_of_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_project(tmpdir)
+            # A relative link, then an absolute one pointing at it.
+            os.symlink("out/bin.pex", root / "relative-link.pex")
+            os.symlink(root / "relative-link.pex", Path(tmpdir) / "absolute-link.pex")
+            out = self._run(
+                [str(Path(tmpdir) / "absolute-link.pex")], cwd=tempfile.gettempdir()
+            )
+            self.assertIn("ran with PYTHONPATH", out)
+
+    def test_runs_without_a_usable_path(self) -> None:
+        # Pexes get used as build tools, where buck2 scrubs the environment.
+        # Nothing in the trampoline may depend on finding a helper on $PATH.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pex = self._make_project(tmpdir) / "out/bin.pex"
+            proc = subprocess.run(
+                [str(pex)],
+                env={},
+                capture_output=True,
+                encoding="utf8",
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("ran with PYTHONPATH", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This got us good at Mercury and took down some builds when we enabled `default_allow_cache_upload = true`.

The primary bug: make_py_package_inplace writes a bootstrap script like so:

```python
python = str(args.python)
if not os.path.isabs(python) and os.path.sep in python:
    python = os.path.abspath(python)

new_data = data.replace("<PYTHON>", f"/usr/bin/env {python}")
```

Absolutizing the interpreter path causes this to be a cache poisoning bug if ever uploaded. In our case, our python interpreter is an artifact, so it gets made absolute, thus baking our GitHub actions home directory into the uploaded actions.

This bug came from 5f5f6927c3 (D79552056) which was endeavouring to make calling PARs not rely on the working directory anymore which it did successfully but via means it calls a "terrible idea".

Let's do this in a way that's not terrible.

Why didn't this hit Meta: the RE sandbox is always at `/re_cwd`, and the Python interpreter is usually(?) at an absolute path.

This also fixes a bug where `allow_cache_upload` (via `cxx_attrs_get_allow_cache_upload`) got dropped before hitting the PAR actions, so it's not even possible to turn it off on known non-hermetic actions.

The methodology behind this PR was that I told some agents to find how Bazel fixes this Python bootstrapping problem and learn all the footguns they hit.

One of their impls: https://github.com/bazel-contrib/rules_python/blob/16e167a5b269930f2f5000c4d9dc99b72f930f2b/python/private/pypi/venv_shebang_rewriter.sh

Here's a brief list:

1. `!#/bin/bash` is not compatible with NixOS: `#!/usr/bin/env bash` or `#!/bin/sh` is preferable.
2. Apparently Bazel has a bug with their wrappers' $0 where they got symlink handling wrong: it needs to walk component by component.
3. `exec -a` is not POSIX, so `dash` doesn't implement it. We have to use a `sh -c` trick instead.

You know the deal, the tests are vibed, you can throw them out or clean them up as desired, since I can't run them without being at fb.

Fixes: https://github.com/facebook/buck2/issues/1135
Fixes: https://github.com/facebook/buck2/issues/1268