### PR TITLE
cxx/python/rust: propagate UnixEnvInfo

### DIFF
--- a/prelude/cxx/cxx.bzl
+++ b/prelude/cxx/cxx.bzl
@@ -317,9 +317,10 @@ def get_auto_link_group_specs(ctx: AnalysisContext, link_group_info: [LinkGroupI
 
 def cxx_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     link_strategy = to_link_strategy(cxx_attr_link_style(ctx))
+    deps = cxx_attr_deps(ctx)
     link_group_info = get_link_group_info(
         ctx,
-        filter_and_map_idx(LinkableGraph, cxx_attr_deps(ctx)),
+        filter_and_map_idx(LinkableGraph, deps),
         link_strategy,
     )
     params = CxxRuleConstructorParams(
@@ -387,9 +388,7 @@ def cxx_binary_impl(ctx: AnalysisContext) -> list[Provider]:
                     ),
                 ],
             ),
-            # TODO(agallagher): We only want to traverse deps when dynamically
-            # linking.
-            # deps = ctx.attrs.deps,
+            deps = deps,
         ),
     )
 

--- a/prelude/python/make_py_package.bzl
+++ b/prelude/python/make_py_package.bzl
@@ -100,6 +100,7 @@ def make_py_package_providers(ctx: AnalysisContext, manifest_identifier: str, pe
                         ),
                     ],
                 ),
+                deps = ctx.attrs.deps,
             )
         )
 

--- a/prelude/rust/rust_binary.bzl
+++ b/prelude/rust/rust_binary.bzl
@@ -61,6 +61,7 @@ load(
 )
 load("@prelude//linking:stamp_build_info.bzl", "PRE_STAMPED_SUFFIX", "cxx_stamp_build_info", "stamp_build_info")
 load("@prelude//os_lookup:defs.bzl", "OsLookup")
+load("@prelude//python:manifest.bzl", "create_manifest_for_entries")
 load("@prelude//rust/rust-analyzer:provider.bzl", "rust_analyzer_provider")
 load("@prelude//test:inject_test_run_info.bzl", "inject_test_run_info")
 load(
@@ -71,6 +72,7 @@ load(
     "@prelude//utils:build_graph_pattern.bzl",
     "new_build_graph_info",
 )
+load("@prelude//unix:providers.bzl", "UnixEnv", "create_unix_env_info")
 load("@prelude//utils:utils.bzl", "flatten_dict")
 load(
     ":build.bzl",
@@ -101,6 +103,7 @@ load(
     "inherited_linkable_graphs",
     "inherited_rust_cxx_link_group_info",
     "inherited_shared_libs",
+    "resolve_deps",
 )
 load(":named_deps.bzl", "write_named_deps_names")
 load(":outputs.bzl", "RustcExtraOutputsInfo", "output_as_diag_subtargets")
@@ -187,7 +190,7 @@ def _create_content_based_dist(
 
 def _rust_binary_common(
     ctx: AnalysisContext, compile_ctx: CompileContext, default_roots: list[str], extra_flags: list[str], allow_cache_upload: bool
-) -> (list[Provider], cmd_args):
+) -> (list[Provider], cmd_args, Artifact):
     toolchain_info = compile_ctx.toolchain_info
 
     simple_crate = attr_simple_crate_for_filenames(ctx)
@@ -693,12 +696,12 @@ def _rust_binary_common(
             default_roots = default_roots,
         )
     )
-    return (providers, args)
+    return (providers, args, dist_exe if dist_bundle else final_output)
 
 def rust_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     compile_ctx = compile_context(ctx, binary = True)
 
-    providers, args = _rust_binary_common(
+    providers, args, binary = _rust_binary_common(
         ctx = ctx,
         compile_ctx = compile_ctx,
         default_roots = ["main.rs"],
@@ -706,7 +709,23 @@ def rust_binary_impl(ctx: AnalysisContext) -> list[Provider]:
         allow_cache_upload = cxx_attrs_get_allow_cache_upload(ctx.attrs),
     )
 
-    return providers + [RunInfo(args = args)]
+    return providers + [
+        RunInfo(args = args),
+        create_unix_env_info(
+            actions = ctx.actions,
+            env = UnixEnv(
+                label = ctx.label,
+                binaries = [
+                    create_manifest_for_entries(
+                        ctx = ctx,
+                        name = "unix_env",
+                        entries = [(ctx.label.name, binary, "")],
+                    ),
+                ],
+            ),
+            deps = [dep.dep for dep in resolve_deps(ctx, compile_ctx.dep_ctx)],
+        ),
+    ]
 
 def rust_test_impl(ctx: AnalysisContext) -> list[Provider]:
     compile_ctx = compile_context(ctx, binary = True)
@@ -716,7 +735,7 @@ def rust_test_impl(ctx: AnalysisContext) -> list[Provider]:
     if ctx.attrs.framework:
         extra_flags += ["--test"]
 
-    providers, args = _rust_binary_common(
+    providers, args, _binary = _rust_binary_common(
         ctx = ctx,
         compile_ctx = compile_ctx,
         # Unless default_roots are provided, it is ambiguous whether this test rule is invoked


### PR DESCRIPTION
Motivation: I want to pass shared library dependencies through my binary targets, so that `snowydeer_package` (our nix package builder; see my LixCon 2026 talk and https://github.com/mercurytechnologies/snowydeer) can automatically include them in the `lib/` directory in the output.

Implementation/test plan: honestly this is a *massive* YOLO. This is clauded and I am *absolutely* not sure why this propagation was originally disabled, nor do I have enough tests out of tree to meaningfully exercise it.

A note: "we only want to traverse deps while dynamically linking" is potentially wrong when you have a setup that prefers the static link style but still allows dynamic linking (which is what we're in; we try to statically link first-party but Rust (https://github.com/rust-lang/rust/issues/73632) and other things force dynamic linking).

This is more of a question for why it was off in the first place with a "yolo" button than a normal PR :)