### PR TITLE
re_grpc: retry io errors wrapped in h2::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,6 +336,7 @@ games = { path = "games" }
 gazebo = { path = "gazebo/gazebo", features = ["str_pattern_extensions"] }
 glob = "0.3.4"
 globset = { version = "0.4.20", features = ["serde1"] }
+h2 = "0.4"
 hashbrown = "0.17.1"
 hex = { version = "0.4.3", features = ["alloc"] }
 host_sharing = { path = "host_sharing" }

--- a/remote_execution/oss/re_grpc/BUCK
+++ b/remote_execution/oss/re_grpc/BUCK
@@ -12,6 +12,7 @@ rust_library(
         "fbsource//third-party/rust:anyhow",
         "fbsource//third-party/rust:async-compression",
         "fbsource//third-party/rust:futures",
+        "fbsource//third-party/rust:h2",
         "fbsource//third-party/rust:http",
         "fbsource//third-party/rust:http-body",
         "fbsource//third-party/rust:http-body-util",

--- a/remote_execution/oss/re_grpc/Cargo.toml
+++ b/remote_execution/oss/re_grpc/Cargo.toml
@@ -15,6 +15,7 @@ buck2_util.workspace = true
 dupe.workspace = true
 futures.workspace = true
 gazebo.workspace = true
+h2.workspace = true
 http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -555,12 +555,31 @@ impl BatchUploadReqAggregator {
     }
 }
 
+/// Returns true if an `io::Error` indicates a transport-level disruption that
+/// a fresh connection can recover from.
+fn is_transient_io_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::BrokenPipe
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::UnexpectedEof
+            | std::io::ErrorKind::TimedOut
+    )
+}
+
 /// Returns true if an error is a transient connection/transport error worth
 /// retrying. Walks the error chain checking for:
 ///   - `tonic::Status` with codes the gRPC retry policy treats as transient
 ///     (Unavailable, ResourceExhausted, Aborted, Cancelled)
 ///   - `io::Error` of a kind that indicates a transport-level disruption
 ///     (BrokenPipe, ConnectionReset/Aborted, UnexpectedEof, TimedOut)
+///   - `h2::Error` wrapping such an `io::Error`. `h2::Error` does not
+///     implement `source()`, so the inner `io::Error` never appears as its
+///     own link in the chain; tonic also maps these errors to
+///     `Code::Unknown`. Body errors on an established connection (for
+///     example a TCP reset during a `BatchReadBlobs` response) take this
+///     path and need the explicit downcast.
 ///
 /// `tonic::transport::Error` is not matched directly — its transient subset
 /// surfaces as an `io::Error` somewhere in the chain, which we catch above.
@@ -578,13 +597,15 @@ fn is_retryable(err: &anyhow::Error) -> bool {
             }
         }
         if let Some(io_err) = cause.downcast_ref::<std::io::Error>() {
-            match io_err.kind() {
-                std::io::ErrorKind::BrokenPipe
-                | std::io::ErrorKind::ConnectionReset
-                | std::io::ErrorKind::ConnectionAborted
-                | std::io::ErrorKind::UnexpectedEof
-                | std::io::ErrorKind::TimedOut => return true,
-                _ => {}
+            if is_transient_io_error(io_err) {
+                return true;
+            }
+        }
+        if let Some(h2_err) = cause.downcast_ref::<h2::Error>() {
+            if let Some(io_err) = h2_err.get_io() {
+                if is_transient_io_error(io_err) {
+                    return true;
+                }
             }
         }
     }


### PR DESCRIPTION
h2::Error does not override source() in its Error impl, so an io::Error inside it never appears in the error chain and is_retryable misses it. tonic also maps these errors to Code::Unknown. A TCP reset during a BatchReadBlobs response body therefore failed the build with zero retries. Downcast to h2::Error and check the inner io::Error directly.