### PR TITLE
RE bugfix: check output validity before uploading

### DIFF
--- a/app/buck2_action_impl/src/actions/impls/run.rs
+++ b/app/buck2_action_impl/src/actions/impls/run.rs
@@ -1650,6 +1650,14 @@ impl Action for RunAction {
             (false, false) => buck2_data::IncrementalKind::NonIncremental,
         };
 
+        // We need to validate the outputs before uploading to cache, to avoid turning a buggy
+        // successful action into a cache corruption.
+        // There's a second check in BuckActionExecutor::execute for non-RunAction actions; this one
+        // just stops upload bugs.
+        if result.was_success() {
+            ctx.validate_command_execution_outputs(&result)?;
+        }
+
         // If there is a dep file entry AND if dep file cache upload is enabled, upload it
         if result.was_success()
             && !result.was_served_by_remote_dep_file_cache()

--- a/app/buck2_build_api/src/actions.rs
+++ b/app/buck2_build_api/src/actions.rs
@@ -295,6 +295,12 @@ pub trait ActionExecutionCtx: Send + Sync {
         dep_file_entry: Option<&mut dyn IntoRemoteDepFile>,
     ) -> buck2_error::Result<CacheUploadResults>;
 
+    /// Validate the executor's complete result against this action's declared outputs.
+    fn validate_command_execution_outputs(
+        &self,
+        result: &CommandExecutionResult,
+    ) -> Result<(), ExecuteError>;
+
     /// Executes a command
     /// TODO(bobyf) this seems like it deserves critical sections?
     async fn exec_cmd(

--- a/app/buck2_build_api/src/actions/execute/action_executor.rs
+++ b/app/buck2_build_api/src/actions/execute/action_executor.rs
@@ -49,6 +49,7 @@ use buck2_execute::execute::kind::CommandExecutionKind;
 use buck2_execute::execute::manager::CommandExecutionManager;
 use buck2_execute::execute::prepared::PreparedAction;
 use buck2_execute::execute::prepared::PreparedCommand;
+use buck2_execute::execute::request::CommandExecutionOutput;
 use buck2_execute::execute::request::CommandExecutionRequest;
 use buck2_execute::execute::request::ExecutorPreference;
 use buck2_execute::execute::request::OutputType;
@@ -429,6 +430,77 @@ struct BuckActionExecutionContext<'a, 'd> {
     cancellations: &'a CancellationContext,
 }
 
+fn validate_action_outputs(
+    fs: &ArtifactFs,
+    declared_outputs: &[BuildArtifact],
+    actual_outputs: &ActionOutputs,
+) -> Result<(), ExecuteError> {
+    // Check that all the outputs are the right output_type.
+    for output in declared_outputs {
+        let declared = output.output_type();
+        // FIXME: One day we should treat FileOrDirectory as a File, and soft_error if it is a directory
+        if declared != OutputType::FileOrDirectory
+            && let Some(value) = actual_outputs.get(output.get_path())
+        {
+            let real = if value.is_dir() {
+                OutputType::Directory
+            } else {
+                OutputType::File
+            };
+            if real != declared {
+                return Err(ExecuteError::WrongOutputType {
+                    path: fs
+                        .resolve_build(output.get_path(), Some(&value.content_based_path_hash()))?,
+                    declared,
+                    real,
+                });
+            }
+        }
+    }
+
+    // Ignore ordering as outputs in the original action might be ordered differently from output
+    // paths in the action result (they are sorted there).
+    let actual_output_paths: BuckMutSet<&BuildArtifactPath> =
+        actual_outputs.iter().map(|(path, _)| path).collect();
+    let all_declared_outputs_returned = declared_outputs
+        .iter()
+        .all(|output| actual_output_paths.contains(output.get_path()))
+        && declared_outputs.len() == actual_output_paths.len();
+
+    // TODO (T122966509): Check projections here as well.
+    if !all_declared_outputs_returned {
+        let declared = declared_outputs
+            .iter()
+            .filter(|output| actual_outputs.get(output.get_path()).is_none())
+            .map(|output| {
+                fs.resolve_build(
+                    output.get_path(),
+                    Some(&ContentBasedPathHash::for_output_artifact()),
+                )
+            })
+            .collect::<buck2_error::Result<_>>()?;
+        let real = actual_outputs
+            .iter()
+            .map(|(path, _)| path)
+            .filter(|path| {
+                // This is an error message; linear search is fine.
+                !declared_outputs
+                    .iter()
+                    .map(|output| output.get_path())
+                    .contains(path)
+            })
+            .map(|path| fs.resolve_build(path, Some(&ContentBasedPathHash::for_output_artifact())))
+            .collect::<buck2_error::Result<Vec<_>>>()?;
+        if real.is_empty() {
+            Err(ExecuteError::MissingOutputs { declared })
+        } else {
+            Err(ExecuteError::MismatchedOutputs { declared, real })
+        }
+    } else {
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl ActionExecutionCtx for BuckActionExecutionContext<'_, '_> {
     fn target(&self) -> ActionExecutionTarget<'_> {
@@ -689,6 +761,25 @@ impl ActionExecutionCtx for BuckActionExecutionContext<'_, '_> {
             .await?)
     }
 
+    fn validate_command_execution_outputs(
+        &self,
+        result: &CommandExecutionResult,
+    ) -> Result<(), ExecuteError> {
+        let actual_outputs = ActionOutputs::new(
+            result
+                .outputs
+                .iter()
+                .filter_map(|(output, value)| match output {
+                    CommandExecutionOutput::BuildArtifact { path, .. } => {
+                        Some((path.dupe(), value.dupe()))
+                    }
+                    CommandExecutionOutput::TestPath { .. } => None,
+                })
+                .collect(),
+        );
+        validate_action_outputs(self.fs(), self.outputs, &actual_outputs)
+    }
+
     async fn cleanup_outputs(&self) -> buck2_error::Result<()> {
         // Delete all outputs before we start, so things will be clean.
         let output_paths = self
@@ -767,87 +858,8 @@ impl<'d> BuckActionExecutor<'d> {
 
             let (result, metadata) = action.execute(&mut ctx, waiting_data).await?;
 
-            // Check that all the outputs are the right output_type
-            for x in outputs.iter() {
-                let declared = x.output_type();
-                // FIXME: One day we should treat FileOrDirectory as a File, and soft_error if it is a directory
-                if declared != OutputType::FileOrDirectory {
-                    if let Some(t) = result.0.outputs.get(x.get_path()) {
-                        let real = if t.is_dir() {
-                            OutputType::Directory
-                        } else {
-                            OutputType::File
-                        };
-                        if real != declared {
-                            return Err(ExecuteError::WrongOutputType {
-                                path: self.command_executor.fs().resolve_build(
-                                    x.get_path(),
-                                    Some(&t.content_based_path_hash()),
-                                )?,
-                                declared,
-                                real,
-                            });
-                        }
-                    }
-                }
-            }
-
-            fn check_all_requested_outputs_returned_without_extra<'a>(
-                outputs: &[BuildArtifact],
-                result_outputs: impl IntoIterator<Item = &'a BuildArtifactPath>,
-            ) -> bool {
-                // Ignore ordering as outputs in original action might be ordered differently from
-                // output paths in action result (they are sorted there).
-                let result_output_paths: BuckMutSet<&BuildArtifactPath> =
-                    result_outputs.into_iter().collect();
-                let mut outputs_count = 0;
-                for output in outputs.iter() {
-                    outputs_count += 1;
-                    let output_path = output.get_path();
-                    if !result_output_paths.contains(output_path) {
-                        return false;
-                    }
-                }
-                outputs_count == result_output_paths.len()
-            }
-
-            // TODO (T122966509): Check projections here as well
-            if !check_all_requested_outputs_returned_without_extra(
-                &outputs,
-                result.0.outputs.keys(),
-            ) {
-                let declared = outputs
-                    .iter()
-                    .filter(|x| !result.0.outputs.contains_key(x.get_path()))
-                    .map(|x| {
-                        self.command_executor.fs().resolve_build(
-                            x.get_path(),
-                            Some(&ContentBasedPathHash::for_output_artifact()),
-                        )
-                    })
-                    .collect::<buck2_error::Result<_>>()?;
-                let real = result
-                    .0
-                    .outputs
-                    .keys()
-                    .filter(|x| {
-                        // This is error message, linear search is fine.
-                        !outputs.iter().map(|b| b.get_path()).contains(x)
-                    })
-                    .map(|x| {
-                        self.command_executor
-                            .fs()
-                            .resolve_build(x, Some(&ContentBasedPathHash::for_output_artifact()))
-                    })
-                    .collect::<buck2_error::Result<Vec<_>>>()?;
-                if real.is_empty() {
-                    Err(ExecuteError::MissingOutputs { declared })
-                } else {
-                    Err(ExecuteError::MismatchedOutputs { declared, real })
-                }
-            } else {
-                Ok((result, metadata))
-            }
+            validate_action_outputs(self.command_executor.fs(), &outputs, &result)?;
+            Ok((result, metadata))
         }
         .await;
 

--- a/tests/core/executor/test_cache_uploads.py
+++ b/tests/core/executor/test_cache_uploads.py
@@ -12,6 +12,7 @@
 import sys
 
 from buck2.tests.e2e_util.api.buck import Buck
+from buck2.tests.e2e_util.asserts import expect_failure
 from buck2.tests.e2e_util.buck_workspace import buck_test
 from buck2.tests.e2e_util.helper.utils import json_get, random_string
 
@@ -99,3 +100,27 @@ async def test_re_uploads_default(buck: Buck) -> None:
     ]
     await buck.build("root//:write_default", *args)
     await _assert_locally_executed_upload_attempted(buck, 1)
+
+
+@buck_test()
+async def test_missing_output_is_not_uploaded(buck: Buck) -> None:
+    # Give the action a fresh digest so an entry left by a buggy Buck2 cannot
+    # turn this into an action-cache hit.
+    args = ["-c", f"write.nonce={random_string()}"]
+    await expect_failure(
+        buck.build("root//:missing_output", *args),
+        stderr_regex="Required outputs are missing",
+    )
+
+    # A successful command with an invalid output set must be rejected before
+    # Buck2 enters the cache-upload path. Check all CacheUpload events here,
+    # including rejected uploads that the other tests tolerate as CI infra
+    # limitations.
+    log = (await buck.log("show")).stdout.strip().splitlines()
+    uploads = [
+        line
+        for line in log
+        if json_get(line, "Event", "data", "SpanEnd", "data", "CacheUpload")
+        is not None
+    ]
+    assert uploads == []

--- a/tests/core/executor/test_cache_uploads_data/TARGETS.fixture
+++ b/tests/core/executor/test_cache_uploads_data/TARGETS.fixture
@@ -1,4 +1,4 @@
-load("@root//:rules.bzl", "write")
+load("@root//:rules.bzl", "missing_output", "write")
 
 write(
     name = "write",
@@ -34,6 +34,13 @@ write(
     text = read_config("write", "text") or fail("text missing"),
     allow_cache_upload = None,
     local_only = True,
+    default_target_platform = "//platforms:target",
+    exec_compatible_with = ["//platforms:cache_uploads"],
+)
+
+missing_output(
+    name = "missing_output",
+    nonce = read_config("write", "nonce") or fail("nonce missing"),
     default_target_platform = "//platforms:target",
     exec_compatible_with = ["//platforms:cache_uploads"],
 )

--- a/tests/core/executor/test_cache_uploads_data/rules.bzl
+++ b/tests/core/executor/test_cache_uploads_data/rules.bzl
@@ -36,3 +36,27 @@ write = rule(
         "text": attrs.string(),
     },
 )
+
+def _missing_output_impl(ctx):
+    out = ctx.actions.declare_output("out", has_content_based_path = False)
+    ctx.actions.run(
+        [
+            "fbpython",
+            "-c",
+            "pass",
+            ctx.attrs.nonce,
+            out.as_output(),
+        ],
+        category = "missing_output",
+        local_only = True,
+        allow_cache_upload = True,
+    )
+
+    return [DefaultInfo(default_output = out)]
+
+missing_output = rule(
+    impl = _missing_output_impl,
+    attrs = {
+        "nonce": attrs.string(),
+    },
+)


### PR DESCRIPTION
I can't say with confidence that this is why we had a production issue, but here's what happened:

We had a RE action cache item with declared outputs missing compared to its specification. This caused downstream build failures when they pulled it from cache. The action was run with the GHC persistent worker and it is unquestionably a bug in there, but buck2 should not let this persistent worker bug become an instant cache corruption.

Previously outputs were only checked *after* running the action and uploading it, in BuckActionExecutor::execute.

Output:
```
[2026-08-13T16:07:33.194+00:00] Required outputs are missing: Action failed to produce outputs: `buck-out/v2/art/root/aaaaaaaaaaaaaaaa/local-packages/a-mercury-prelude/__a-mercury-prelude__/mod-static_pic/A/MercuryPrelude/Data/Foldable.o`, `buck-out/v2/art/root/aaaaaaaaaaaaaaaa/local-packages/a-mercury-prelude/__a-mercury-prelude__/mod-static_pic/A/MercuryPrelude/Data/Foldable.hi`, `buck-out/v2/art/root/aaaaaaaaaaaaaaaa/local-packages/a-mercury-prelude/__a-mercury-prelude__/mod-static_pic/A/MercuryPrelude/Data/Foldable.hie`
[2026-08-13T16:07:33.194+00:00] Remote action digest: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:142'
```

The tests are vibecoded, sorry, I can't actually run them so they're included for illustration; feel free to deal with them however you'd like.