### PR TITLE
Fix expand-external-cell copying stale buck-out files for bundled cells

### DIFF
--- a/app/buck2_external_cells/src/bundled.rs
+++ b/app/buck2_external_cells/src/bundled.rs
@@ -463,31 +463,36 @@ pub(crate) async fn get_file_ops_delegate(
         .dupe()
 }
 
+/// Materializes every file actually bundled with this binary for `cell`, returning each file's
+/// path relative to the cell root paired with the buck-out path it was materialized to.
+///
+/// Does not return the buck-out directory root: that directory persists across buck2 upgrades
+/// and can hold stale files no longer bundled, so callers must copy exactly the files listed
+/// here rather than the directory as a whole.
 pub(crate) async fn materialize_all(
     ctx: &mut DiceComputations<'_>,
     cell: CellName,
-) -> buck2_error::Result<ProjectRelativePathBuf> {
+) -> buck2_error::Result<Vec<(ForwardRelativePathBuf, ProjectRelativePathBuf)>> {
     let artifact_fs = ctx.get_artifact_fs().await?;
     let buck_out_resolver = artifact_fs.buck_out_path_resolver();
 
     let ops = get_file_ops_delegate(ctx, cell).await?;
     let materializer = ctx.per_transaction_data().get_materializer();
+    let mut files = Vec::new();
     let mut paths = Vec::new();
-    for (path, _entry) in ops.dir.unordered_walk_leaves().with_paths() {
-        let path = buck_out_resolver.resolve_external_cell_source(
-            CellRelativePath::new(path.as_ref()),
+    for (rel_path, _entry) in ops.dir.unordered_walk_leaves().with_paths() {
+        let source_path = buck_out_resolver.resolve_external_cell_source(
+            CellRelativePath::new(rel_path.as_ref()),
             ExternalCellOrigin::Bundled(cell),
         );
-        paths.push(path);
+        paths.push(source_path.clone());
+        files.push((rel_path, source_path));
     }
 
     materializer
         .ensure_materialized(paths, MaterializationPurpose::IntermediateOnly)
         .await?;
-    Ok(buck_out_resolver.resolve_external_cell_source(
-        CellRelativePath::unchecked_new(""),
-        ExternalCellOrigin::Bundled(cell),
-    ))
+    Ok(files)
 }
 
 #[cfg(test)]

--- a/app/buck2_external_cells/src/lib.rs
+++ b/app/buck2_external_cells/src/lib.rs
@@ -83,18 +83,28 @@ impl buck2_common::external_cells::ExternalCellsImpl for ConcreteExternalCellsIm
             }
         }
 
-        // Materialize the whole cell, and then copy it into the repository.
+        // Materialize the whole cell, then copy its files into the repository.
         //
         // FIXME(JakobDegen): Ideally we'd be able to ask the materializer to just make a copy
         // without doing the actual materialization. However, that's not currently possible without
         // it resulting in the materializer tracking paths in the repo, so this will have to do for
         // now.
-        let materialized_path = match origin {
-            ExternalCellOrigin::Bundled(cell) => bundled::materialize_all(ctx, cell).await?,
-            ExternalCellOrigin::Git(setup) => git::materialize_all(ctx, cell, setup).await?,
-        };
+        match origin {
+            ExternalCellOrigin::Bundled(cell) => {
+                // Copy files individually rather than the whole buck-out directory; see
+                // `materialize_all`'s doc comment for why.
+                for (rel_path, source_path) in bundled::materialize_all(ctx, cell).await? {
+                    io.project_root()
+                        .copy(&source_path, dest_path.join(&rel_path))?;
+                }
+            }
+            ExternalCellOrigin::Git(setup) => {
+                let materialized_path = git::materialize_all(ctx, cell, setup).await?;
+                io.project_root().copy(&materialized_path, &dest_path)?;
+            }
+        }
 
-        Ok(io.project_root().copy(&materialized_path, &dest_path)?)
+        Ok(())
     }
 }
 

--- a/tests/core/external_cells/test_bundled.py
+++ b/tests/core/external_cells/test_bundled.py
@@ -84,3 +84,29 @@ async def test_expand_external_cell(buck: Buck) -> None:
     )
     p = Path(result.stdout.strip())
     assert p.read_text().strip() == "\n".join(["value", "6", "foobar3", "foobar2"])
+
+
+# This test verifies the fix for https://github.com/facebook/buck2/issues/1079
+@buck_test()
+async def test_expand_external_cell_ignores_stray_files(buck: Buck) -> None:
+    bundled_dir = (
+        buck.cwd
+        / "buck-out"
+        / "v2"
+        / "external_cells"
+        / "bundled"
+        / "test_bundled_cell"
+    )
+    stray_nested_dir = bundled_dir / "dir"
+    stray_nested_dir.mkdir(parents=True, exist_ok=True)
+    (bundled_dir / "STRAY_TOP").write_text("stray\n")
+    (stray_nested_dir / "STRAY_NESTED").write_text("stray\n")
+
+    await buck.expand_external_cell("test_bundled_cell")
+
+    # Stray files must not have been copied into the expanded cell...
+    assert not (buck.cwd / "test_bundled_cell" / "STRAY_TOP").exists()
+    assert not (buck.cwd / "test_bundled_cell" / "dir" / "STRAY_NESTED").exists()
+    # ...but genuinely bundled files, including ones nested in a subdirectory, still are.
+    assert (buck.cwd / "test_bundled_cell" / ".buckconfig").exists()
+    assert (buck.cwd / "test_bundled_cell" / "dir" / "src.txt").exists()


### PR DESCRIPTION
Fixes #1079

## Problem

`buck2 expand-external-cell` materializes bundled cell data into `buck-out/v2/external_cells/bundled/<cell>/` and then does a plain recursive directory copy into the destination. That copy has no awareness of which files are actually part of the current bundled data — it copies whatever happens to be sitting on disk.

`materialize_all` only ever writes/refreshes the files it currently knows about via `ensure_materialized`; it never prunes anything else already present in that directory. So a file left behind by a previous buck2 version (whose bundled data has since changed) sits there indefinitely, and every subsequent `expand-external-cell` copies it along with the genuinely bundled files.

Repro from the issue:

buck2 init testproj
cd testproj
mkdir -p buck-out/v2/external_cells/bundled/prelude
echo OHNOES > buck-out/v2/external_cells/bundled/prelude/ZSOL
buck2 expand-external-cell prelude
cat prelude/ZSOL # prints OHNOES — should not exist

## Fix

`bundled::materialize_all` already enumerates the authoritative set of bundled files (from the compile-time-embedded `BundledCell.files`) to drive `ensure_materialized` — that enumeration was previously discarded, with only the directory root returned. This change:

- Changes `materialize_all`'s return type to the list of `(relative path, resolved buck-out path)` pairs it already computes.
- Changes the `Bundled` arm of `expand()` in `lib.rs` to copy each file individually into `dest_path.join(rel_path)`, instead of doing a whole-directory copy.

The `Git` external cell origin is untouched — its `materialize_all` returns a path into a content-addressed checkout per commit, which doesn't have this staleness problem.

## Testing

Verified locally on aarch64-apple-darwin, cargo 1.97.0-nightly:

- `cargo check -p buck2_external_cells` — clean.
- Manual repro from the issue, against a locally built release binary: `cat prelude/ZSOL` now fails with "No such file or directory".
- Real bundled prelude (2227 files, deeply nested) still copies correctly and completely under the new per-file copy path.
- Repo's clippy invocation (`test.py --lint-rust-only --git buck2_external_cells`) — clean, zero errors.

Added a regression test to `tests/core/external_cells/test_bundled.py` that plants a stray file in the buck-out external-cells directory before expansion and asserts it's absent afterward. Note: `tests/core/*` integration tests don't run in public GitHub Actions CI for this repo — this test will run as part of Meta's internal review/CI once the PR is accepted.