### PR TITLE
Don't pass unconfigured targets to cquery in pyrefly.bxl

### DIFF
--- a/prelude/python/sourcedb/pyrefly.bxl
+++ b/prelude/python/sourcedb/pyrefly.bxl
@@ -85,7 +85,7 @@ def _append_or_default_if_module(
 def _list_targets(ctx: bxl.Context) -> bxl.ConfiguredTargetSet:
     cquery = ctx.cquery()
     uquery = ctx.uquery()
-    files = cquery.deps(uquery.owner(ctx.cli_args.file), 0)  # deps(0) to convert to configured
+    files = cquery.deps(ctx.target_universe(uquery.owner(ctx.cli_args.file)).target_set(), 0)
     targets = cquery.eval("kind('python_library|alias|genrule', %s)", ctx.cli_args.target)
     res = files
     for target in targets.values():


### PR DESCRIPTION
`uquery.owner()` returns unconfigured targets, and passing those into `cquery.deps()` relies on implicit configuration. That usage is flagged by the `bxl_unconfigured_target_in_cquery` soft error, which is promoted to a hard error on open-source builds (`error_on_oss: true`), so the sourcedb query always fails for OSS users unless a target platform is passed explicitly:

```
error: Unconfigured target with label `...` was passed into cquery.
Targets passed into cquery should be configured (recommendation is
to use `ctx.target_universe()`).
```

This can be worked around by passing `--target-platforms`, but we can fix this properly by `ctx.target_universe()` as the error message recommends.