### PR TITLE
Tag DaemonDisconnect where the stream error is created

### DIFF
--- a/app/buck2_client_ctx/src/events_ctx.rs
+++ b/app/buck2_client_ctx/src/events_ctx.rs
@@ -201,6 +201,7 @@ impl<'a> DaemonEventsCtx<'a> {
                         Err(e)
                             .buck_error_context("Buck daemon event bus encountered an error, the root cause (if available) is displayed above this message.")
                             .tag(ErrorTag::ClientGrpcStream)
+                            .tag(ErrorTag::DaemonDisconnect)
                     };
                 }
             };

--- a/tests/core/build/test_error_categorization.py
+++ b/tests/core/build/test_error_categorization.py
@@ -162,18 +162,19 @@ async def test_daemon_crash(buck: Buck) -> None:
     else:
         assert "stream closed because of a broken pipe" in error["message"]
 
-    assert error["tags"][0:3] == [
+    assert error["tags"][0:4] == [
         "CLIENT_GRPC",
         "CLIENT_GRPC_STREAM",
+        "DAEMON_DISCONNECT",
         "SERVER_PANICKED",
     ]
-    assert error["tags"][4].startswith("crash")
+    assert error["tags"][5].startswith("crash")
     assert "buckd stderr:\n" in error["message"]
     assert "panicked at" in error["message"]
 
     assert error["best_tag"] == "SERVER_PANICKED"
     category_key = error["category_key"]
-    assert category_key.startswith("SERVER_PANICKED")
+    assert category_key.startswith("DAEMON_DISCONNECT:SERVER_PANICKED")
 
     # TODO dump stack trace on windows
     if not is_running_on_windows():


### PR DESCRIPTION
A mid-stream event bus failure is tagged only ClientGrpcStream, which is rank!(unspecified), so the command exits 1 (UnknownFailure).

This change tags the error with DaemonDisconnect which causes it to exit with code 2 InfraError, which allows users to differentiate it from build failures and do a retry.

This appears to be a bug fix and in line with comments and documentation for how a daemon death should be handle.d

BTW, I could not build the main branch with cargo due to its dependency on `fbsource/darwin-libproc`