### PR TITLE
prelude//cpu/constraints:wasm32: don't regress

### DIFF
--- a/prelude/cpu/constraints/BUCK
+++ b/prelude/cpu/constraints/BUCK
@@ -14,6 +14,7 @@ constraint_with_aliases(
         "arm64": "arm64",
         "x86_32": "x86_32",
         "x86_64": "x86_64",
+        "wasm32": "wasm32",
     },
     default = "unspecified",
     values = [


### PR DESCRIPTION
On the current prelude used by Mercury, we were using prelude//cpu/constraints:wasm32
(https://github.com/MercuryTechnologies/buck2/blob/07f4a07ed01b674102b2db7db1f1348e5afe9fc2/prelude/cpu/constraints/BUCK#L46-L50) to drive a transition (so I don't think we want to use the prelude//cpu:wasm32 config_setting).

The change to use the modernized constraints removed prelude//cpu/constraints:wasm32 as a target. We need it to exist so that we can smoothly migrate (we have a rollout mechanism for new buck2 versions in CI so we need our repo to work across both new and old).