### PR TITLE
Cap jemalloc arenas in check_dependencies_test to cut aarch64 memory (#1481)

### DIFF
--- a/tests/e2e_util/test_bxl_check_dependencies_template.py
+++ b/tests/e2e_util/test_bxl_check_dependencies_template.py
@@ -71,6 +71,12 @@ if FLAVOR == "check_dependencies_test":  # noqa: C901
                 "BUCK2_TEST_DISABLE_LOG_UPLOAD": "false",
                 "BUCK2_RUNTIME_THREADS": "8",
                 "BUCK2_MAX_BLOCKING_THREADS": "8",
+                # Cap jemalloc arenas: the default (4*ncpu) arenas each retain
+                # dirty pages rounded up to aarch64's 64KB page, inflating the
+                # buck2 daemon's DICE-graph RSS ~5x vs x86 (4KB pages). Cuts ARM
+                # peak ~68% to x86 parity, no x86 regression. See T286274456.
+                "MALLOC_CONF": "narenas:4,dirty_decay_ms:0,muzzy_decay_ms:0",
+                "_RJEM_MALLOC_CONF": "narenas:4,dirty_decay_ms:0,muzzy_decay_ms:0",
             },
         )
         if expect_failure_msg == "":
@@ -161,6 +167,12 @@ elif FLAVOR == "check_mutually_exclusive_dependencies_test":
                 "BUCK2_TEST_DISABLE_LOG_UPLOAD": "false",
                 "BUCK2_RUNTIME_THREADS": "8",
                 "BUCK2_MAX_BLOCKING_THREADS": "8",
+                # Cap jemalloc arenas: the default (4*ncpu) arenas each retain
+                # dirty pages rounded up to aarch64's 64KB page, inflating the
+                # buck2 daemon's DICE-graph RSS ~5x vs x86 (4KB pages). Cuts ARM
+                # peak ~68% to x86 parity, no x86 regression. See T286274456.
+                "MALLOC_CONF": "narenas:4,dirty_decay_ms:0,muzzy_decay_ms:0",
+                "_RJEM_MALLOC_CONF": "narenas:4,dirty_decay_ms:0,muzzy_decay_ms:0",
             },
         )
         if expect_failure_msg == "":


### PR DESCRIPTION
Summary:

The buck2 dep-audit e2e tests (check_dependencies_test /
check_mutually_exclusive_dependencies_test) dominate the ARM/x86 CI
memory-divergence top-25 (~19 of 25). Each spins up a buck2 daemon that walks a
full transitive-dep closure; the peak RAM is the daemon's live DICE graph, not
the test body. On aarch64 that graph costs ~5x its x86 size: jemalloc's default
narenas (4*ncpu, ~288 arenas on a 72-core box) each retain dirty pages rounded
up to the 64KB ARM page, where x86's 4KB pages make the same arenas 16x cheaper.

Set MALLOC_CONF/_RJEM_MALLOC_CONF=narenas:4,dirty_decay_ms:0,muzzy_decay_ms:0 in
the env these bxl invocations already run under. This is allocator tuning of the
daemon subprocess only -- it does not change test semantics. Applied
unconditionally (no arch gate) because it also helps, or is neutral, on x86.

Reviewed By: IanChilds

Differential Revision: D117546126


