### PR TITLE
docs: clarify the bxl global namespace

### DIFF
--- a/app/buck2_bxl/src/bxl/starlark_defs/bxl_function.rs
+++ b/app/buck2_bxl/src/bxl/starlark_defs/bxl_function.rs
@@ -65,6 +65,9 @@ pub(crate) fn register_bxl_prefixed_main_function(builder: &mut GlobalsBuilder) 
 
 #[starlark_module]
 pub(crate) fn register_bxl_main_function(builder: &mut GlobalsBuilder) {
+    /// Declares the entry point for a BXL script.
+    ///
+    /// `bxl.main` is equivalent to the legacy top-level `bxl_main` function.
     fn main<'v>(
         #[starlark(require = named)] r#impl: StarlarkCallable<'v>,
         #[starlark(require = named)] cli_args: UnpackDictEntries<&'v str, &'v CliArgs>,

--- a/app/buck2_cmd_docs_server/src/builtins.rs
+++ b/app/buck2_cmd_docs_server/src/builtins.rs
@@ -25,6 +25,7 @@ use buck2_interpreter_for_build::interpreter::globals::starlark_library_extensio
 use buck2_server_ctx::ctx::ServerCommandContextTrait;
 use dice::DiceTransaction;
 use starlark::docs::DocItem;
+use starlark::docs::DocString;
 use starlark::docs::multipage::DocModuleInfo;
 use starlark::docs::multipage::render_markdown_multipage;
 use starlark::environment::Globals;
@@ -97,9 +98,18 @@ pub(crate) async fn docs_starlark_builtins(
         .build()
         .documentation();
 
-    let Some(DocItem::Module(bxl)) = bxl.members.shift_remove("bxl") else {
+    let Some(DocItem::Module(mut bxl)) = bxl.members.shift_remove("bxl") else {
         return Err(internal_error!("bxl namespace should exist"));
     };
+
+    bxl.docs = Some(DocString {
+        summary: "APIs exposed by the `bxl` global object in BXL files.".to_owned(),
+        details: Some(
+            "Every BXL file has access to the `bxl` global object. Its members are called as `bxl.<member>`, for example `bxl.main(...)`."
+                .to_owned(),
+        ),
+        examples: None,
+    });
 
     let modules_infos = vec![
         DocModuleInfo {


### PR DESCRIPTION
## Summary

- clarify that `bxl` is the global API namespace available in `.bxl` files
- document that `bxl.main` declares a BXL entry point
- note that `bxl.main` is equivalent to the legacy top-level `bxl_main`

Fixes #1021

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p buck2_cmd_docs_server`