### PR TITLE
tui: rename "tasks" to "actions"

### DIFF
--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list.rs
@@ -461,7 +461,7 @@ mod tests {
         let expected = [
             "────────────────────────────────────────",
             "e1 · speak of the devil             1.0s",
-            "<span italic>1/3 running tasks shown</span>",
+            "<span italic>1/3 running actions shown</span>",
         ]
         .iter()
         .map(|l| format!("{l}\n"))

--- a/app/buck2_client_ctx/src/subscribers/superconsole/timed_list/table_builder.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole/timed_list/table_builder.rs
@@ -139,7 +139,7 @@ pub(crate) struct SummaryRow {
 impl SummaryRow {
     fn line(&self) -> Line {
         let summary = format!(
-            "{}/{} running tasks shown",
+            "{}/{} running actions shown",
             self.visible_roots, self.total_roots
         );
         Line::from_iter([Span::new_styled_lossy(summary.italic())])


### PR DESCRIPTION
The TUI lists _actions_ being run, "tasks" are not a thing in this context.