### PR TITLE
python: fix exec platform handling

### DIFF
--- a/prelude/toolchains/python.bzl
+++ b/prelude/toolchains/python.bzl
@@ -8,6 +8,11 @@
 
 load("@prelude//:prelude.bzl", "native")
 load(
+    "@prelude//os_lookup:defs.bzl",
+    "Os",
+    "OsLookup",
+)
+load(
     "@prelude//python:python_wheel_toolchain.bzl",
     "PythonWheelToolchainInfo",
 )
@@ -46,11 +51,23 @@ _INTERPRETER = select({
     "config//os:windows": "python.exe",
 })
 
-def _python_bootstrap_toolchain_impl(ctx):
-    interpreter = ctx.attrs.interpreter if isinstance(ctx.attrs.interpreter, str) else ctx.attrs.interpreter[RunInfo].args
+_EXEC_OS_TYPE = attrs.default_only(attrs.exec_dep(default = "prelude//os_lookup/targets:os_lookup"))
+
+def _interpreter_for_os(os: Os) -> str:
+    return "python.exe" if os == Os("windows") else "python3"
+
+def _system_python_bootstrap_toolchain_impl(ctx):
+    # the interpreter name needs to be selected based on the exec platform, not the target
+    interpreter = ctx.attrs.interpreter or _interpreter_for_os(ctx.attrs._exec_os_type[OsLookup].os)
     return [
         DefaultInfo(),
         PythonBootstrapToolchainInfo(interpreter = interpreter),
+    ]
+
+def _python_bootstrap_toolchain_impl(ctx):
+    return [
+        DefaultInfo(),
+        PythonBootstrapToolchainInfo(interpreter = ctx.attrs.interpreter[RunInfo].args),
     ]
 
 # Creates a new bootstrap toolchain using Python that is installed on your system.
@@ -65,9 +82,10 @@ def _python_bootstrap_toolchain_impl(ctx):
 # )
 # ```
 system_python_bootstrap_toolchain = rule(
-    impl = _python_bootstrap_toolchain_impl,
+    impl = _system_python_bootstrap_toolchain_impl,
     attrs = {
-        "interpreter": attrs.string(default = _INTERPRETER),
+        "interpreter": attrs.option(attrs.string(), default = None),
+        "_exec_os_type": _EXEC_OS_TYPE,
     },
     is_toolchain_rule = True,
 )
@@ -90,12 +108,15 @@ def _system_python_toolchain_impl(ctx):
     A very simple toolchain that is hardcoded to the current environment.
     """
 
+    # the "host" (exec platform) interpreter needs to be selected based on the exec platform
+    host_interpreter = ctx.attrs.host_interpreter or _interpreter_for_os(ctx.attrs._exec_os_type[OsLookup].os)
+
     return [
         DefaultInfo(),
         PythonToolchainInfo(
             binary_linker_flags = ctx.attrs.binary_linker_flags,
             linker_flags = ctx.attrs.linker_flags,
-            host_interpreter = RunInfo(args = [ctx.attrs.interpreter]),
+            host_interpreter = RunInfo(args = [host_interpreter]),
             interpreter = RunInfo(args = [ctx.attrs.interpreter]),
             compile = RunInfo(args = ["echo", "COMPILEINFO"]),
             package_style = "inplace",
@@ -110,6 +131,11 @@ system_python_toolchain = rule(
     impl = _system_python_toolchain_impl,
     attrs = {
         "binary_linker_flags": attrs.default_only(attrs.list(attrs.arg(), default = [])),
+        "host_interpreter": attrs.option(
+            attrs.string(),
+            default = None,
+            doc = "Interpreter to run actions on the exec platform. Defaults to the usual interpreter name for the exec platform.",
+        ),
         "interpreter": attrs.string(default = _INTERPRETER),
         "linker_flags": attrs.default_only(attrs.list(attrs.arg(), default = [])),
         "pex_extension": attrs.string(default = ".pex"),
@@ -118,6 +144,7 @@ system_python_toolchain = rule(
             default = None,
             doc = "See `PythonToolchainInfo.type_checker` for the executable contract.",
         ),
+        "_exec_os_type": _EXEC_OS_TYPE,
     },
     is_toolchain_rule = True,
 )
@@ -127,7 +154,7 @@ def python_toolchain_impl(ctx) -> list[Provider]:
         DefaultInfo(),
         PythonToolchainInfo(
             interpreter = ctx.attrs.interpreter[RunInfo],
-            host_interpreter = ctx.attrs.interpreter[RunInfo],
+            host_interpreter = ctx.attrs.host_interpreter[RunInfo],
             compile = ctx.attrs.compile[DefaultInfo].default_outputs[0],
             package_style = "inplace",
             native_link_strategy = "separate",
@@ -139,11 +166,19 @@ def python_toolchain_impl(ctx) -> list[Provider]:
         PythonPlatformInfo(name = "x86_64"),
     ]
 
-python_toolchain = rule(
+_python_toolchain = rule(
     impl = python_toolchain_impl,
     attrs = {
-        "compile": attrs.default_only(attrs.dep(default = "prelude//python/tools:compile.py")),
+        "compile": attrs.default_only(attrs.exec_dep(default = "prelude//python/tools:compile.py")),
         "extension_linker_flags": attrs.list(attrs.arg()),
+        "host_interpreter": attrs.exec_dep(
+            providers = [RunInfo],
+            doc = """
+            Interpreter used to run build-time actions, such as compiling bytecode. Typically the
+            same label as `interpreter` (as defaulted by the python_toolchain wrapper macro), but
+            uses a separate attr to transition to exec configuration.
+            """,
+        ),
         "interpreter": attrs.dep(providers = [RunInfo]),
         "type_checker": attrs.option(
             attrs.exec_dep(providers = [RunInfo]),
@@ -154,6 +189,19 @@ python_toolchain = rule(
     is_toolchain_rule = True,
     doc = "A Python toolchain that can build Python extensions, given an interpreter and the extra linker flags to use with it. See `remote_python_toolchain` for a toolchain that configures the interpreter and linker flags for you.",
 )
+
+def python_toolchain(name: str, interpreter, host_interpreter = None, **kwargs) -> None:
+    """
+    A Python toolchain that can build Python extensions, given an interpreter and
+    the extra linker flags to use with it. See `remote_python_toolchain` for a
+    toolchain that configures the interpreter and linker flags for you.
+    """
+    _python_toolchain(
+        name = name,
+        interpreter = interpreter,
+        host_interpreter = interpreter if host_interpreter == None else host_interpreter,
+        **kwargs
+    )
 
 # archives for 3.13
 # update this by running `prelude//python/tools:discover_python_archives.sh`


### PR DESCRIPTION
- python_bootstrap_toolchain.interpreter -> exec_dep. Every python_bootstrap_binary in the prelude is a build tool.
- python_toolchain.compile -> exec_dep. It is read by the bytecode compile action in prelude/python/compile.bzl.
- Split host_interpreter out of interpreter. make_py_package already passes them to the packaging tool as separate --python/--host-python flags, so this is a distinction upheld by the rest of the prelude.

  We introduce a macro to retain source compatibility.
- Fix system_python_bootstrap_toolchain to properly consider the exec platform when determining the name of the interpreter, rather than doing it based on target platform.

related to #1465: this sort of independently fixes the python binaries to work correctly (by forcing them to use the exec platform's interpreter, which is the only correct choice for bootstrap binaries), though it's still correct to transition them to exec configuration as that PR does.