### PR TITLE
Make clean stale scan art-anon and art-bxl dirs

### DIFF
--- a/app/buck2_execute_impl/src/materializers/deferred/clean_stale.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred/clean_stale.rs
@@ -244,7 +244,7 @@ impl CleanStaleArtifactsCommand {
         let start_time = Instant::now();
 
         let mut artifact_dirs = Vec::new();
-        for dir_name in &["gen", "art"] {
+        for dir_name in &["gen", "art", "art-anon", "art-bxl"] {
             let dir_path = io
                 .buck_out_path()
                 .join(ProjectRelativePathBuf::unchecked_new(dir_name.to_string()));


### PR DESCRIPTION
Anon target and bxl outputs are written to sibling directories rather than under `art`: their `make_hashed_path` impls append `-anon`/`-bxl` to the path prefix. The scan root list named only `gen` and `art`, so the walk never reached them and artifacts there were never cleaned, either as stale or as untracked.