### PR TITLE
prelude/cxx: Provide TemplatePlaceholderInfo from prebuilt_cxx_library.

### DIFF
--- a/prelude/cxx/cxx.bzl
+++ b/prelude/cxx/cxx.bzl
@@ -190,6 +190,10 @@ load(
     ":shared_library_interface.bzl",
     "shared_library_interface",
 )
+load(
+    ":template_placeholders.bzl",
+    "cxx_template_placeholder_info",
+)
 
 #####################################################################
 # Operations
@@ -694,6 +698,7 @@ def _create_prebuilt_library_providers(
     inherited_link,
     first_order_deps,
     exported_first_order_deps,
+    propagated_preprocessor,
 ):
     """
     Create and return providers for a prebuilt library with a specific preferred linkage.
@@ -718,17 +723,24 @@ def _create_prebuilt_library_providers(
     pic_behavior = cxx_toolchain.pic_behavior
 
     # Propagate link info provider.
+    merged_native_link_info = create_merged_link_info(
+        ctx,
+        pic_behavior,
+        # Add link info for each link style,
+        libraries,
+        preferred_linkage = preferred_linkage,
+        # Export link info from non-exported deps (when necessary).
+        deps = inherited_link,
+        # Export link info from out (exported) deps.
+        exported_deps = inherited_exported_link,
+    )
+    providers.append(merged_native_link_info)
+
     providers.append(
-        create_merged_link_info(
+        cxx_template_placeholder_info(
             ctx,
-            pic_behavior,
-            # Add link info for each link style,
-            libraries,
-            preferred_linkage = preferred_linkage,
-            # Export link info from non-exported deps (when necessary).
-            deps = inherited_link,
-            # Export link info from out (exported) deps.
-            exported_deps = inherited_exported_link,
+            propagated_preprocessor,
+            merged_native_link_info,
         )
     )
 
@@ -975,6 +987,7 @@ def prebuilt_cxx_library_impl(ctx: AnalysisContext) -> list[Provider]:
             inherited_link,
             first_order_deps,
             exported_first_order_deps,
+            propagated_preprocessor,
         )
 
     providers, sub_targets, output = linkage_providers[preferred_linkage]

--- a/prelude/cxx/cxx_library.bzl
+++ b/prelude/cxx/cxx_library.bzl
@@ -89,14 +89,12 @@ load(
     "UnstrippedLinkOutputInfo",
     "create_merged_link_info",
     "get_lib_output_style",
-    "get_link_args_for_strategy",
     "get_output_styles_for_linkage",
     "make_link_command_debug_output",
     "make_link_command_debug_output_json_info",
     "process_link_strategy_for_pic_behavior",
     "subtarget_for_output_style",
     "to_link_strategy",
-    "unpack_link_args",
     "wrap_link_info",
 )
 load(
@@ -252,6 +250,10 @@ load(
 load(
     ":shared_library_interface.bzl",
     "shared_library_interface",
+)
+load(
+    ":template_placeholders.bzl",
+    "cxx_template_placeholder_info",
 )
 
 # A possible output of a `cxx_library`. This could be an archive or a shared library. Generally for an archive
@@ -1240,58 +1242,7 @@ def cxx_library_parameterized(ctx: AnalysisContext, impl_params: CxxRuleConstruc
             providers.append(apple_resource_graph)
 
     if impl_params.generate_providers.template_placeholders:
-        templ_vars = {}
-
-        # Some rules, e.g. fbcode//thrift/lib/cpp:thrift-core-module
-        # define preprocessor flags as things like: -DTHRIFT_PLATFORM_CONFIG=<thrift/facebook/PlatformConfig.h>
-        # and unless they get quoted, they break shell syntax.
-        cxx_compiler_info = get_cxx_toolchain_info(ctx).cxx_compiler_info
-        cxx_preprocessor_flags = cmd_args(
-            cmd_args(cxx_compiler_info.preprocessor_flags or [], quote = "shell"),
-            cmd_args(propagated_preprocessor.set.project_as_args("args"), quote = "shell"),
-            propagated_preprocessor.set.project_as_args("include_dirs"),
-        )
-        templ_vars["cxxppflags"] = cxx_preprocessor_flags
-
-        c_compiler_info = get_cxx_toolchain_info(ctx).c_compiler_info
-        c_preprocessor_flags = cmd_args(
-            cmd_args(c_compiler_info.preprocessor_flags or [], quote = "shell"),
-            cmd_args(propagated_preprocessor.set.project_as_args("args"), quote = "shell"),
-            propagated_preprocessor.set.project_as_args("include_dirs"),
-        )
-        templ_vars["cppflags"] = c_preprocessor_flags
-
-        # Add in ldflag macros.
-        for link_strategy in (LinkStrategy("static"), LinkStrategy("static_pic")):
-            name = "ldflags-" + link_strategy.value.replace("_", "-")
-            args = []
-            linker_info = get_cxx_toolchain_info(ctx).linker_info
-            args.append(linker_info.linker_flags or [])
-
-            # Normally, we call get_link_args_for_strategy for getting the args for our own link from our
-            # deps. This case is a bit different as we are effectively trying to get the args for how this library
-            # would be represented on a dependent's link line and so it is appropriate to use our own merged_native_link_info.
-            link_args = get_link_args_for_strategy(
-                ctx.actions,
-                ctx.label,
-                get_cxx_toolchain_info(ctx).linker_info,
-                [merged_native_link_info],
-                link_strategy,
-                prefer_stripped = False,
-                transformation_spec_context = None,
-            )
-            args.append(unpack_link_args(link_args))
-            templ_vars[name] = cmd_args(args)
-
-        # TODO(T110378127): To implement `$(ldflags-shared ...)` properly, we'd need
-        # to setup a symink tree rule for all transitive shared libs.  Since this
-        # currently would be pretty costly (O(N^2)?), and since it's not that
-        # commonly used anyway, just use `static-pic` instead.  Longer-term, once
-        # v1 is gone, macros that use `$(ldflags-shared ...)` (e.g. Haskell's
-        # hsc2hs) can move to a v2 rules-based API to avoid needing this macro.
-        templ_vars["ldflags-shared"] = templ_vars["ldflags-static-pic"]
-
-        providers.append(TemplatePlaceholderInfo(keyed_variables = templ_vars))
+        providers.append(cxx_template_placeholder_info(ctx, propagated_preprocessor, merged_native_link_info))
 
     # It is possible (e.g. in a java binary or an Android APK) to have C++ libraries that depend
     # upon Java libraries (through JNI). In some cases those Java libraries are not depended upon

--- a/prelude/cxx/template_placeholders.bzl
+++ b/prelude/cxx/template_placeholders.bzl
@@ -1,0 +1,78 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is dual-licensed under either the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree or the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree. You may select, at your option, one of the
+# above-listed licenses.
+
+load(
+    "@prelude//linking:link_info.bzl",
+    "LinkStrategy",
+    "MergedLinkInfo",  # @unused Used as a type
+    "get_link_args_for_strategy",
+    "unpack_link_args",
+)
+load(":cxx_context.bzl", "get_cxx_toolchain_info")
+load(
+    ":preprocessor.bzl",
+    "CPreprocessorInfo",  # @unused Used as a type
+)
+
+def cxx_template_placeholder_info(
+        ctx: AnalysisContext,
+        propagated_preprocessor: [CPreprocessorInfo, None],
+        merged_native_link_info: MergedLinkInfo) -> TemplatePlaceholderInfo:
+    templ_vars = {}
+
+    if propagated_preprocessor != None:
+        # Some rules, e.g. fbcode//thrift/lib/cpp:thrift-core-module
+        # define preprocessor flags as things like: -DTHRIFT_PLATFORM_CONFIG=<thrift/facebook/PlatformConfig.h>
+        # and unless they get quoted, they break shell syntax.
+        cxx_compiler_info = get_cxx_toolchain_info(ctx).cxx_compiler_info
+        cxx_preprocessor_flags = cmd_args(
+            cmd_args(cxx_compiler_info.preprocessor_flags or [], quote = "shell"),
+            cmd_args(propagated_preprocessor.set.project_as_args("args"), quote = "shell"),
+            propagated_preprocessor.set.project_as_args("include_dirs"),
+        )
+        templ_vars["cxxppflags"] = cxx_preprocessor_flags
+
+        c_compiler_info = get_cxx_toolchain_info(ctx).c_compiler_info
+        c_preprocessor_flags = cmd_args(
+            cmd_args(c_compiler_info.preprocessor_flags or [], quote = "shell"),
+            cmd_args(propagated_preprocessor.set.project_as_args("args"), quote = "shell"),
+            propagated_preprocessor.set.project_as_args("include_dirs"),
+        )
+        templ_vars["cppflags"] = c_preprocessor_flags
+
+    # Add in ldflag macros.
+    for link_strategy in (LinkStrategy("static"), LinkStrategy("static_pic")):
+        name = "ldflags-" + link_strategy.value.replace("_", "-")
+        args = []
+        linker_info = get_cxx_toolchain_info(ctx).linker_info
+        args.append(linker_info.linker_flags or [])
+
+        # Normally, we call get_link_args_for_strategy for getting the args for our own link from our
+        # deps. This case is a bit different as we are effectively trying to get the args for how this library
+        # would be represented on a dependent's link line and so it is appropriate to use our own merged_native_link_info.
+        link_args = get_link_args_for_strategy(
+            ctx.actions,
+            ctx.label,
+            get_cxx_toolchain_info(ctx).linker_info,
+            [merged_native_link_info],
+            link_strategy,
+            prefer_stripped = False,
+            transformation_spec_context = None,
+        )
+        args.append(unpack_link_args(link_args))
+        templ_vars[name] = cmd_args(args)
+
+    # TODO(T110378127): To implement `$(ldflags-shared ...)` properly, we'd need
+    # to setup a symink tree rule for all transitive shared libs.  Since this
+    # currently would be pretty costly (O(N^2)?), and since it's not that
+    # commonly used anyway, just use `static-pic` instead.  Longer-term, once
+    # v1 is gone, macros that use `$(ldflags-shared ...)` (e.g. Haskell's
+    # hsc2hs) can move to a v2 rules-based API to avoid needing this macro.
+    templ_vars["ldflags-shared"] = templ_vars["ldflags-static-pic"]
+
+    return TemplatePlaceholderInfo(keyed_variables = templ_vars)

--- a/prelude/haskell/haskell.bzl
+++ b/prelude/haskell/haskell.bzl
@@ -54,6 +54,10 @@ load(
     "cxx_merge_cpreprocessors",
 )
 load(
+    "@prelude//cxx:template_placeholders.bzl",
+    "cxx_template_placeholder_info",
+)
+load(
     "@prelude//haskell:compile.bzl",
     "CompileResultInfo",
     "compile",
@@ -861,39 +865,7 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
     if indexing_tsets:
         providers.append(HaskellIndexInfo(info = indexing_tsets))
 
-    # TODO(cjhopman): This code is for templ_vars is duplicated from cxx_library
-    templ_vars = {}
-
-    # Add in ldflag macros.
-    for link_style in (LinkStyle("static"), LinkStyle("static_pic")):
-        name = "ldflags-" + link_style.value.replace("_", "-")
-        args = cmd_args()
-        linker_info = ctx.attrs._cxx_toolchain[CxxToolchainInfo].linker_info
-        args.add(linker_info.linker_flags)
-        args.add(
-            unpack_link_args(
-                get_link_args_for_strategy(
-                    ctx.actions,
-                    ctx.label,
-                    linker_info,
-                    [merged_link_info],
-                    to_link_strategy(link_style),
-                    prefer_stripped = False,
-                    transformation_spec_context = None,
-                ),
-            )
-        )
-        templ_vars[name] = args
-
-    # TODO(T110378127): To implement `$(ldflags-shared ...)` properly, we'd need
-    # to setup a symink tree rule for all transitive shared libs.  Since this
-    # currently would be pretty costly (O(N^2)?), and since it's not that
-    # commonly used anyway, just use `static-pic` instead.  Longer-term, once
-    # v1 is gone, macros that use `$(ldflags-shared ...)` (e.g. Haskell's
-    # hsc2hs) can move to a v2 rules-based API to avoid needing this macro.
-    templ_vars["ldflags-shared"] = templ_vars["ldflags-static-pic"]
-
-    providers.append(TemplatePlaceholderInfo(keyed_variables = templ_vars))
+    providers.append(cxx_template_placeholder_info(ctx, None, merged_link_info))
 
     providers.append(merge_link_group_lib_info(deps = attr_deps(ctx)))
 


### PR DESCRIPTION
This deduplicates the `TemplatePlaceholderInfo` code between `cxx_library` and `haskell_library` into a helper, and additionally adds the `TemplatePlaceholderInfo` to `prebuilt_cxx_library`.