### PR TITLE
re_grpc: consider network interruptions retryable

### DIFF
--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -558,7 +558,7 @@ impl BatchUploadReqAggregator {
 /// Returns true if an error is a transient connection/transport error worth
 /// retrying. Walks the error chain checking for:
 ///   - `tonic::Status` with codes the gRPC retry policy treats as transient
-///     (Unavailable, ResourceExhausted, Aborted)
+///     (Unavailable, ResourceExhausted, Aborted, Cancelled)
 ///   - `io::Error` of a kind that indicates a transport-level disruption
 ///     (BrokenPipe, ConnectionReset/Aborted, UnexpectedEof, TimedOut)
 ///
@@ -572,7 +572,8 @@ fn is_retryable(err: &anyhow::Error) -> bool {
             match status.code() {
                 tonic::Code::Unavailable
                 | tonic::Code::ResourceExhausted
-                | tonic::Code::Aborted => return true,
+                | tonic::Code::Aborted
+                | tonic::Code::Cancelled => return true,
                 _ => {}
             }
         }


### PR DESCRIPTION

Right now, intermittent network failures like these fail the build immediately:

```
Error: (Failed to make BatchReadBlobs request: code: 'The operation was
cancelled', message: "operation was canceled", source: tonic::transport::Error(
Transport, hyper::Error(Canceled, "connection closed")): transport error:
operation was canceled: connection closed)
```

Add `Cancelled` cause to list of retryable errors.
