### PR TITLE
buck2_test: don't poison results channel via internal orchestrator drop

### DIFF
--- a/app/buck2_test/src/command.rs
+++ b/app/buck2_test/src/command.rs
@@ -137,14 +137,24 @@ struct TestOutcome {
 impl TestOutcome {
     fn exit_code(&self) -> buck2_error::Result<i32> {
         self.executor_report
-            .exit_code
+            .exit_code()
             .internal_error("Test executor did not provide an exit code")
     }
 }
 
+/// Exit code for a run in which tests failed;
+/// matches `RunVerdict::Fail` in the OSS test runner
+const TESTS_FAILED_EXIT_CODE: i32 = 32;
+
 #[derive(Default)]
 struct ExecutorReport {
-    exit_code: Option<i32>,
+    /// Exit code reported by the external test executor via
+    /// `end_of_test_results`; `None` if the executor exited without
+    /// reporting. Not the run's verdict — see `exit_code()`.
+    executor_exit_code: Option<i32>,
+    /// Whether any target ran in-process. Only then can the executor's
+    /// exit code miss results collected here.
+    used_internal_runner: bool,
     statuses: TestStatuses,
     info_messages: Vec<String>,
 }
@@ -156,11 +166,22 @@ impl ExecutorReport {
                 self.statuses.ingest(res, session);
             }
             ExecutorMessage::ExitCode(exit_code) => {
-                self.exit_code = Some(*exit_code);
+                self.executor_exit_code = Some(*exit_code);
             }
             ExecutorMessage::InfoMessage(message) => {
                 self.info_messages.push(message.clone());
             }
+        }
+    }
+
+    /// Verdict for the whole run. The executor's exit code is authoritative
+    /// unless it reports success while internal-runner tests failed.
+    fn exit_code(&self) -> Option<i32> {
+        match self.executor_exit_code {
+            Some(0) if self.used_internal_runner && self.statuses.has_failures() => {
+                Some(TESTS_FAILED_EXIT_CODE)
+            }
+            code => code,
         }
     }
 }
@@ -230,6 +251,17 @@ impl TestStatuses {
             TestStatus::LISTING_SUCCESS => self.listing_success.add(name),
             TestStatus::LISTING_FAILED => self.listing_failed.add(name),
         }
+    }
+
+    /// Whether any result with a failing status was reported. SKIP/OMITTED
+    /// deliberately don't count: ignored tests and cancellations must not
+    /// fail a run.
+    fn has_failures(&self) -> bool {
+        self.failed.count > 0
+            || self.fatals.count > 0
+            || self.timed_out.count > 0
+            || self.infra_failure.count > 0
+            || self.listing_failed.count > 0
     }
 }
 
@@ -797,10 +829,13 @@ async fn test_targets(
                     std::mem::replace(&mut driver.build_target_result, BuildTargetResult::new());
                 drop(driver);
 
-                // Drop internal runner resources so their senders don't
-                // keep the results channel open during try_fold.
-                drop(internal_orchestrator);
+                // Drop the internal runner's sender clone so it doesn't keep
+                // the results channel open during try_fold. Orchestrator is not
+                // dropped yet -- see below.
                 drop(internal_test_status_sender);
+
+                // Whether any target ran in-process deciding whether the exit code accounts for every result collected.
+                let used_internal_runner = internal_orchestrator.initialized();
 
                 test_executor
                     .end_of_test_requests()
@@ -808,13 +843,19 @@ async fn test_targets(
                     .buck_error_context("Failed to notify test executor of end-of-tests")?;
 
                 // Wait for the tests to finish running.
-                let test_statuses = test_status_receiver
+                let mut test_statuses = test_status_receiver
                     .try_fold(ExecutorReport::default(), |mut acc, result| {
                         acc.ingest(&result, &session);
                         future::ready(Ok(acc))
                     })
                     .await
                     .buck_error_context("Did not receive all results from executor")?;
+
+                test_statuses.used_internal_runner = used_internal_runner;
+
+                // The results channel is closed now, so the internal
+                // orchestrator's Drop poison lands nowhere.
+                drop(internal_orchestrator);
 
                 // Shutdown our server. This is technically not *required* since dropping it would shut it
                 // down implicitly, but let's do it anyway so we can collect any errors.


### PR DESCRIPTION
Fixes #1479.

Any `buck2 test` run in which at least one target used InternalRunnerTestInfo fails at teardown with

    Did not receive all results from executor: BuckTestOrchestrator
    exited before end-of-tests was received

even though all per-test results were already reported correctly.

Root cause: drop order in test_targets.

Fix: drop the internal orchestrator after try_fold.

This fix also surfaces other issue so the next fix is the exit code for failing internal-runner tests: they showed `Fail` in the UI but `buck2 test` exited 0 (green CI on red tests).

<details>
<summary>
Reproducer
</summary>

**`.buckconfig`**
```ini
[cells]
root = .
```

**`defs.bzl`**
```python
def _listing(content: str) -> list[dict]:
    return [{"name": n, "filter": n} for n in content.split()]

def _result(stdout: str, stderr: str, exit_code: int) -> list[dict]:
    # empty -> the runner synthesizes PASS/FAIL from the exit code
    return []

def _impl(ctx):
    return [DefaultInfo(), InternalRunnerTestInfo(
        type = "sh",
        listing_command = ["/bin/sh", "-c", "echo alpha beta"],
        command = ["/bin/sh", "-c", "exit 0"],
        parse_test_listing = _listing,
        parse_test_result = _result,
    )]

internal_test = rule(impl = _impl, attrs = {})
```

**`BUCK`**
```python
load(":defs.bzl", "internal_test")

internal_test(name = "t")
```
</details>

<details>
<summary>
Before
</summary>

```
$ buck2 test //:t; echo $?
✓ Pass: alpha (0.0s)
✓ Pass: beta (0.0s)
Command failed:
Test executor exited unexpectedly with status 1.
Stdout:

Stderr:
Command failed: code: 'Unknown error', message: "Failed to report end-of-tests: end_of_tests was received twice (internal error)"
1
```
</details>

<details>
<summary>
After
</summary>

```
$ buck2 test //:t; echo $?
Tests finished: Pass 2. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
0
```

With a failing command (`exit 1` for test `beta`):

```
$ buck2 test //:t; echo $?
Tests finished: Pass 1. Fail 1. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
1 TESTS FAILED
  ✗ beta (<unspecified>)
32
```
</details>

