### PR TITLE
Fix OSS RE client dropping ExecutedActionMetadata.auxiliary_metadata

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -156,6 +156,21 @@ fn ttimestamp_from(ts: Option<::prost_types::Timestamp>) -> TTimestamp {
     }
 }
 
+fn tany_to(any: TAny) -> ::prost_types::Any {
+    ::prost_types::Any {
+        type_url: any.type_url,
+        value: any.value,
+    }
+}
+
+fn tany_from(any: ::prost_types::Any) -> TAny {
+    TAny {
+        type_url: any.type_url,
+        value: any.value,
+        ..Default::default()
+    }
+}
+
 /// Contains information queried from the Remote Execution Capabilities service.
 pub struct RECapabilities {
     /// Largest size of a message before being uploaded using bytestream service.
@@ -1179,6 +1194,7 @@ fn convert_action_result(action_result: ActionResult) -> anyhow::Result<TActionR
             output_upload_completed_timestamp: ttimestamp_from(
                 execution_metadata.output_upload_completed_timestamp,
             ),
+            auxiliary_metadata: execution_metadata.auxiliary_metadata.into_map(tany_from),
             input_analyzing_start_timestamp: Default::default(),
             input_analyzing_completed_timestamp: Default::default(),
             execution_dir: "".to_owned(),
@@ -1225,7 +1241,7 @@ fn convert_t_action_result2(t_action_result: TActionResult2) -> anyhow::Result<A
         output_upload_completed_timestamp: Some(ttimestamp_to(
             t_execution_metadata.output_upload_completed_timestamp,
         )),
-        auxiliary_metadata: Vec::new(),
+        auxiliary_metadata: t_execution_metadata.auxiliary_metadata.into_map(tany_to),
     });
 
     let output_files = t_action_result


### PR DESCRIPTION
The OSS gRPC RE client never converts `auxiliary_metadata` on
`ExecutedActionMetadata`, in **either** direction:

- **Outbound** — `convert_t_action_result2` hard-coded
  `auxiliary_metadata: Vec::new()` (`remote_execution/oss/re_grpc/src/client.rs`),
  discarding whatever the caller set before an `UpdateActionResult`.
- **Inbound** — `convert_action_result` never assigned the field, so it fell to
  `Default::default()` (empty) on every `GetActionResult`.

As a result remote dep-file caching cannot work in any OSS build. That field is where buck2 stores the `RemoteDepFile` proto for the remote
dep-file cache:

- `app/buck2_execute_impl/src/executors/caching.rs` already *populates* it on
  upload (`action_result.execution_metadata.auxiliary_metadata = vec![dep_file_tany]`).
- `app/buck2_execute_impl/src/executors/action_cache.rs` already *consumes* it on
  lookup.

Because the OSS client severed both ends, the value written was dropped on the way
out, and the field read back was always empty. The read side treats "no entry
found" as `ControlFlow::Continue`, an normal cache miss. Same type of OSS-client bug as other recent fixes: #1255 #1256, #1257, #1248, #1247.




