### PR TITLE
Sort `dynamic analysis` actions last in `superconsole` output

### DIFF
--- a/app/buck2_event_observer/src/span_tracker.rs
+++ b/app/buck2_event_observer/src/span_tracker.rs
@@ -420,6 +420,7 @@ impl SpanTrackable for BuckEvent {
         use buck2_data::span_start_event::Data;
 
         match self.span_start_event().and_then(|span| span.data.as_ref()) {
+            Some(Data::DynamicLambda(..)) => true,
             Some(Data::ExecutorStage(data)) => {
                 use buck2_data::executor_stage_start::Stage;
 


### PR DESCRIPTION
This shows what's actually executing, rather than listing a ton of dynamic analysis actions at the top; we implement this change by marking dynamic analysis actions as 'boring'.