### PR TITLE
OSS RE: timeout hung CAS/AC RPCs and Ensure

### DIFF
--- a/app/buck2_execute_impl/src/materializers/deferred.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Duration as StdDuration;
 
 use allocative::Allocative;
 use artifact_tree::ArtifactMaterializationMethod;
@@ -43,6 +44,7 @@ use buck2_directory::directory::directory_iterator::DirectoryIteratorPathStack;
 use buck2_directory::directory::entry::DirectoryEntry;
 use buck2_directory::directory::walk::unordered_entry_walk;
 use buck2_error::BuckErrorContext;
+use buck2_error::buck2_error;
 use buck2_events::dispatch::EventDispatcher;
 use buck2_events::dispatch::current_span;
 use buck2_events::dispatch::get_dispatcher;
@@ -131,6 +133,10 @@ pub struct DeferredMaterializerAccessor<T: IoHandler + 'static> {
     materialize_final_artifacts: bool,
     defer_write_actions: bool,
     eager_materialization_enabled: bool,
+    /// Bound on waiting for `buck2-dm` to dequeue `Ensure`. `None` disables.
+    /// Does not bound the CAS download that follows; that is the RE client RPC timeout.
+    #[allocative(skip)]
+    ensure_timeout: Option<StdDuration>,
 
     io: Arc<T>,
 
@@ -165,6 +171,9 @@ pub struct DeferredMaterializerConfigs {
     pub clean_stale_config: Option<CleanStaleConfig>,
     pub disable_eager_write_dispatch: bool,
     pub eager_materialization_enabled: bool,
+    /// Client-side timeout waiting for `buck2-dm` to accept `Ensure`.
+    /// Default 60s. `None` disables. Does not bound the download future.
+    pub ensure_timeout: Option<StdDuration>,
 }
 
 pub struct TtlRefreshConfiguration {
@@ -539,9 +548,26 @@ impl<T: IoHandler + Allocative> Materializer for DeferredMaterializerAccessor<T>
                 sender,
             ))
             .buck_error_context("Sending Ensure() command.")?;
-        let materialization_fut = recv
-            .await
-            .buck_error_context("Receiving materialization future from command thread.")?;
+        // Bound only this oneshot. If `buck2-dm` is stuck in sqlite/WAL/clean-stale,
+        // `Ensure` is never dequeued and no CAS RPC is sent. The download future
+        // returned here is already bounded by the RE client RPC timeout.
+        let materialization_fut = if let Some(timeout) = self.ensure_timeout {
+            match tokio::time::timeout(timeout, recv).await {
+                Ok(r) => {
+                    r.buck_error_context("Receiving materialization future from command thread.")?
+                }
+                Err(_) => {
+                    return Err(buck2_error!(
+                        buck2_error::ErrorTag::MaterializationError,
+                        "Materializer did not accept `Ensure` within {:?}; `buck2-dm` may be stuck",
+                        timeout
+                    ));
+                }
+            }
+        } else {
+            recv.await
+                .buck_error_context("Receiving materialization future from command thread.")?
+        };
         Ok(materialization_fut)
     }
 
@@ -741,6 +767,7 @@ impl DeferredMaterializerAccessor<DefaultIoHandler> {
             materialize_final_artifacts: configs.materialize_final_artifacts,
             defer_write_actions: configs.defer_write_actions,
             eager_materialization_enabled: configs.eager_materialization_enabled,
+            ensure_timeout: configs.ensure_timeout,
             io,
             materializer_state_info,
             stats,

--- a/app/buck2_execute_impl/src/materializers/deferred/tests.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred/tests.rs
@@ -531,6 +531,7 @@ mod state_machine {
                 materialize_final_artifacts: true,
                 defer_write_actions: true,
                 eager_materialization_enabled: true,
+                ensure_timeout: None,
                 io,
                 materializer_state_info: buck2_data::MaterializerStateInfo {
                     num_entries_from_sqlite: 0,
@@ -567,6 +568,35 @@ mod state_machine {
             Ok(())
         })
         .await
+    }
+
+    #[tokio::test]
+    async fn test_ensure_times_out_if_command_thread_never_runs() {
+        let io = Arc::new(StubIoHandler::new(temp_root()));
+        let (processor, command_sender, command_receiver, _events) =
+            make_processor_for_io(io.dupe());
+        let dm = DeferredMaterializerAccessor {
+            command_thread: None,
+            command_sender,
+            materialize_final_artifacts: true,
+            defer_write_actions: true,
+            eager_materialization_enabled: true,
+            ensure_timeout: Some(TokioDuration::from_millis(50)),
+            io,
+            materializer_state_info: buck2_data::MaterializerStateInfo {
+                num_entries_from_sqlite: 0,
+            },
+            stats: Arc::new(DeferredMaterializerStats::default()),
+        };
+        // Keep the receiver so `send` succeeds, but never run the command loop.
+        let _keep_unprocessed = (processor, command_receiver);
+
+        let err = match dm.materialize_many(vec![make_path("foo")]).await {
+            Ok(_) => panic!("expected Ensure timeout"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Ensure") && msg.contains("buck2-dm"), "{msg}");
     }
 
     #[tokio::test]

--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -477,6 +477,13 @@ pub struct Buck2OssReConfiguration {
     pub max_connections: Option<usize>,
     /// Maximum concurrent streams per connection.
     pub max_concurrency_per_connection: Option<usize>,
+    /// Client-side timeout for unary CAS/AC RPCs (`BatchReadBlobs`,
+    /// `GetActionResult`, `FindMissingBlobs`, `BatchUpdateBlobs`), in seconds.
+    /// Default 60. `0` disables. Not applied to `Execute` (long-running).
+    pub grpc_timeout_secs: Option<u64>,
+    /// Client-side timeout for ByteStream `Read`/`Write`, in seconds.
+    /// Default 600. `0` disables.
+    pub grpc_stream_timeout_secs: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -613,6 +620,14 @@ impl Buck2OssReConfiguration {
             max_concurrency_per_connection: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_concurrency_per_connection",
+            })?,
+            grpc_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_timeout_secs",
+            })?,
+            grpc_stream_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_stream_timeout_secs",
             })?,
         })
     }

--- a/app/buck2_server/src/daemon/state.rs
+++ b/app/buck2_server/src/daemon/state.rs
@@ -489,6 +489,15 @@ impl DaemonState {
                     .unwrap_or_else(RolloutPercentage::never)
                     .roll();
 
+                let ensure_timeout = match root_config.parse::<u64>(BuckconfigKeyRef {
+                    section: "buck2",
+                    property: "materializer_ensure_timeout_secs",
+                })? {
+                    None => Some(std::time::Duration::from_secs(60)),
+                    Some(0) => None,
+                    Some(n) => Some(std::time::Duration::from_secs(n)),
+                };
+
                 DeferredMaterializerConfigs {
                     materialize_final_artifacts: matches!(
                         materializations,
@@ -505,6 +514,7 @@ impl DaemonState {
                     clean_stale_config,
                     disable_eager_write_dispatch,
                     eager_materialization_enabled,
+                    ensure_timeout,
                 }
             };
             let disable_eager_write_dispatch =

--- a/docs/users/advanced/deferred_materialization.md
+++ b/docs/users/advanced/deferred_materialization.md
@@ -50,6 +50,17 @@ To enable, add this to your Buckconfig:
 sqlite_materializer_state = true
 ```
 
+`ensure_materialized` waits on a oneshot until the materializer command
+thread (`buck2-dm`) dequeues `Ensure`. That wait is bounded (default 60
+seconds) so a stuck command thread fails instead of freezing the build.
+Set to `0` to disable. This does not bound the CAS download that follows
+an accepted `Ensure`.
+
+```ini
+[buck2]
+materializer_ensure_timeout_secs = 60
+```
+
 ## Deferring Write Actions
 
 To further speedup builds, Buck2 can also be instructed to not execute any

--- a/docs/users/remote_execution.md
+++ b/docs/users/remote_execution.md
@@ -38,6 +38,12 @@ Keys supported include:
   interpolation syntax ($VAR). They will be substituted before reading the file.
 - `instance_name` - an instance name to pass on execution, action cache, and CAS
   requests.
+- `grpc_timeout_secs` - client-side timeout in seconds for unary CAS and action
+  cache RPCs (`BatchReadBlobs`, `GetActionResult`, `FindMissingBlobs`,
+  `BatchUpdateBlobs`). Default `60`. Set to `0` to disable. Not applied to
+  `Execute`.
+- `grpc_stream_timeout_secs` - client-side timeout in seconds for ByteStream
+  `Read`/`Write`. Default `600`. Set to `0` to disable.
 
 Buck2 uses `SHA256` for all its hashing by default. If your RE engine requires
 something else, this can be configured in `.buckconfig` as follows:

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -165,6 +165,13 @@ pub struct RECapabilities {
     supported_compressors: Vec<Compressor>,
 }
 
+/// Default unary CAS/AC RPC timeout. Long enough for a large `BatchReadBlobs`
+/// on a slow link, short enough that a hung frontend cannot freeze
+/// `ensure_materialized` for hours. Not applied to `Execute`.
+const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default ByteStream `Read`/`Write` timeout. Large blobs can take minutes.
+const DEFAULT_STREAM_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// Contains runtime options for the remote execution client as set under `buck2_re_client`
 pub struct RERuntimeOpts {
     /// Use the Meta version of the request metadata
@@ -175,6 +182,19 @@ pub struct RERuntimeOpts {
     cas_ttl_secs: i64,
     /// Maximum number of digests per `FindMissingBlobs` RPC.
     find_missing_blobs_batch_size: usize,
+    /// Client-side timeout for unary CAS/AC RPCs. `None` disables.
+    rpc_timeout: Option<Duration>,
+    /// Client-side timeout for ByteStream `Read`/`Write`. `None` disables.
+    stream_timeout: Option<Duration>,
+}
+
+/// `None` → default. `Some(0)` → disabled. Anything else → that many seconds.
+fn timeout_from_config(secs: Option<u64>, default: Duration) -> Option<Duration> {
+    match secs {
+        None => Some(default),
+        Some(0) => None,
+        Some(n) => Some(Duration::from_secs(n)),
+    }
 }
 
 struct InstanceName(Option<String>);
@@ -321,6 +341,11 @@ impl REClientBuilder {
                 // on the TTL of the remote blob.
                 cas_ttl_secs: opts.cas_ttl_secs.unwrap_or(3 * 60 * 60),
                 find_missing_blobs_batch_size: opts.find_missing_blobs_batch_size.unwrap_or(100),
+                rpc_timeout: timeout_from_config(opts.grpc_timeout_secs, DEFAULT_RPC_TIMEOUT),
+                stream_timeout: timeout_from_config(
+                    opts.grpc_stream_timeout_secs,
+                    DEFAULT_STREAM_TIMEOUT,
+                ),
             },
             capabilities,
             instance_name,
@@ -543,7 +568,7 @@ impl BatchUploadReqAggregator {
 /// Returns true if an error is a transient connection/transport error worth
 /// retrying. Walks the error chain checking for:
 ///   - `tonic::Status` with codes the gRPC retry policy treats as transient
-///     (Unavailable, ResourceExhausted, Aborted)
+///     (Unavailable, ResourceExhausted, Aborted, DeadlineExceeded)
 ///   - `io::Error` of a kind that indicates a transport-level disruption
 ///     (BrokenPipe, ConnectionReset/Aborted, UnexpectedEof, TimedOut)
 ///
@@ -557,7 +582,8 @@ fn is_retryable(err: &anyhow::Error) -> bool {
             match status.code() {
                 tonic::Code::Unavailable
                 | tonic::Code::ResourceExhausted
-                | tonic::Code::Aborted => return true,
+                | tonic::Code::Aborted
+                | tonic::Code::DeadlineExceeded => return true,
                 _ => {}
             }
         }
@@ -573,6 +599,29 @@ fn is_retryable(err: &anyhow::Error) -> bool {
         }
     }
     false
+}
+
+/// Bound a single RPC future on the client.
+///
+/// `Request::set_timeout` only writes the `grpc-timeout` header; a hung peer
+/// that never resets TCP still never returns. `Endpoint::timeout` would also
+/// fire on `Execute`, which shares the same frontend address as CAS — so CAS
+/// and AC calls wrap here, and `Execute` does not.
+async fn await_rpc<T>(
+    timeout: Option<Duration>,
+    fut: impl Future<Output = Result<T, tonic::Status>>,
+) -> anyhow::Result<T> {
+    let res = if let Some(timeout) = timeout {
+        match tokio::time::timeout(timeout, fut).await {
+            Ok(r) => r,
+            Err(_) => Err(tonic::Status::deadline_exceeded(format!(
+                "client RPC timeout ({timeout:?}) expired"
+            ))),
+        }
+    } else {
+        fut.await
+    };
+    res.map_err(Into::into)
 }
 
 /// Retry a fallible async operation on transient connection errors.
@@ -654,10 +703,10 @@ impl REClient {
         request: ActionResultRequest,
     ) -> anyhow::Result<ActionResultResponse> {
         retry(|| async {
-            let res = self
-                .action_cache_client()
-                .await?
-                .get_action_result(with_re_metadata(
+            let mut client = self.action_cache_client().await?;
+            let res = await_rpc(
+                self.runtime_opts.rpc_timeout,
+                client.get_action_result(with_re_metadata(
                     GetActionResultRequest {
                         instance_name: self.instance_name.as_str().to_owned(),
                         action_digest: Some(tdigest_to(request.digest.clone())),
@@ -665,8 +714,10 @@ impl REClient {
                     },
                     metadata.clone(),
                     self.runtime_opts.use_fbcode_metadata,
-                ))
-                .await?;
+                    self.runtime_opts.rpc_timeout,
+                )),
+            )
+            .await?;
 
             Ok(ActionResultResponse {
                 action_result: convert_action_result(res.into_inner())?,
@@ -684,10 +735,10 @@ impl REClient {
         let action_result = convert_t_action_result2(request.action_result)?;
 
         retry(|| async {
-            let res = self
-                .action_cache_client()
-                .await?
-                .update_action_result(with_re_metadata(
+            let mut client = self.action_cache_client().await?;
+            let res = await_rpc(
+                self.runtime_opts.rpc_timeout,
+                client.update_action_result(with_re_metadata(
                     UpdateActionResultRequest {
                         instance_name: self.instance_name.as_str().to_owned(),
                         action_digest: Some(tdigest_to(request.action_digest.clone())),
@@ -697,8 +748,10 @@ impl REClient {
                     },
                     metadata.clone(),
                     self.runtime_opts.use_fbcode_metadata,
-                ))
-                .await?;
+                    self.runtime_opts.rpc_timeout,
+                )),
+            )
+            .await?;
 
             Ok(WriteActionResultResponse {
                 actual_action_result: convert_action_result(res.into_inner())?,
@@ -737,6 +790,8 @@ impl REClient {
                     },
                     metadata.clone(),
                     self.runtime_opts.use_fbcode_metadata,
+                    // Execute is long-running; a unary timeout would abort live actions.
+                    None,
                 ))
                 .await?
                 .into_inner();
@@ -852,30 +907,34 @@ impl REClient {
             |re_request| {
                 let metadata = metadata.clone();
                 async move {
-                    let resp = self
-                        .cas_client()
-                        .await?
-                        .batch_update_blobs(with_re_metadata(
+                    let mut client = self.cas_client().await?;
+                    let resp = await_rpc(
+                        self.runtime_opts.rpc_timeout,
+                        client.batch_update_blobs(with_re_metadata(
                             re_request,
                             metadata,
                             self.runtime_opts.use_fbcode_metadata,
-                        ))
-                        .await?;
+                            self.runtime_opts.rpc_timeout,
+                        )),
+                    )
+                    .await?;
                     Ok(resp.into_inner())
                 }
             },
             |segments| {
                 let metadata = metadata.clone();
                 async move {
-                    let resp = self
-                        .bytestream_client()
-                        .await?
-                        .write(with_re_metadata(
+                    let mut client = self.bytestream_client().await?;
+                    let resp = await_rpc(
+                        self.runtime_opts.stream_timeout,
+                        client.write(with_re_metadata(
                             futures::stream::iter(segments),
                             metadata,
                             self.runtime_opts.use_fbcode_metadata,
-                        ))
-                        .await?;
+                            self.runtime_opts.stream_timeout,
+                        )),
+                    )
+                    .await?;
                     Ok(resp.into_inner())
                 }
             },
@@ -921,31 +980,35 @@ impl REClient {
             |re_request| {
                 let metadata = metadata.clone();
                 async move {
-                    let resp = self
-                        .cas_client()
-                        .await?
-                        .batch_read_blobs(with_re_metadata(
+                    let mut client = self.cas_client().await?;
+                    let resp = await_rpc(
+                        self.runtime_opts.rpc_timeout,
+                        client.batch_read_blobs(with_re_metadata(
                             re_request,
                             metadata,
                             self.runtime_opts.use_fbcode_metadata,
-                        ))
-                        .await?;
+                            self.runtime_opts.rpc_timeout,
+                        )),
+                    )
+                    .await?;
                     Ok(resp.into_inner())
                 }
             },
             |read_request| {
                 let metadata = metadata.clone();
                 async move {
-                    let response = self
-                        .bytestream_client()
-                        .await?
-                        .read(with_re_metadata(
+                    let mut client = self.bytestream_client().await?;
+                    let response = await_rpc(
+                        self.runtime_opts.stream_timeout,
+                        client.read(with_re_metadata(
                             read_request,
                             metadata,
                             self.runtime_opts.use_fbcode_metadata,
-                        ))
-                        .await?
-                        .into_inner();
+                            self.runtime_opts.stream_timeout,
+                        )),
+                    )
+                    .await?
+                    .into_inner();
                     Ok(Box::pin(response.into_stream()))
                 }
             },
@@ -986,10 +1049,10 @@ impl REClient {
                 tracing::debug!(num_digests = digests_to_check.len(), "FindMissingBlobs");
                 let blob_digests: Vec<_> = digests_to_check.map(|b| tdigest_to(b.clone()));
                 let resp: FindMissingBlobsResponse = retry(|| async {
-                    let resp = self
-                        .cas_client()
-                        .await?
-                        .find_missing_blobs(with_re_metadata(
+                    let mut client = self.cas_client().await?;
+                    let resp = await_rpc(
+                        self.runtime_opts.rpc_timeout,
+                        client.find_missing_blobs(with_re_metadata(
                             FindMissingBlobsRequest {
                                 instance_name: self.instance_name.as_str().to_owned(),
                                 blob_digests: blob_digests.clone(),
@@ -997,9 +1060,11 @@ impl REClient {
                             },
                             metadata.clone(),
                             self.runtime_opts.use_fbcode_metadata,
-                        ))
-                        .await
-                        .context("Failed to request what blobs are not present on remote")?;
+                            self.runtime_opts.rpc_timeout,
+                        )),
+                    )
+                    .await
+                    .context("Failed to request what blobs are not present on remote")?;
                     Ok(resp.into_inner())
                 })
                 .await?;
@@ -1739,6 +1804,7 @@ fn with_re_metadata<T>(
     t: T,
     metadata: RemoteExecutionMetadata,
     use_fbcode_metadata: bool,
+    timeout: Option<Duration>,
 ) -> tonic::Request<T> {
     // This creates a new Tonic request with attached metadata for the RE
     // backend. There are two cases here we need to support:
@@ -1811,7 +1877,13 @@ fn with_re_metadata<T>(
             "build.bazel.remote.execution.v2.requestmetadata-bin",
             MetadataValue::from_bytes(&encoded),
         );
-    };
+    }
+
+    // Header for servers that honor it. The client-side bound is `await_rpc`;
+    // this header alone does not unstick a hung TCP session.
+    if let Some(timeout) = timeout {
+        msg.set_timeout(timeout);
+    }
     msg
 }
 
@@ -2924,6 +2996,64 @@ mod tests {
         assert_eq!(substitute_env_vars_impl("foo", getter).unwrap(), "foo");
         assert_eq!(substitute_env_vars_impl("FOO", getter).unwrap(), "FOO");
         assert!(substitute_env_vars_impl("$FOO$BAZ", getter).is_err());
+    }
+
+    #[test]
+    fn test_timeout_from_config() {
+        assert_eq!(
+            timeout_from_config(None, DEFAULT_RPC_TIMEOUT),
+            Some(DEFAULT_RPC_TIMEOUT)
+        );
+        assert_eq!(timeout_from_config(Some(0), DEFAULT_RPC_TIMEOUT), None);
+        assert_eq!(
+            timeout_from_config(Some(15), DEFAULT_RPC_TIMEOUT),
+            Some(Duration::from_secs(15))
+        );
+    }
+
+    #[test]
+    fn test_deadline_exceeded_is_retryable() {
+        let err = anyhow::Error::new(tonic::Status::deadline_exceeded("stuck"));
+        assert!(is_retryable(&err));
+        let err = anyhow::Error::new(tonic::Status::internal("bug"));
+        assert!(!is_retryable(&err));
+    }
+
+    #[test]
+    fn test_with_re_metadata_sets_grpc_timeout() {
+        let req = with_re_metadata(
+            (),
+            RemoteExecutionMetadata::default(),
+            false,
+            Some(Duration::from_secs(30)),
+        );
+        assert_eq!(req.metadata().get("grpc-timeout").unwrap(), "30000000u");
+    }
+
+    #[test]
+    fn test_with_re_metadata_execute_has_no_timeout() {
+        let req = with_re_metadata((), RemoteExecutionMetadata::default(), false, None);
+        assert!(req.metadata().get("grpc-timeout").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_await_rpc_times_out() {
+        let err = await_rpc(
+            Some(Duration::from_millis(20)),
+            std::future::pending::<Result<(), tonic::Status>>(),
+        )
+        .await
+        .unwrap_err();
+        assert!(is_retryable(&err));
+        let status = err.downcast_ref::<tonic::Status>().unwrap();
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    #[tokio::test]
+    async fn test_await_rpc_disabled_completes() {
+        await_rpc(None, async { Ok::<_, tonic::Status>(()) })
+            .await
+            .unwrap();
     }
 }
 

--- a/remote_execution/oss/re_grpc/src/pool.rs
+++ b/remote_execution/oss/re_grpc/src/pool.rs
@@ -199,6 +199,11 @@ fn create_endpoint(
         ))
         .keep_alive_while_idle(config.grpc_keepalive_while_idle.unwrap_or(true));
 
+    // Do not set `Endpoint::timeout` here. CAS, AC, and Execute share this
+    // channel when they share a frontend address; a channel timeout would
+    // abort long-running Execute streams. Unary CAS/AC RPCs are bounded in
+    // `client.rs` via `await_rpc` instead.
+
     Ok(endpoint)
 }
 


### PR DESCRIPTION
OSS CAS/AC RPCs and the `Ensure` oneshot have no deadline. A hung `BatchReadBlobs` freezes `ensure_materialized` (`dynamic analysis [local_materialize_inputs]`) forever; keepalives leave TCP ESTABLISHED. `Endpoint::timeout` would also kill `Execute` on a shared frontend (#1221).

Bound unary CAS/AC (60s), ByteStream open (600s), and the `Ensure` oneshot (60s). `Execute` unbounded. `DeadlineExceeded` is retryable. `0` on `grpc_timeout_secs` / `grpc_stream_timeout_secs` / `materializer_ensure_timeout_secs` disables.

Seen on Buildbarn with `--materializations=none`: timeout fires (`client RPC timeout (60s) expired`), `buck2-dm` idle in `ep_poll`, build proceeds past the hang.