### PR TITLE
Timeout oss Execute stream

### DIFF
--- a/app/buck2_execute/src/re/client.rs
+++ b/app/buck2_execute/src/re/client.rs
@@ -332,6 +332,7 @@ impl RemoteExecutionClient {
         meta_internal_extra_params: &MetaInternalExtraParams,
         worker_tool_action_digest: Option<ActionDigest>,
         priority: Option<i32>,
+        action_timeout: Option<Duration>,
     ) -> buck2_error::Result<ExecuteResponseOrCancelled> {
         self.data
             .executes
@@ -351,6 +352,7 @@ impl RemoteExecutionClient {
                 meta_internal_extra_params,
                 worker_tool_action_digest,
                 priority,
+                action_timeout,
             ))
             .await
     }
@@ -1485,6 +1487,7 @@ impl RemoteExecutionClientImpl {
         meta_internal_extra_params: &MetaInternalExtraParams,
         worker_tool_action_digest: Option<ActionDigest>,
         priority: Option<i32>,
+        action_timeout: Option<Duration>,
     ) -> buck2_error::Result<ExecuteResponseOrCancelled> {
         let _exec_permit = self.exec_semaphore.acquire().await;
 
@@ -1492,6 +1495,8 @@ impl RemoteExecutionClientImpl {
         let _unused = worker_tool_action_digest;
         #[cfg(not(fbcode_build))]
         let _unused = re_gang_workers;
+        #[cfg(fbcode_build)]
+        let _ = action_timeout;
 
         if buck2_env!("BUCK2_TEST_FAIL_RE_EXECUTE", bool, applicability = testing)? {
             return Err(test_re_error("Injected error", TCode::FAILED_PRECONDITION));
@@ -1666,6 +1671,8 @@ impl RemoteExecutionClientImpl {
                     ..Default::default()
                 })
             },
+            #[cfg(not(fbcode_build))]
+            timeout: action_timeout,
             ..Default::default()
         };
         let re_action = format!("Execute with digest {}", action_digest);

--- a/app/buck2_execute/src/re/manager.rs
+++ b/app/buck2_execute/src/re/manager.rs
@@ -437,6 +437,7 @@ impl ManagedRemoteExecutionClient {
         meta_internal_extra_params: &MetaInternalExtraParams,
         worker_tool_action_digest: Option<ActionDigest>,
         priority: Option<i32>,
+        action_timeout: Option<Duration>,
     ) -> buck2_error::Result<ExecuteResponseOrCancelled> {
         self.lock()?
             .get()
@@ -457,6 +458,7 @@ impl ManagedRemoteExecutionClient {
                 meta_internal_extra_params,
                 worker_tool_action_digest,
                 priority,
+                action_timeout,
             )
             .await
     }

--- a/app/buck2_execute_impl/src/executors/re.rs
+++ b/app/buck2_execute_impl/src/executors/re.rs
@@ -196,6 +196,7 @@ impl ReExecutor {
             meta_internal_extra_params,
             worker_tool_action_digest,
             self.priority,
+            request.timeout(),
         );
 
         let execute_response =

--- a/app/buck2_execute_impl/src/materializers/deferred.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::time::Duration as StdDuration;
 
 use allocative::Allocative;
 use artifact_tree::ArtifactClassification;
@@ -44,6 +45,7 @@ use buck2_directory::directory::directory_iterator::DirectoryIteratorPathStack;
 use buck2_directory::directory::entry::DirectoryEntry;
 use buck2_directory::directory::walk::unordered_entry_walk;
 use buck2_error::BuckErrorContext;
+use buck2_error::buck2_error;
 use buck2_events::dispatch::EventDispatcher;
 use buck2_events::dispatch::current_span;
 use buck2_events::dispatch::get_dispatcher;
@@ -136,6 +138,10 @@ pub struct DeferredMaterializerAccessor<T: IoHandler + 'static> {
     materialize_final_artifacts: bool,
     defer_write_actions: bool,
     eager_materialization_enabled: bool,
+    /// Bound on waiting for `buck2-dm` to dequeue `Ensure`. `None` disables.
+    /// Does not bound the CAS download that follows; that is the RE client RPC timeout.
+    #[allocative(skip)]
+    ensure_timeout: Option<StdDuration>,
 
     io: Arc<T>,
 
@@ -206,6 +212,9 @@ pub struct DeferredMaterializerConfigs {
     pub verbose_materializer_log: bool,
     pub clean_stale_config: CleanStaleConfig,
     pub eager_materialization_enabled: bool,
+    /// Client-side timeout waiting for `buck2-dm` to accept `Ensure`.
+    /// Default 60s. `None` disables. Does not bound the download future.
+    pub ensure_timeout: Option<StdDuration>,
 }
 
 pub struct TtlRefreshConfiguration {
@@ -581,9 +590,26 @@ impl<T: IoHandler + Allocative> Materializer for DeferredMaterializerAccessor<T>
                 sender,
             ))
             .buck_error_context("Sending Ensure() command.")?;
-        let materialization_fut = recv
-            .await
-            .buck_error_context("Receiving materialization future from command thread.")?;
+        // Bound only this oneshot. If `buck2-dm` is stuck in sqlite/WAL/clean-stale,
+        // `Ensure` is never dequeued and no CAS RPC is sent. The download future
+        // returned here is already bounded by the RE client RPC timeout.
+        let materialization_fut = if let Some(timeout) = self.ensure_timeout {
+            match tokio::time::timeout(timeout, recv).await {
+                Ok(r) => {
+                    r.buck_error_context("Receiving materialization future from command thread.")?
+                }
+                Err(_) => {
+                    return Err(buck2_error!(
+                        buck2_error::ErrorTag::MaterializationError,
+                        "Materializer did not accept `Ensure` within {:?}; `buck2-dm` may be stuck",
+                        timeout
+                    ));
+                }
+            }
+        } else {
+            recv.await
+                .buck_error_context("Receiving materialization future from command thread.")?
+        };
         Ok(materialization_fut)
     }
 
@@ -851,6 +877,7 @@ impl<T: IoHandler + Allocative> DeferredMaterializerAccessor<T> {
             materialize_final_artifacts: configs.materialize_final_artifacts,
             defer_write_actions: configs.defer_write_actions,
             eager_materialization_enabled: configs.eager_materialization_enabled,
+            ensure_timeout: configs.ensure_timeout,
             io,
             materializer_state_info,
             stats,
@@ -922,6 +949,7 @@ impl DeferredMaterializerAccessor<NoDiskIoHandler> {
                 verbose_materializer_log: false,
                 clean_stale_config: CleanStaleConfig::default(),
                 eager_materialization_enabled: false,
+                ensure_timeout: None,
             },
             EventDispatcher::null(),
         )

--- a/app/buck2_execute_impl/src/materializers/deferred/tests.rs
+++ b/app/buck2_execute_impl/src/materializers/deferred/tests.rs
@@ -581,6 +581,7 @@ mod state_machine {
                 materialize_final_artifacts: true,
                 defer_write_actions: true,
                 eager_materialization_enabled: true,
+                ensure_timeout: None,
                 io,
                 materializer_state_info: buck2_data::MaterializerStateInfo {
                     num_entries_from_sqlite: 0,
@@ -617,6 +618,35 @@ mod state_machine {
             Ok(())
         })
         .await
+    }
+
+    #[tokio::test]
+    async fn test_ensure_times_out_if_command_thread_never_runs() {
+        let io = Arc::new(StubIoHandler::new(temp_root()));
+        let (processor, command_sender, command_receiver, _events) =
+            make_processor_for_io(io.dupe());
+        let dm = DeferredMaterializerAccessor {
+            command_thread: None,
+            command_sender,
+            materialize_final_artifacts: true,
+            defer_write_actions: true,
+            eager_materialization_enabled: true,
+            ensure_timeout: Some(TokioDuration::from_millis(50)),
+            io,
+            materializer_state_info: buck2_data::MaterializerStateInfo {
+                num_entries_from_sqlite: 0,
+            },
+            stats: Arc::new(DeferredMaterializerStats::default()),
+        };
+        // Keep the receiver so `send` succeeds, but never run the command loop.
+        let _keep_unprocessed = (processor, command_receiver);
+
+        let err = match dm.materialize_many(vec![make_path("foo")]).await {
+            Ok(_) => panic!("expected Ensure timeout"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Ensure") && msg.contains("buck2-dm"), "{msg}");
     }
 
     #[tokio::test]

--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -453,6 +453,13 @@ pub struct Buck2OssReConfiguration {
     pub max_connections: Option<usize>,
     /// Maximum concurrent streams per connection.
     pub max_concurrency_per_connection: Option<usize>,
+    /// Client-side timeout for unary CAS/AC RPCs (`BatchReadBlobs`,
+    /// `GetActionResult`, `FindMissingBlobs`, `BatchUpdateBlobs`), in seconds.
+    /// Default 60. `0` disables. Not applied to `Execute` (long-running).
+    pub grpc_timeout_secs: Option<u64>,
+    /// Client-side timeout for ByteStream `Read`/`Write`, in seconds.
+    /// Default 600. `0` disables.
+    pub grpc_stream_timeout_secs: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -589,6 +596,14 @@ impl Buck2OssReConfiguration {
             max_concurrency_per_connection: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "max_concurrency_per_connection",
+            })?,
+            grpc_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_timeout_secs",
+            })?,
+            grpc_stream_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_stream_timeout_secs",
             })?,
         })
     }

--- a/app/buck2_re_configuration/src/lib.rs
+++ b/app/buck2_re_configuration/src/lib.rs
@@ -455,11 +455,24 @@ pub struct Buck2OssReConfiguration {
     pub max_concurrency_per_connection: Option<usize>,
     /// Client-side timeout for unary CAS/AC RPCs (`BatchReadBlobs`,
     /// `GetActionResult`, `FindMissingBlobs`, `BatchUpdateBlobs`), in seconds.
-    /// Default 60. `0` disables. Not applied to `Execute` (long-running).
+    /// Default 60. `0` disables. Not applied to `Execute` (see
+    /// `grpc_execute_without_action_timeout_secs` /
+    /// `grpc_execute_after_action_timeout_secs`).
     pub grpc_timeout_secs: Option<u64>,
     /// Client-side timeout for ByteStream `Read`/`Write`, in seconds.
     /// Default 600. `0` disables.
     pub grpc_stream_timeout_secs: Option<u64>,
+    /// Client wait for the next `Execute` stream message when the action has
+    /// no `Action.timeout` (`timeout_seconds` unset). Default 1800. `0`
+    /// disables. Not a default stamped onto the action; only the client hang
+    /// detector.
+    pub grpc_execute_without_action_timeout_secs: Option<u64>,
+    /// Added to `Action.timeout` (`timeout_seconds`) to form the client wait
+    /// for the next `Execute` stream message. Default 300. `0` adds nothing
+    /// (wait equals the action timeout). Distinct from `grpc_timeout_secs` so
+    /// a hung Execute cannot sit until the job dies, without a 60s unary bound
+    /// killing live actions.
+    pub grpc_execute_after_action_timeout_secs: Option<u64>,
 }
 
 #[derive(Clone, Debug, Default, Allocative)]
@@ -604,6 +617,14 @@ impl Buck2OssReConfiguration {
             grpc_stream_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
                 section: BUCK2_RE_CLIENT_CFG_SECTION,
                 property: "grpc_stream_timeout_secs",
+            })?,
+            grpc_execute_without_action_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_execute_without_action_timeout_secs",
+            })?,
+            grpc_execute_after_action_timeout_secs: legacy_config.parse(BuckconfigKeyRef {
+                section: BUCK2_RE_CLIENT_CFG_SECTION,
+                property: "grpc_execute_after_action_timeout_secs",
             })?,
         })
     }

--- a/app/buck2_server/src/daemon/state.rs
+++ b/app/buck2_server/src/daemon/state.rs
@@ -539,6 +539,15 @@ impl DaemonState {
                     .unwrap_or_else(RolloutPercentage::never)
                     .roll();
 
+                let ensure_timeout = match root_config.parse::<u64>(BuckconfigKeyRef {
+                    section: "buck2",
+                    property: "materializer_ensure_timeout_secs",
+                })? {
+                    None => Some(std::time::Duration::from_secs(60)),
+                    Some(0) => None,
+                    Some(n) => Some(std::time::Duration::from_secs(n)),
+                };
+
                 DeferredMaterializerConfigs {
                     materialize_final_artifacts: matches!(
                         final_artifact_materialization,
@@ -554,6 +563,7 @@ impl DaemonState {
                     verbose_materializer_log,
                     clean_stale_config,
                     eager_materialization_enabled,
+                    ensure_timeout,
                 }
             };
             let eager_materialization_enabled =

--- a/docs/users/advanced/deferred_materialization.md
+++ b/docs/users/advanced/deferred_materialization.md
@@ -50,6 +50,17 @@ To enable, add this to your Buckconfig:
 sqlite_materializer_state = true
 ```
 
+`ensure_materialized` waits on a oneshot until the materializer command
+thread (`buck2-dm`) dequeues `Ensure`. That wait is bounded (default 60
+seconds) so a stuck command thread fails instead of freezing the build.
+Set to `0` to disable. This does not bound the CAS download that follows
+an accepted `Ensure`.
+
+```ini
+[buck2]
+materializer_ensure_timeout_secs = 60
+```
+
 ## Deferring Write Actions
 
 To further speedup builds, Buck2 can also be instructed to not execute any

--- a/docs/users/remote_execution.md
+++ b/docs/users/remote_execution.md
@@ -38,6 +38,12 @@ Keys supported include:
   interpolation syntax ($VAR). They will be substituted before reading the file.
 - `instance_name` - an instance name to pass on execution, action cache, and CAS
   requests.
+- `grpc_timeout_secs` - client-side timeout in seconds for unary CAS and action
+  cache RPCs (`BatchReadBlobs`, `GetActionResult`, `FindMissingBlobs`,
+  `BatchUpdateBlobs`). Default `60`. Set to `0` to disable. Not applied to
+  `Execute`.
+- `grpc_stream_timeout_secs` - client-side timeout in seconds for ByteStream
+  `Read`/`Write`. Default `600`. Set to `0` to disable.
 
 Buck2 uses `SHA256` for all its hashing by default. If your RE engine requires
 something else, this can be configured in `.buckconfig` as follows:

--- a/docs/users/remote_execution.md
+++ b/docs/users/remote_execution.md
@@ -44,6 +44,15 @@ Keys supported include:
   `Execute`.
 - `grpc_stream_timeout_secs` - client-side timeout in seconds for ByteStream
   `Read`/`Write`. Default `600`. Set to `0` to disable.
+- `grpc_execute_without_action_timeout_secs` - client wait in seconds for the
+  next `Execute` stream message when the action has no `Action.timeout`
+  (`timeout_seconds` unset on `ctx.actions.run`). Default `1800`. Set to `0`
+  to disable. This is not stamped onto the action.
+- `grpc_execute_after_action_timeout_secs` - added to `Action.timeout`
+  (`timeout_seconds`) to form the client wait for the next `Execute` stream
+  message. Default `300`. Set to `0` to wait exactly the action timeout.
+  Independent of `grpc_timeout_secs` so a hung Execute cannot sit until the
+  job dies, without a 60s unary bound killing live actions.
 
 Buck2 uses `SHA256` for all its hashing by default. If your RE engine requires
 something else, this can be configured in `.buckconfig` as follows:

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -186,6 +186,13 @@ pub struct RECapabilities {
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(60);
 /// Default ByteStream `Read`/`Write` timeout. Large blobs can take minutes.
 const DEFAULT_STREAM_TIMEOUT: Duration = Duration::from_secs(600);
+/// Default client wait for the next `Execute` stream message when the action
+/// has no `Action.timeout`. Long enough for a queued compile; short enough
+/// that a dead Execute stream cannot burn a 90-minute CI job.
+const DEFAULT_EXECUTE_WITHOUT_ACTION_TIMEOUT: Duration = Duration::from_secs(1800);
+/// Default added to `Action.timeout` for the client Execute stream wait
+/// (queue leftover + time for the backend to report completion).
+const DEFAULT_EXECUTE_AFTER_ACTION_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Contains runtime options for the remote execution client as set under `buck2_re_client`
 pub struct RERuntimeOpts {
@@ -201,6 +208,11 @@ pub struct RERuntimeOpts {
     rpc_timeout: Option<Duration>,
     /// Client-side timeout for ByteStream `Read`/`Write`. `None` disables.
     stream_timeout: Option<Duration>,
+    /// Client wait for the next `Execute` stream message when the action has
+    /// no `Action.timeout`. `None` disables.
+    execute_without_action_timeout: Option<Duration>,
+    /// Added to `Action.timeout` to form the client Execute stream wait.
+    execute_after_action_timeout: Duration,
 }
 
 /// `None` → default. `Some(0)` → disabled. Anything else → that many seconds.
@@ -209,6 +221,28 @@ fn timeout_from_config(secs: Option<u64>, default: Duration) -> Option<Duration>
         None => Some(default),
         Some(0) => None,
         Some(n) => Some(Duration::from_secs(n)),
+    }
+}
+
+/// `None` → default. `Some(n)` (including `0`) → that many seconds. Never
+/// disables: `0` means add nothing to `Action.timeout`.
+fn after_action_timeout_from_config(secs: Option<u64>, default: Duration) -> Duration {
+    match secs {
+        None => default,
+        Some(n) => Duration::from_secs(n),
+    }
+}
+
+/// Client wait for the next `Execute` stream message.
+/// `action_timeout` is REAPI `Action.timeout` (`timeout_seconds` on the run).
+fn execute_stream_wait(
+    action_timeout: Option<Duration>,
+    without: Option<Duration>,
+    after: Duration,
+) -> Option<Duration> {
+    match action_timeout {
+        Some(t) => Some(t.saturating_add(after)),
+        None => without,
     }
 }
 
@@ -360,6 +394,14 @@ impl REClientBuilder {
                 stream_timeout: timeout_from_config(
                     opts.grpc_stream_timeout_secs,
                     DEFAULT_STREAM_TIMEOUT,
+                ),
+                execute_without_action_timeout: timeout_from_config(
+                    opts.grpc_execute_without_action_timeout_secs,
+                    DEFAULT_EXECUTE_WITHOUT_ACTION_TIMEOUT,
+                ),
+                execute_after_action_timeout: after_action_timeout_from_config(
+                    opts.grpc_execute_after_action_timeout_secs,
+                    DEFAULT_EXECUTE_AFTER_ACTION_TIMEOUT,
                 ),
             },
             capabilities,
@@ -820,6 +862,11 @@ impl REClient {
             .map(|ep| ep.priority)
             .unwrap_or_default();
 
+        let execute_timeout = execute_stream_wait(
+            execute_request.timeout,
+            self.runtime_opts.execute_without_action_timeout,
+            self.runtime_opts.execute_after_action_timeout,
+        );
         let stream = retry(|| async {
             let stream = self
                 .execution_client()
@@ -835,7 +882,8 @@ impl REClient {
                     },
                     metadata,
                     self.runtime_opts.use_fbcode_metadata,
-                    // Execute is long-running; a unary timeout would abort live actions.
+                    // Do not put the unary CAS timeout on Execute (would abort
+                    // live actions). Stream-message waits use execute_timeout.
                     None,
                 ))
                 .await?
@@ -844,10 +892,26 @@ impl REClient {
         })
         .await?;
 
-        let stream = futures::stream::try_unfold(stream, move |mut stream| async {
-            let msg = match stream.try_next().await.context("RE channel error")? {
-                Some(msg) => msg,
-                None => return Ok(None),
+        let stream = futures::stream::try_unfold(stream, move |mut stream| async move {
+            let msg = {
+                let next = stream.try_next();
+                let msg = if let Some(timeout) = execute_timeout {
+                    match tokio::time::timeout(timeout, next).await {
+                        Ok(r) => r.context("RE channel error")?,
+                        Err(_) => {
+                            return Err(tonic::Status::deadline_exceeded(format!(
+                                "client Execute stream timeout ({timeout:?}) expired"
+                            ))
+                            .into());
+                        }
+                    }
+                } else {
+                    next.await.context("RE channel error")?
+                };
+                match msg {
+                    Some(msg) => msg,
+                    None => return Ok(None),
+                }
             };
 
             let status = if msg.done {
@@ -3047,6 +3111,38 @@ mod tests {
     }
 
     #[test]
+    fn test_after_action_timeout_from_config() {
+        assert_eq!(
+            after_action_timeout_from_config(None, DEFAULT_EXECUTE_AFTER_ACTION_TIMEOUT),
+            DEFAULT_EXECUTE_AFTER_ACTION_TIMEOUT
+        );
+        assert_eq!(
+            after_action_timeout_from_config(Some(0), DEFAULT_EXECUTE_AFTER_ACTION_TIMEOUT),
+            Duration::ZERO
+        );
+        assert_eq!(
+            after_action_timeout_from_config(Some(120), DEFAULT_EXECUTE_AFTER_ACTION_TIMEOUT),
+            Duration::from_secs(120)
+        );
+    }
+
+    #[test]
+    fn test_execute_stream_wait() {
+        let after = Duration::from_secs(300);
+        let without = Some(Duration::from_secs(1800));
+        assert_eq!(execute_stream_wait(None, without, after), without);
+        assert_eq!(
+            execute_stream_wait(Some(Duration::from_secs(3600)), without, after),
+            Some(Duration::from_secs(3900))
+        );
+        assert_eq!(execute_stream_wait(None, None, after), None);
+        assert_eq!(
+            execute_stream_wait(Some(Duration::from_secs(60)), None, Duration::ZERO),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
     fn test_deadline_exceeded_is_retryable() {
         let err = anyhow::Error::new(tonic::Status::deadline_exceeded("stuck"));
         assert!(is_retryable(&err));
@@ -3100,6 +3196,28 @@ mod tests {
         await_rpc(None, async { Ok::<_, tonic::Status>(()) })
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_execute_stream_wait_times_out() {
+        let err = match tokio::time::timeout(
+            Duration::from_millis(20),
+            std::future::pending::<Result<Option<()>, anyhow::Error>>(),
+        )
+        .await
+        {
+            Ok(_) => panic!("pending future completed"),
+            Err(_) => tonic::Status::deadline_exceeded(format!(
+                "client Execute stream timeout ({:?}) expired",
+                Duration::from_millis(20)
+            )),
+        };
+        let err = anyhow::Error::new(err);
+        assert!(is_retryable(&err));
+        assert_eq!(
+            err.downcast_ref::<tonic::Status>().unwrap().code(),
+            tonic::Code::DeadlineExceeded
+        );
     }
 }
 

--- a/remote_execution/oss/re_grpc/src/client.rs
+++ b/remote_execution/oss/re_grpc/src/client.rs
@@ -180,6 +180,13 @@ pub struct RECapabilities {
     supported_compressors: Vec<Compressor>,
 }
 
+/// Default unary CAS/AC RPC timeout. Long enough for a large `BatchReadBlobs`
+/// on a slow link, short enough that a hung frontend cannot freeze
+/// `ensure_materialized` for hours. Not applied to `Execute`.
+const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default ByteStream `Read`/`Write` timeout. Large blobs can take minutes.
+const DEFAULT_STREAM_TIMEOUT: Duration = Duration::from_secs(600);
+
 /// Contains runtime options for the remote execution client as set under `buck2_re_client`
 pub struct RERuntimeOpts {
     /// Use the Meta version of the request metadata
@@ -190,6 +197,19 @@ pub struct RERuntimeOpts {
     cas_ttl_secs: i64,
     /// Maximum number of digests per `FindMissingBlobs` RPC.
     find_missing_blobs_batch_size: usize,
+    /// Client-side timeout for unary CAS/AC RPCs. `None` disables.
+    rpc_timeout: Option<Duration>,
+    /// Client-side timeout for ByteStream `Read`/`Write`. `None` disables.
+    stream_timeout: Option<Duration>,
+}
+
+/// `None` → default. `Some(0)` → disabled. Anything else → that many seconds.
+fn timeout_from_config(secs: Option<u64>, default: Duration) -> Option<Duration> {
+    match secs {
+        None => Some(default),
+        Some(0) => None,
+        Some(n) => Some(Duration::from_secs(n)),
+    }
 }
 
 struct InstanceName(Option<String>);
@@ -336,6 +356,11 @@ impl REClientBuilder {
                 // on the TTL of the remote blob.
                 cas_ttl_secs: opts.cas_ttl_secs.unwrap_or(3 * 60 * 60),
                 find_missing_blobs_batch_size: opts.find_missing_blobs_batch_size.unwrap_or(100),
+                rpc_timeout: timeout_from_config(opts.grpc_timeout_secs, DEFAULT_RPC_TIMEOUT),
+                stream_timeout: timeout_from_config(
+                    opts.grpc_stream_timeout_secs,
+                    DEFAULT_STREAM_TIMEOUT,
+                ),
             },
             capabilities,
             instance_name,
@@ -571,7 +596,7 @@ fn is_transient_io_error(err: &std::io::Error) -> bool {
 /// Returns true if an error is a transient connection/transport error worth
 /// retrying. Walks the error chain checking for:
 ///   - `tonic::Status` with codes the gRPC retry policy treats as transient
-///     (Unavailable, ResourceExhausted, Aborted, Cancelled)
+///     (Unavailable, ResourceExhausted, Aborted, Cancelled, DeadlineExceeded)
 ///   - `io::Error` of a kind that indicates a transport-level disruption
 ///     (BrokenPipe, ConnectionReset/Aborted, UnexpectedEof, TimedOut)
 ///   - `h2::Error` wrapping such an `io::Error`. `h2::Error` does not
@@ -580,6 +605,7 @@ fn is_transient_io_error(err: &std::io::Error) -> bool {
 ///     `Code::Unknown`. Body errors on an established connection (for
 ///     example a TCP reset during a `BatchReadBlobs` response) take this
 ///     path and need the explicit downcast.
+///   - `tonic::TimeoutExpired`, the expiry of the `grpc-timeout` we set
 ///
 /// `tonic::transport::Error` is not matched directly — its transient subset
 /// surfaces as an `io::Error` somewhere in the chain, which we catch above.
@@ -587,12 +613,20 @@ fn is_transient_io_error(err: &std::io::Error) -> bool {
 /// an `io::Error` source, so they correctly do not retry.
 fn is_retryable(err: &anyhow::Error) -> bool {
     for cause in err.chain() {
+        // `grpc-timeout` expiry is reported as `TimeoutExpired`, which
+        // `Status` maps to Cancelled rather than DeadlineExceeded. It is the
+        // same transient condition, so match it directly and not just via the
+        // enclosing status code.
+        if cause.is::<tonic::TimeoutExpired>() {
+            return true;
+        }
         if let Some(status) = cause.downcast_ref::<tonic::Status>() {
             match status.code() {
                 tonic::Code::Unavailable
                 | tonic::Code::ResourceExhausted
                 | tonic::Code::Aborted
-                | tonic::Code::Cancelled => return true,
+                | tonic::Code::Cancelled
+                | tonic::Code::DeadlineExceeded => return true,
                 _ => {}
             }
         }
@@ -610,6 +644,29 @@ fn is_retryable(err: &anyhow::Error) -> bool {
         }
     }
     false
+}
+
+/// Bound a single RPC future on the client.
+///
+/// `Request::set_timeout` only writes the `grpc-timeout` header; a hung peer
+/// that never resets TCP still never returns. `Endpoint::timeout` would also
+/// fire on `Execute`, which shares the same frontend address as CAS — so CAS
+/// and AC calls wrap here, and `Execute` does not.
+async fn await_rpc<T>(
+    timeout: Option<Duration>,
+    fut: impl Future<Output = Result<T, tonic::Status>>,
+) -> anyhow::Result<T> {
+    let res = if let Some(timeout) = timeout {
+        match tokio::time::timeout(timeout, fut).await {
+            Ok(r) => r,
+            Err(_) => Err(tonic::Status::deadline_exceeded(format!(
+                "client RPC timeout ({timeout:?}) expired"
+            ))),
+        }
+    } else {
+        fut.await
+    };
+    res.map_err(Into::into)
 }
 
 /// Retry a fallible async operation on transient connection errors.
@@ -691,10 +748,10 @@ impl REClient {
         request: ActionResultRequest,
     ) -> anyhow::Result<ActionResultResponse> {
         retry(|| async {
-            let res = self
-                .action_cache_client()
-                .await?
-                .get_action_result(with_re_metadata(
+            let mut client = self.action_cache_client().await?;
+            let res = await_rpc(
+                self.runtime_opts.rpc_timeout,
+                client.get_action_result(with_re_metadata(
                     GetActionResultRequest {
                         instance_name: self.instance_name.as_str().to_owned(),
                         action_digest: Some(tdigest_to(request.digest.clone())),
@@ -702,8 +759,10 @@ impl REClient {
                     },
                     metadata,
                     self.runtime_opts.use_fbcode_metadata,
-                ))
-                .await?;
+                    self.runtime_opts.rpc_timeout,
+                )),
+            )
+            .await?;
 
             Ok(ActionResultResponse {
                 action_result: convert_action_result(res.into_inner())?,
@@ -721,10 +780,10 @@ impl REClient {
         let action_result = convert_t_action_result2(request.action_result)?;
 
         retry(|| async {
-            let res = self
-                .action_cache_client()
-                .await?
-                .update_action_result(with_re_metadata(
+            let mut client = self.action_cache_client().await?;
+            let res = await_rpc(
+                self.runtime_opts.rpc_timeout,
+                client.update_action_result(with_re_metadata(
                     UpdateActionResultRequest {
                         instance_name: self.instance_name.as_str().to_owned(),
                         action_digest: Some(tdigest_to(request.action_digest.clone())),
@@ -734,8 +793,10 @@ impl REClient {
                     },
                     metadata,
                     self.runtime_opts.use_fbcode_metadata,
-                ))
-                .await?;
+                    self.runtime_opts.rpc_timeout,
+                )),
+            )
+            .await?;
 
             Ok(WriteActionResultResponse {
                 actual_action_result: convert_action_result(res.into_inner())?,
@@ -774,6 +835,8 @@ impl REClient {
                     },
                     metadata,
                     self.runtime_opts.use_fbcode_metadata,
+                    // Execute is long-running; a unary timeout would abort live actions.
+                    None,
                 ))
                 .await?
                 .into_inner();
@@ -887,27 +950,31 @@ impl REClient {
             self.capabilities.max_total_batch_size,
             self.runtime_opts.max_concurrent_uploads_per_action,
             |re_request| async move {
-                let resp = self
-                    .cas_client()
-                    .await?
-                    .batch_update_blobs(with_re_metadata(
+                let mut client = self.cas_client().await?;
+                let resp = await_rpc(
+                    self.runtime_opts.rpc_timeout,
+                    client.batch_update_blobs(with_re_metadata(
                         re_request,
                         metadata,
                         self.runtime_opts.use_fbcode_metadata,
-                    ))
-                    .await?;
+                        self.runtime_opts.rpc_timeout,
+                    )),
+                )
+                .await?;
                 Ok(resp.into_inner())
             },
             |segments| async move {
-                let resp = self
-                    .bytestream_client()
-                    .await?
-                    .write(with_re_metadata(
+                let mut client = self.bytestream_client().await?;
+                let resp = await_rpc(
+                    self.runtime_opts.stream_timeout,
+                    client.write(with_re_metadata(
                         futures::stream::iter(segments),
                         metadata,
                         self.runtime_opts.use_fbcode_metadata,
-                    ))
-                    .await?;
+                        self.runtime_opts.stream_timeout,
+                    )),
+                )
+                .await?;
                 Ok(resp.into_inner())
             },
         )
@@ -950,28 +1017,32 @@ impl REClient {
             self.bystream_compressor,
             self.capabilities.max_total_batch_size,
             |re_request| async move {
-                let resp = self
-                    .cas_client()
-                    .await?
-                    .batch_read_blobs(with_re_metadata(
+                let mut client = self.cas_client().await?;
+                let resp = await_rpc(
+                    self.runtime_opts.rpc_timeout,
+                    client.batch_read_blobs(with_re_metadata(
                         re_request,
                         metadata,
                         self.runtime_opts.use_fbcode_metadata,
-                    ))
-                    .await?;
+                        self.runtime_opts.rpc_timeout,
+                    )),
+                )
+                .await?;
                 Ok(resp.into_inner())
             },
             |read_request| async move {
-                let response = self
-                    .bytestream_client()
-                    .await?
-                    .read(with_re_metadata(
+                let mut client = self.bytestream_client().await?;
+                let response = await_rpc(
+                    self.runtime_opts.stream_timeout,
+                    client.read(with_re_metadata(
                         read_request,
                         metadata,
                         self.runtime_opts.use_fbcode_metadata,
-                    ))
-                    .await?
-                    .into_inner();
+                        self.runtime_opts.stream_timeout,
+                    )),
+                )
+                .await?
+                .into_inner();
                 Ok(Box::pin(response.into_stream()))
             },
         )
@@ -1011,10 +1082,10 @@ impl REClient {
                 tracing::debug!(num_digests = digests_to_check.len(), "FindMissingBlobs");
                 let blob_digests: Vec<_> = digests_to_check.map(|b| tdigest_to(b.clone()));
                 let resp: FindMissingBlobsResponse = retry(|| async {
-                    let resp = self
-                        .cas_client()
-                        .await?
-                        .find_missing_blobs(with_re_metadata(
+                    let mut client = self.cas_client().await?;
+                    let resp = await_rpc(
+                        self.runtime_opts.rpc_timeout,
+                        client.find_missing_blobs(with_re_metadata(
                             FindMissingBlobsRequest {
                                 instance_name: self.instance_name.as_str().to_owned(),
                                 blob_digests: blob_digests.clone(),
@@ -1022,9 +1093,11 @@ impl REClient {
                             },
                             metadata,
                             self.runtime_opts.use_fbcode_metadata,
-                        ))
-                        .await
-                        .context("Failed to request what blobs are not present on remote")?;
+                            self.runtime_opts.rpc_timeout,
+                        )),
+                    )
+                    .await
+                    .context("Failed to request what blobs are not present on remote")?;
                     Ok(resp.into_inner())
                 })
                 .await?;
@@ -1765,6 +1838,7 @@ fn with_re_metadata<T>(
     t: T,
     metadata: &RemoteExecutionMetadata,
     use_fbcode_metadata: bool,
+    timeout: Option<Duration>,
 ) -> tonic::Request<T> {
     // This creates a new Tonic request with attached metadata for the RE
     // backend. There are two cases here we need to support:
@@ -1838,7 +1912,13 @@ fn with_re_metadata<T>(
             "build.bazel.remote.execution.v2.requestmetadata-bin",
             MetadataValue::from_bytes(&encoded),
         );
-    };
+    }
+
+    // Header for servers that honor it. The client-side bound is `await_rpc`;
+    // this header alone does not unstick a hung TCP session.
+    if let Some(timeout) = timeout {
+        msg.set_timeout(timeout);
+    }
     msg
 }
 
@@ -2951,6 +3031,75 @@ mod tests {
         assert_eq!(substitute_env_vars_impl("foo", getter).unwrap(), "foo");
         assert_eq!(substitute_env_vars_impl("FOO", getter).unwrap(), "FOO");
         assert!(substitute_env_vars_impl("$FOO$BAZ", getter).is_err());
+    }
+
+    #[test]
+    fn test_timeout_from_config() {
+        assert_eq!(
+            timeout_from_config(None, DEFAULT_RPC_TIMEOUT),
+            Some(DEFAULT_RPC_TIMEOUT)
+        );
+        assert_eq!(timeout_from_config(Some(0), DEFAULT_RPC_TIMEOUT), None);
+        assert_eq!(
+            timeout_from_config(Some(15), DEFAULT_RPC_TIMEOUT),
+            Some(Duration::from_secs(15))
+        );
+    }
+
+    #[test]
+    fn test_deadline_exceeded_is_retryable() {
+        let err = anyhow::Error::new(tonic::Status::deadline_exceeded("stuck"));
+        assert!(is_retryable(&err));
+        let err = anyhow::Error::new(tonic::Status::internal("bug"));
+        assert!(!is_retryable(&err));
+    }
+
+    #[test]
+    fn test_timeout_expired_is_retryable() {
+        // How a `grpc-timeout` expiry reaches us: Cancelled, with
+        // `TimeoutExpired` kept as the source.
+        let status = tonic::Status::from_error(Box::new(tonic::TimeoutExpired(())));
+        assert_eq!(status.code(), tonic::Code::Cancelled);
+        assert!(is_retryable(&anyhow::Error::new(status)));
+        let err = anyhow::Error::new(tonic::Status::invalid_argument("bad digest"));
+        assert!(!is_retryable(&err));
+    }
+
+    #[test]
+    fn test_with_re_metadata_sets_grpc_timeout() {
+        let req = with_re_metadata(
+            (),
+            &RemoteExecutionMetadata::default(),
+            false,
+            Some(Duration::from_secs(30)),
+        );
+        assert_eq!(req.metadata().get("grpc-timeout").unwrap(), "30000000u");
+    }
+
+    #[test]
+    fn test_with_re_metadata_execute_has_no_timeout() {
+        let req = with_re_metadata((), &RemoteExecutionMetadata::default(), false, None);
+        assert!(req.metadata().get("grpc-timeout").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_await_rpc_times_out() {
+        let err = await_rpc(
+            Some(Duration::from_millis(20)),
+            std::future::pending::<Result<(), tonic::Status>>(),
+        )
+        .await
+        .unwrap_err();
+        assert!(is_retryable(&err));
+        let status = err.downcast_ref::<tonic::Status>().unwrap();
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    #[tokio::test]
+    async fn test_await_rpc_disabled_completes() {
+        await_rpc(None, async { Ok::<_, tonic::Status>(()) })
+            .await
+            .unwrap();
     }
 }
 

--- a/remote_execution/oss/re_grpc/src/pool.rs
+++ b/remote_execution/oss/re_grpc/src/pool.rs
@@ -202,7 +202,9 @@ fn create_endpoint(
     // Do not set `Endpoint::timeout` here. CAS, AC, and Execute share this
     // channel when they share a frontend address; a channel timeout would
     // abort long-running Execute streams. Unary CAS/AC RPCs are bounded in
-    // `client.rs` via `await_rpc` instead.
+    // `client.rs` via `await_rpc`; Execute stream waits via
+    // `grpc_execute_without_action_timeout_secs` /
+    // `grpc_execute_after_action_timeout_secs`.
 
     Ok(endpoint)
 }

--- a/remote_execution/oss/re_grpc/src/pool.rs
+++ b/remote_execution/oss/re_grpc/src/pool.rs
@@ -199,6 +199,11 @@ fn create_endpoint(
         ))
         .keep_alive_while_idle(config.grpc_keepalive_while_idle.unwrap_or(true));
 
+    // Do not set `Endpoint::timeout` here. CAS, AC, and Execute share this
+    // channel when they share a frontend address; a channel timeout would
+    // abort long-running Execute streams. Unary CAS/AC RPCs are bounded in
+    // `client.rs` via `await_rpc` instead.
+
     Ok(endpoint)
 }
 

--- a/remote_execution/oss/re_grpc/src/request.rs
+++ b/remote_execution/oss/re_grpc/src/request.rs
@@ -8,6 +8,8 @@
  * above-listed licenses.
  */
 
+use std::time::Duration;
+
 pub use crate::digest::*;
 use crate::grpc::Platform as TPlatform;
 use crate::response::TActionResult2;
@@ -91,6 +93,10 @@ pub struct ExecuteRequest {
     pub execution_policy: Option<TExecutionPolicy>,
     pub host_runtime_requirements: THostRuntimeRequirements,
     pub gang: Option<GangSpecification>,
+    /// `Action.timeout` from `ctx.actions.run(timeout_seconds=...)`. Not sent
+    /// on the Execute RPC (it is already in the Action blob); used only to
+    /// size the client stream wait.
+    pub timeout: Option<Duration>,
     pub _dot_dot: (),
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #1488. That PR bounds unary CAS/AC and the Ensure oneshot; Execute streams were still unbounded.

This adds a client wait for the next Execute message (`QUEUED` / `EXECUTING` / `COMPLETED`):
- action has `timeout_seconds` → wait = that + `grpc_execute_after_action_timeout_secs` (default 300)
- no `timeout_seconds` → wait = `grpc_execute_without_action_timeout_secs` (default 1800, `0` disables)

Does not put the CAS unary timeout on Execute.
HTTP/2 keepalive is unchanged (connection up ≠ action still running).
