### PR TITLE
buck2 cache upload: fix data corruption due to races

### DIFF
--- a/app/buck2_execute/src/execute/result.rs
+++ b/app/buck2_execute/src/execute/result.rs
@@ -20,6 +20,7 @@ use buck2_action_metadata_proto::RemoteDepFile;
 use buck2_build_signals::env::WaitingData;
 use buck2_core::content_hash::ContentBasedPathHash;
 use buck2_core::fs::artifact_path_resolver::ArtifactFs;
+use buck2_core::fs::project_rel_path::ProjectRelativePathBuf;
 use buck2_data::SchedulingMode;
 use buck2_hash::BuckIndexMap;
 use buck2_util::time_span::TimeSpan;
@@ -307,27 +308,48 @@ impl CommandExecutionResult {
         )
     }
 
-    /// For content-based outputs, resolve the outputs to the "constant" (non-content-based) paths
-    /// that are used during execution.
+    /// Resolves the output path as used by execution, a stable path it can be
+    /// accessed at without holding a lock, and the artifact value.
+    ///
+    /// For content-based outputs, we resolve the outputs to the placeholder
+    /// paths that are used during execution, so that e.g. remote execution can
+    /// key on a path matching that used by execution.
+    ///
+    /// The [`ResolvedCommandExecutionOutput`] returned by this function is not
+    /// safe to read without holding a `NamedSemaphores` permit for it: when it
+    /// is a [`ContentBasedPathHash::OutputArtifact`] path,
+    /// concurrently-running `run` actions in different configurations may
+    /// overwrite it.
     pub fn resolve_outputs<'a>(
         &'a self,
         fs: &'a ArtifactFs,
     ) -> impl Iterator<
-        Item = buck2_error::Result<(ResolvedCommandExecutionOutput, &'a ArtifactValue)>,
+        Item = buck2_error::Result<(
+            ResolvedCommandExecutionOutput,
+            ProjectRelativePathBuf,
+            &'a ArtifactValue,
+        )>,
     > + 'a {
         self.outputs.iter().map(|(output, value)| {
-            Ok((
-                output.as_ref().resolve(
-                    fs,
-                    if output.has_content_based_path() {
-                        Some(ContentBasedPathHash::OutputArtifact)
-                    } else {
-                        None
-                    }
-                    .as_ref(),
-                )?,
-                value,
-            ))
+            let has_content_based_path = output.has_content_based_path();
+            let resolved = output.as_ref().resolve(
+                fs,
+                if has_content_based_path {
+                    Some(ContentBasedPathHash::OutputArtifact)
+                } else {
+                    None
+                }
+                .as_ref(),
+            )?;
+            let content_path = if has_content_based_path {
+                output
+                    .as_ref()
+                    .resolve(fs, Some(&value.content_based_path_hash()))?
+                    .into_path()
+            } else {
+                resolved.path().to_buf()
+            };
+            Ok((resolved, content_path, value))
         })
     }
 }

--- a/app/buck2_execute_impl/src/executors/caching.rs
+++ b/app/buck2_execute_impl/src/executors/caching.rs
@@ -34,6 +34,7 @@ use buck2_execute::execute::cache_uploader::DepFileCacheUploadOutcome;
 use buck2_execute::execute::cache_uploader::IntoRemoteDepFile;
 use buck2_execute::execute::cache_uploader::UploadCache;
 use buck2_execute::execute::result::CommandExecutionResult;
+use buck2_execute::materialize::materializer::MaterializationPurpose;
 use buck2_execute::materialize::materializer::Materializer;
 use buck2_execute::re::client::ActionCacheWriteType;
 use buck2_execute::re::manager::ManagedRemoteExecutionClient;
@@ -344,8 +345,11 @@ impl CacheUploader {
         let mut output_files: Vec<TFile> = Vec::new();
         let mut output_directories: Vec<TDirectory2> = Vec::new();
 
+        let mut content_paths = Vec::new();
+
         for output_result in result.resolve_outputs(&self.artifact_fs) {
-            let (output, value) = output_result?;
+            let (output, content_path, value) = output_result?;
+            content_paths.push(content_path.clone());
             match value.entry().as_ref() {
                 DirectoryEntry::Leaf(ActionDirectoryMember::File(f)) => {
                     output_files.push(TFile {
@@ -364,10 +368,13 @@ impl CacheUploader {
                     });
 
                     let fut = async move {
+                        // We use the content-based path so we don't have to
+                        // hold a lock for the placeholder path used by
+                        // execution.
                         let name = self
                             .artifact_fs
                             .fs()
-                            .resolve(output.path())
+                            .resolve(&content_path)
                             .as_maybe_relativized_str()?
                             .to_owned();
 
@@ -406,7 +413,7 @@ impl CacheUploader {
                                 self.artifact_fs.fs(),
                                 self.materializer.as_ref(),
                                 &action_blobs,
-                                output.path(),
+                                &content_path,
                                 &d.dupe().as_immutable(),
                                 identity,
                                 digest_config,
@@ -433,6 +440,15 @@ impl CacheUploader {
         }
 
         let uploads = async {
+            // This may be belt-and-suspenders: the action just ran, so one
+            // would expect these to exist. I'm not sure it's 100% necessary to
+            // ask the materializer to ensure just-built possibly-content-based
+            // paths exist.
+            self.materializer
+                .ensure_materialized(content_paths, MaterializationPurpose::IntermediateOnly)
+                .await
+                .buck_error_context("Error materializing outputs for cache upload")?;
+
             buck2_util::future::try_join_all(upload_futs)
                 .await
                 .buck_error_context("Error uploading outputs")?;

--- a/app/buck2_execute_impl/src/executors/local.rs
+++ b/app/buck2_execute_impl/src/executors/local.rs
@@ -937,8 +937,9 @@ impl LocalExecutor {
                         // wrote outputs at "placeholder" paths, not the final content-based paths (because
                         // they are not know until the output is produced), and (b) other actions can declare
                         // outputs at the same content-based path. Note that only remote actions can do that
-                        // concurrently (with this local action), as we prevent any local actions with any of
-                        // the same placeholder output paths from running at the same time.
+                        // concurrently (with this local action), as we prevent any local run actions with any of
+                        // the same placeholder output paths from running at the same time (see
+                        // NamedSemaphores and HostSharingRequirements).
                         // We do the following:
                         // (1) We create a symlink from the configuration-based path to the content-based path
                         //     (for any users/tooling that only has access to the configuration-based path)


### PR DESCRIPTION
version: austin's fork, occurred on version 98bf97c8fffeed117b0cd417c522f408b827553d

# what was i doing

i was building a small pile of golang on macOS in my [dotfiles](https://github.com/lf-/dotfiles) on rev 165b13169df097572d80f1b368358ce99d9dae83.

this was basically `configs/nix/packages2/buck2-austin/buck2 build //...` on a mac with buildbuddy set up in the buckconfig.local.

```
[buck2_re_client]
  # local  -- ignore RE entirely
  # cached -- run everything here, read and write BuildBuddy's cache
  # remote -- also dispatch this machine's own actions, which needs BuildBuddy
  #           to have workers for this machine's OS (its hosted pool is Linux
  #           only, so on a Mac this wants to stay "cached")
  default_mode = cached
  http_headers = x-buildbuddy-api-key:....
```

symptom:

```
2026-08-05T06:32:25.438240Z  WARN buck2_execute::execute::cache_uploader: Cache upload for `a8fcdf6cb485bcf81f19a5f3b373cb5145f4a55a4a809cd366663afbfe6d7b47:141` failed: Error uploading outputs: Remote Execution Error on upload_files_and_directories for ReSession GRPC-SESSION-ID
Error: (Batch upload failed: ["Unable to upload blob 'd8da673f46b4e0012afabdfa5a8b10947e253de4c07f88ec6c00b29efc68d9f7', rpc status code: 3, message: \"Uploaded bytes checksum (\"dc25da770d7cd25f0aa6d9e30944beda7a755c40d1ad0a75629ba10aa06572ec\") did not match digest (\"d8da673f46b4e0012afabdfa5a8b10947e253de4c07f88ec6c00b29efc68d9f7\").\""])
```

# cause

uhh. it appears that there are multiple actions using `__action_0_239__` in the `output_artifacts` unbound dir that execute close together in time in my log.

that is a really suspicious combination with the offending hashes appearing in the same spot in the output directory. it vaguely implies that these got switcheroo'd.

```
$ sha256sum buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/*/go_compile_out_non-shared.x
d8da673f46b4e0012afabdfa5a8b10947e253de4c07f88ec6c00b29efc68d9f7  buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/d8da673f46b4e001/go_compile_out_non-shared.x
dc25da770d7cd25f0aa6d9e30944beda7a755c40d1ad0a75629ba10aa06572ec  buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/dc25da770d7cd25f/go_compile_out_non-shared.x
dc25da770d7cd25f0aa6d9e30944beda7a755c40d1ad0a75629ba10aa06572ec  buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/output_artifacts/go_compile_out_non-shared.x
```

```
build	prelude//go/tools:stdlib (root//platforms:arm64-linux#ce8c0bf00c0f8d33) (go_compile go/constant [non-shared])	local	env -C "$(buck2 root --kind project)" -- 'TMPDIR=/Users/jade/.dotfiles/buck-out/v2/tmp/prelude/76143a280e33f102/go_compile/_buck_4b3f4d306503fdba' 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/prelude/76143a280e33f102/go_compile/_buck_4b3f4d306503fdba' 'GOARCH=arm64' 'GOEXPERIMENT=' 'GOOS=linux' 'BUCK2_DAEMON_UUID=fa36071c-d237-4b01-93b9-414c650f0944' 'BUCK_BUILD_ID=6bbcea1a-8092-4757-9c26-19249495dd64' buck-out/v2/art/prelude/go/tools/__go_wrapper__/7d251197f13eaba5/go_wrapper --go buck-out/v2/art/toolchains/23970406e468f12c/__go__archive_darwin_arm64__/go__archive_darwin_arm64/pkg/tool/darwin_arm64/compile -- '-buildid=' -nolocalimports -pack -trimpath '%cwd%' -p go/constant -importcfg buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/6c4954525cd52d22/non_shared.importcfg -o buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/output_artifacts/go_compile_out_non-shared.x -linkobj buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/output_artifacts/go_compile_out_non-shared.a -complete -std @buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/41e842d4be79d281/non-shared_srcs.go_package_argsfile
build	prelude//go/tools:stdlib (root//platforms:arm64-macos#a8115d6e81a1e6cd) (go_compile go/scanner [non-shared])	local	env -C "$(buck2 root --kind project)" -- 'TMPDIR=/Users/jade/.dotfiles/buck-out/v2/tmp/prelude/76143a280e33f102/go_compile/_buck_fe74aecdf98c69d8' 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/prelude/76143a280e33f102/go_compile/_buck_fe74aecdf98c69d8' 'GOARCH=arm64' 'GOEXPERIMENT=' 'GOOS=darwin' 'BUCK2_DAEMON_UUID=fa36071c-d237-4b01-93b9-414c650f0944' 'BUCK_BUILD_ID=6bbcea1a-8092-4757-9c26-19249495dd64' buck-out/v2/art/prelude/go/tools/__go_wrapper__/7d251197f13eaba5/go_wrapper --go buck-out/v2/art/toolchains/23970406e468f12c/__go__archive_darwin_arm64__/go__archive_darwin_arm64/pkg/tool/darwin_arm64/compile -- '-buildid=' -nolocalimports -pack -trimpath '%cwd%' -p go/scanner -importcfg buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/815d7a8bbe1475fb/non_shared.importcfg -o buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/output_artifacts/go_compile_out_non-shared.x -linkobj buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/output_artifacts/go_compile_out_non-shared.a -complete -std @buck-out/v2/art/prelude/go/tools/__stdlib__/__action___0_239__/2d5820e224d4e2a5/non-shared_srcs.go_package_argsfile
```

# commentary and diagnosis

here's where it gets a path:
https://github.com/facebook/buck2/blob/42ed7efc3e366bba83297840bfc7c00cff19d966/app/buck2_execute_impl/src/executors/caching.rs#L366-L373

here's how the path is formed:
https://github.com/facebook/buck2/blob/065afcb59b519dc0e766d3a72d02969d7c045cdc/app/buck2_execute/src/execute/request.rs#L870-L875

and:
https://github.com/facebook/buck2/blob/d57d17ccc18b2b427bb4fe7fb390428bfa357770/app/buck2_core/src/fs/buck_out_path.rs#L289-L307

my thoughts:
- hm, these are two actions in two different configurations (note the different targets) being executed locally at the same time.

  i would suspect this happens at fb; it happened for me bc of a mac->linux config transition.

  hypothesis as to why y'all didn't notice: maybe it happens at fb but cas doesn't do secondary verification of the hash and there's corruption? that sounds scary and unlikely, but idk maybe!

  or, there's not enough obervability of the log to notice the errors? [it looks like the logs get trashed so maybe there's something to that](https://github.com/facebook/buck2/blob/01b3d9aaddeddca76413ea91bb41db58f9e5bbb7/app/buck2_execute/src/re/client.rs#L989-L990).
- it seems to be a regression in fff2bbfc23cdb7aece271e0cbcdd00f8fbfeeba7 (D75866194).

  that diff isn't *wrong*, either: it's correct to name the uploaded action after the output_artifacts path since that's what action execution actually did.

  however, consuming the placeholder path in the uploader *while not holding appropriate locks on the path* is busted, since the `output_artifacts` path could get overwritten by concurrently-executing actions.

  there are locks (see NamedSemaphores) but they only affect run actions and are [relinquished after the run action finishes](https://github.com/facebook/buck2/blob/2f411eba848cf31899ecc89a0e101f5dd349a27a/app/buck2_execute_impl/src/executors/local.rs#L1293-L1294) since they're only held locally in exec_cmd.

thus, we have a race.

this is very https://github.com/facebook/buck2/issues/1309 shaped: it's the same bug class where the host sharing permits are only used for run actions and aren't held elsewhere.

in this case, it's that the *uploader* was relying on the invariants of that lock without actually holding it: it was using the `output_artifacts` paths for both picking what to upload and actually pulling it off disk.

proposed fix: uploading should fetch off disk from the content-based path while still telling the remote server about the placeholder path as before. this avoids needing to hold the lock for no good reason, while still being correct.

i wrote this fix with claude but i rewrote all its comments and i am pretty confident in my understanding of the bug based on my own inspection of the code.

i am not 100% convinced about the need to ask the materializer to ensure all the content-based paths, but it's almost certainly harmless since they are almost certainly already on disk.

test plan:
i changed my go toolchain version to cause an invalidation then tried running the command that got *several* failures again on the fresh build. seems to not happen again.