### PR TITLE
java: use exec_dep properly

### DIFF
--- a/prelude/toolchains/java.bzl
+++ b/prelude/toolchains/java.bzl
@@ -62,7 +62,8 @@ def _prebuilt_jar_toolchain_rule_impl(ctx):
 
 _prebuilt_jar_toolchain_rule = rule(
     attrs = {
-        "java": attrs.dep(),
+        # this just goes into the RunInfo of the result, so it's target, not exec
+        "java": attrs.dep(providers = [RunInfo]),
     },
     impl = _prebuilt_jar_toolchain_rule_impl,
     is_toolchain_rule = True,
@@ -154,10 +155,16 @@ _java_toolchain = rule(
     impl = _java_toolchain_impl,
     is_toolchain_rule = True,
     attrs = {
-        "class_abi_generator": attrs.option(attrs.dep(providers = [RunInfo]), default = None),
+        "class_abi_generator": attrs.option(attrs.exec_dep(providers = [RunInfo]), default = None),
         "class_loader_bootstrapper": attrs.option(attrs.source(), default = None),
-        "compile_and_package": attrs.dep(default = "prelude//java/tools:compile_and_package"),
-        "fat_jar": attrs.dep(default = "prelude//java/tools:fat_jar"),
+        "compile_and_package": attrs.exec_dep(
+            default = "prelude//java/tools:compile_and_package",
+            providers = [RunInfo],
+        ),
+        "fat_jar": attrs.exec_dep(
+            default = "prelude//java/tools:fat_jar",
+            providers = [RunInfo],
+        ),
         "fat_jar_main_class_lib": attrs.option(attrs.source(), default = None),
         "gen_class_to_source_map": attrs.exec_dep(
             default = "prelude//java/tools:gen_class_to_source_map",
@@ -170,16 +177,16 @@ _java_toolchain = rule(
             ],
         ),
         "is_bootstrap_toolchain": attrs.bool(default = False),
-        "jar": attrs.option(attrs.dep(providers = [RunInfo]), default = None),
+        "jar": attrs.option(attrs.exec_dep(providers = [RunInfo]), default = None),
         "jar_builder": attrs.source(default = "prelude//toolchains/android/src/com/facebook/buck/util/zip:jar_builder"),
-        "java": attrs.exec_dep(),
-        "java_for_tests": attrs.option(attrs.dep(providers = [RunInfo]), default = None),
-        "javac": attrs.option(attrs.one_of(attrs.dep(), attrs.source(), attrs.string()), default = None),
+        "java": attrs.exec_dep(providers = [RunInfo]),
+        "java_for_tests": attrs.option(attrs.exec_dep(providers = [RunInfo]), default = None),
+        "javac": attrs.option(attrs.one_of(attrs.exec_dep(), attrs.source(), attrs.string()), default = None),
         "javac_protocol": attrs.enum(JavacProtocol.values()),
         "javacd": attrs.option(attrs.source(), default = None),
         "javacd_main_class": attrs.option(attrs.string(), default = None),
-        "jlink": attrs.exec_dep(),
-        "jmod": attrs.exec_dep(),
+        "jlink": attrs.exec_dep(providers = [RunInfo]),
+        "jmod": attrs.exec_dep(providers = [RunInfo]),
         "jrt_fs_jar": attrs.source(),
         "merge_class_to_source_maps": attrs.exec_dep(
             default = "prelude//java/tools:merge_class_to_source_maps",
@@ -225,8 +232,8 @@ _java_test_toolchain_rule = rule(
             attrs.string(),
             default = [],
         ),
-        "list_class_names": attrs.dep(providers = [RunInfo]),
-        "list_tests": attrs.option(attrs.dep(providers = [RunInfo]), default = None),
+        "list_class_names": attrs.exec_dep(providers = [RunInfo]),
+        "list_tests": attrs.option(attrs.exec_dep(providers = [RunInfo]), default = None),
         "test_runner_library_jar": attrs.source(),
         "testng_test_runner_main_class_args": attrs.list(attrs.string()),
     },


### PR DESCRIPTION
Lots of tools here were broken under cross compilation: they'd get the target-platform python then blow up when executed.