### PR TITLE
OSS RE: enable SSLKEYLOGFILE

### DIFF
--- a/remote_execution/oss/re_grpc/src/pool.rs
+++ b/remote_execution/oss/re_grpc/src/pool.rs
@@ -105,7 +105,11 @@ impl ChannelConfig {
     }
 
     async fn create_tls_config(opts: &Buck2OssReConfiguration) -> anyhow::Result<ClientTlsConfig> {
-        let config = ClientTlsConfig::new().with_enabled_roots();
+        // use_key_log(): store the session keys to a file when SSLKEYLOGFILE
+        // is set in env, to allow decrypting PCAP files for debugging. See:
+        // - https://www.ietf.org/archive/id/draft-thomson-tls-keylogfile-00.html
+        // - https://wiki.wireshark.org/TLS
+        let config = ClientTlsConfig::new().with_enabled_roots().use_key_log();
 
         let config = match opts.tls_ca_certs.as_ref() {
             Some(tls_ca_certs) => {


### PR DESCRIPTION
threat model: you are running buck2, you could attach a debugger to it too, so this is not meaningful to security in general.

purpose: capture RE traffic in a decryptable form without putting anything actually in the middle, using tcpdump and then decoding with wireshark or similar.