### PR TITLE
Do not underflow when retained_event_logs is zero

### DIFF
--- a/app/buck2_event_log/src/file_names.rs
+++ b/app/buck2_event_log/src/file_names.rs
@@ -46,7 +46,10 @@ pub(crate) fn get_logfile_name(
 
 pub(crate) async fn remove_old_logs(logdir: &AbsNormPath, retained_event_logs: usize) {
     if let Ok(logfiles) = get_files_in_log_dir(logdir) {
-        futures::stream::iter(logfiles.into_iter().rev().skip(retained_event_logs - 1))
+        // `retained_event_logs` counts the log about to be written, so one fewer
+        // existing log is kept. Saturate rather than wrap: zero means retain none.
+        let retained_existing_logs = retained_event_logs.saturating_sub(1);
+        futures::stream::iter(logfiles.into_iter().rev().skip(retained_existing_logs))
             .then(|file| async move {
                 // The oldest logs might be open from another concurrent build, so suppress error.
                 tokio::fs::remove_file(file).await.ok()
@@ -201,6 +204,40 @@ mod tests {
                 "{} should remain",
                 inside_file.display()
             );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_remove_old_logs_with_zero_retained() -> buck2_error::Result<()> {
+        let logdir = tempfile::tempdir()?;
+        let logdir_path = AbsPath::new(logdir.path())?;
+        let logdir_norm = AbsNormPath::new(logdir_path)?;
+
+        let base_time = SystemTime::now()
+            .checked_sub(Duration::from_secs(100))
+            .unwrap();
+
+        let mut log_paths = Vec::new();
+        for i in 0..3 {
+            let log_path = logdir_path.join(format!("buck-log-{}.zst", i));
+            let mut file = File::create(&log_path)?;
+            file.write_all(format!("log content {}", i).as_bytes())?;
+
+            let mod_time = base_time + Duration::from_secs((i as u64) * 10);
+            let times = std::fs::FileTimes::new().set_modified(mod_time);
+            file.set_times(times)?;
+
+            log_paths.push(log_path);
+        }
+
+        // Zero used to underflow to usize::MAX, which skipped (and so kept)
+        // every existing log.
+        remove_old_logs(logdir_norm, 0).await;
+
+        for path in &log_paths {
+            assert!(!path.exists(), "{} should be removed", path.display());
         }
 
         Ok(())


### PR DESCRIPTION
Fixes #1431.

`remove_old_logs` does `skip(retained_event_logs - 1)`. The `-1` is there because the count includes the log about to be written, but nothing rejects zero: `buck2.retained_event_logs = 0` in `.buckconfig` parses straight through `init.rs` as `0usize`, and in release builds `0 - 1` wraps to `usize::MAX`. The iterator then skips every existing log, so cleanup silently stops and logs accumulate forever. Exactly backwards from what someone setting zero is asking for.

Swapped the subtraction for `saturating_sub(1)`, so zero means retain none and every old log is deleted.

I went with saturating rather than validating the config at parse time. Zero is a coherent thing to ask for, and the underflow is really a bug in the arithmetic rather than in the value, so fixing it where it happens keeps the config surface unchanged and can't break anyone already passing zero.

Added `test_remove_old_logs_with_zero_retained` alongside the existing test. It creates three logs, calls `remove_old_logs(dir, 0)` and asserts all three are gone. On the old code it fails with all three still present.

```
running 2 tests
test file_names::tests::test_remove_old_logs_with_zero_retained ... ok
test file_names::tests::test_remove_old_logs_with_mix_of_files_and_folders ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out
```

Run on nightly-2026-05-22 per `rust-toolchain`, macOS arm64.
